### PR TITLE
fix(release): auto-generate & deploy Sparkle appcasts every release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,5 +51,9 @@ jobs:
         shell: bash
         run: scripts/test-prepare-release-metadata.sh
 
+      - name: Test appcast generation fixture
+        shell: bash
+        run: scripts/test-build-appcast.sh
+
       - name: Build Microsoft Store resolver
         run: dotnet build scripts/store-link/StoreLink.csproj --configuration Release

--- a/.github/workflows/mirror.yml
+++ b/.github/workflows/mirror.yml
@@ -138,6 +138,13 @@ jobs:
             "$R2_PUBLIC_BASE_URL" \
             "${{ needs.probe.outputs.release_tag }}"
 
+      - name: Build macOS Sparkle appcasts
+        shell: bash
+        run: |
+          set -euo pipefail
+          bash scripts/build-appcast.sh arm64 release-manifest.json "$R2_PUBLIC_BASE_URL" appcast.xml
+          bash scripts/build-appcast.sh x64 release-manifest.json "$R2_PUBLIC_BASE_URL" appcast-x64.xml
+
       - name: Publish GitHub Release
         env:
           GH_TOKEN: ${{ github.token }}
@@ -145,11 +152,23 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
+          # The Sparkle .zip archives are checksummed in SHA256SUMS.txt, so attach
+          # them to the Release too (keeps every listed checksum downloadable and
+          # gives the archives a canonical immutable home alongside the mirror).
+          arm_short_version="$(jq -r '.sources.macos.arm64.appcast.shortVersionString' release-manifest.json)"
+          x64_short_version="$(jq -r '.sources.macos.x64.appcast.shortVersionString' release-manifest.json)"
+          mac_arm64_zip="artifacts/codex-macos/Codex-darwin-arm64-${arm_short_version}.zip"
+          mac_intel_zip="artifacts/codex-macos/Codex-darwin-x64-${x64_short_version}.zip"
+          test -f "$mac_arm64_zip"
+          test -f "$mac_intel_zip"
+
           gh release create "${{ steps.meta.outputs.tag }}" \
             --title "${{ steps.meta.outputs.title }}" \
             --notes-file release-notes.md \
             artifacts/codex-macos/Codex-mac-arm64.dmg \
             artifacts/codex-macos/Codex-mac-x64.dmg \
+            "$mac_arm64_zip" \
+            "$mac_intel_zip" \
             artifacts/codex-macos/SHA256SUMS-macos.txt \
             artifacts/codex-windows/* \
             assets/status.png \
@@ -191,6 +210,21 @@ jobs:
           test -f "$mac_intel"
           test -f "$win_msix"
 
+          # Sparkle update archives the generated appcasts point at. Their object
+          # keys (latest/mac/{arm64,intel}/...) must match the enclosure URLs that
+          # build-appcast.sh emits, or the client's downloads would 404.
+          arm_short_version="$(jq -r '.sources.macos.arm64.appcast.shortVersionString' release-manifest.json)"
+          x64_short_version="$(jq -r '.sources.macos.x64.appcast.shortVersionString' release-manifest.json)"
+          mac_arm64_zip="artifacts/codex-macos/Codex-darwin-arm64-${arm_short_version}.zip"
+          mac_intel_zip="artifacts/codex-macos/Codex-darwin-x64-${x64_short_version}.zip"
+          arm_zip_key="latest/mac/arm64/Codex-darwin-arm64-${arm_short_version}.zip"
+          intel_zip_key="latest/mac/intel/Codex-darwin-x64-${x64_short_version}.zip"
+
+          test -f "$mac_arm64_zip"
+          test -f "$mac_intel_zip"
+          test -f appcast.xml
+          test -f appcast-x64.xml
+
           staging_prefix="staging/${{ steps.meta.outputs.tag }}-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
           cleanup_staging() {
             bash scripts/clear-r2-prefix.sh "$R2_BUCKET_NAME" "$staging_prefix" || true
@@ -206,6 +240,15 @@ jobs:
             bash scripts/sync-r2.sh --object "$R2_BUCKET_NAME" "$prefix/manifest" release-manifest.json release-manifest.json
           }
 
+          # appcast feeds are small and change every release, so keep their CDN
+          # cache short; the versioned Sparkle archives are immutable.
+          upload_appcast() {
+            local key="$1"
+            local file="$2"
+            R2_CACHE_CONTROL="public, max-age=600" \
+              bash scripts/sync-r2.sh --object "$R2_BUCKET_NAME" "$key" "$file" "$(basename "$file")"
+          }
+
           upload_aliases "$staging_prefix"
           aws s3 cp "s3://$R2_BUCKET_NAME/$staging_prefix/manifest" /tmp/r2-staging-manifest.json \
             --endpoint-url "$R2_S3_ENDPOINT" \
@@ -219,6 +262,13 @@ jobs:
           bash scripts/sync-r2.sh --object "$R2_BUCKET_NAME" latest/checksums SHA256SUMS.txt SHA256SUMS.txt
           bash scripts/sync-r2.sh --object "$R2_BUCKET_NAME" latest/manifest release-manifest.json release-manifest.json
 
+          # Sparkle archives first, then the appcasts that reference them, so the
+          # feed never advertises an enclosure that is not yet downloadable.
+          bash scripts/sync-r2.sh --object "$R2_BUCKET_NAME" "$arm_zip_key" "$mac_arm64_zip" "$(basename "$mac_arm64_zip")"
+          bash scripts/sync-r2.sh --object "$R2_BUCKET_NAME" "$intel_zip_key" "$mac_intel_zip" "$(basename "$mac_intel_zip")"
+          upload_appcast latest/appcast.xml appcast.xml
+          upload_appcast latest/appcast-x64.xml appcast-x64.xml
+
           curl -fsSL \
             --retry 5 \
             --retry-delay 2 \
@@ -228,6 +278,28 @@ jobs:
             "$R2_PUBLIC_BASE_URL/latest/manifest?run=${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}" \
             -o /tmp/r2-public-manifest.json
           cmp release-manifest.json /tmp/r2-public-manifest.json
+
+          # Read the appcasts back through the public CDN and diff against what we
+          # generated. If R2 ever silently stops accepting these objects, this
+          # fails the workflow instead of leaving a stale (orphaned) feed behind.
+          curl -fsSL \
+            --retry 5 \
+            --retry-delay 2 \
+            --retry-all-errors \
+            --connect-timeout 20 \
+            --max-time 120 \
+            "$R2_PUBLIC_BASE_URL/latest/appcast.xml?run=${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}" \
+            -o /tmp/r2-public-appcast.xml
+          cmp appcast.xml /tmp/r2-public-appcast.xml
+          curl -fsSL \
+            --retry 5 \
+            --retry-delay 2 \
+            --retry-all-errors \
+            --connect-timeout 20 \
+            --max-time 120 \
+            "$R2_PUBLIC_BASE_URL/latest/appcast-x64.xml?run=${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}" \
+            -o /tmp/r2-public-appcast-x64.xml
+          cmp appcast-x64.xml /tmp/r2-public-appcast-x64.xml
 
       - name: Sync GitHub Release assets to secondary S3 mirror
         env:
@@ -254,16 +326,29 @@ jobs:
           mac_intel="artifacts/codex-macos/Codex-mac-x64.dmg"
           win_msix="$(find artifacts/codex-windows -maxdepth 1 -type f \( -name '*.Msix' -o -name '*.msix' \) | sort | head -n 1)"
 
+          arm_short_version="$(jq -r '.sources.macos.arm64.appcast.shortVersionString' release-manifest.json)"
+          x64_short_version="$(jq -r '.sources.macos.x64.appcast.shortVersionString' release-manifest.json)"
+          mac_arm64_zip="artifacts/codex-macos/Codex-darwin-arm64-${arm_short_version}.zip"
+          mac_intel_zip="artifacts/codex-macos/Codex-darwin-x64-${x64_short_version}.zip"
+
           test -f "$mac_arm64"
           test -f "$mac_intel"
           test -f "$win_msix"
+          test -f "$mac_arm64_zip"
+          test -f "$mac_intel_zip"
+          test -f appcast.xml
+          test -f appcast-x64.xml
 
           bash scripts/sync-secondary-s3.sh \
             "$mac_arm64" \
             "$mac_intel" \
             "$win_msix" \
             SHA256SUMS.txt \
-            release-manifest.json
+            release-manifest.json \
+            "$mac_arm64_zip" \
+            "$mac_intel_zip" \
+            appcast.xml \
+            appcast-x64.xml
 
           tmp_config="$(mktemp)"
           cleanup() {
@@ -277,15 +362,28 @@ jobs:
               addressing_style = path
           EOF
 
-          AWS_ACCESS_KEY_ID="$SECONDARY_S3_ACCESS_KEY_ID" \
-          AWS_SECRET_ACCESS_KEY="$SECONDARY_S3_SECRET_ACCESS_KEY" \
-          AWS_DEFAULT_REGION="$SECONDARY_S3_REGION" \
-          AWS_CONFIG_FILE="$tmp_config" \
-          aws s3 cp "s3://$SECONDARY_S3_BUCKET/latest/manifest" /tmp/secondary-s3-manifest.json \
-            --endpoint-url "$SECONDARY_S3_ENDPOINT" \
-            --region "$SECONDARY_S3_REGION" \
-            --no-progress
+          secondary_readback() {
+            local key="$1"
+            local dest="$2"
+            AWS_ACCESS_KEY_ID="$SECONDARY_S3_ACCESS_KEY_ID" \
+            AWS_SECRET_ACCESS_KEY="$SECONDARY_S3_SECRET_ACCESS_KEY" \
+            AWS_DEFAULT_REGION="$SECONDARY_S3_REGION" \
+            AWS_CONFIG_FILE="$tmp_config" \
+            aws s3 cp "s3://$SECONDARY_S3_BUCKET/$key" "$dest" \
+              --endpoint-url "$SECONDARY_S3_ENDPOINT" \
+              --region "$SECONDARY_S3_REGION" \
+              --no-progress
+          }
+
+          secondary_readback latest/manifest /tmp/secondary-s3-manifest.json
           cmp release-manifest.json /tmp/secondary-s3-manifest.json
+
+          # Read the appcasts back from the secondary bucket and diff. Keeps the
+          # secondary feed from silently drifting out of sync with each release.
+          secondary_readback latest/appcast.xml /tmp/secondary-s3-appcast.xml
+          cmp appcast.xml /tmp/secondary-s3-appcast.xml
+          secondary_readback latest/appcast-x64.xml /tmp/secondary-s3-appcast-x64.xml
+          cmp appcast-x64.xml /tmp/secondary-s3-appcast-x64.xml
 
   no_changes:
     name: No new version

--- a/scripts/build-appcast.sh
+++ b/scripts/build-appcast.sh
@@ -1,0 +1,164 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Render a Sparkle appcast (arm64 or x64) from release-manifest.json.
+#
+# The downstream macOS client (Codex App Manager) fetches the mirror appcast,
+# downloads the enclosure `.zip`, and verifies it against a *pinned* OpenAI
+# EdDSA key. EdDSA signs the archive bytes, so as long as we mirror the official
+# archive byte-for-byte, the original `sparkle:edSignature` stays valid even
+# though the enclosure URL points at the mirror.
+#
+# This script therefore copies every upstream appcast field verbatim
+# (shortVersionString, version, minimumSystemVersion, pubDate, title,
+# hardwareRequirements, enclosureLength, enclosureSignature) and only rewrites
+# the enclosure URL to the mirrored archive location. It intentionally emits a
+# full-update-only appcast: the probe does not capture upstream deltas, and the
+# client gracefully falls back to the full archive when no delta matches.
+#
+# Usage:
+#   build-appcast.sh <arch> <manifest> <public-base-url> <output-path>
+#     arch             arm64 | x64
+#     manifest         path to release-manifest.json (schemaVersion 2)
+#     public-base-url  e.g. https://codexapp.agentsmirror.com (no trailing /latest)
+#     output-path      where to write the appcast XML
+
+arch="${1:?arch (arm64|x64) is required}"
+manifest="${2:?manifest path is required}"
+public_base_url="${3:?public base URL is required}"
+output_path="${4:?output path is required}"
+
+require() {
+  if ! command -v "$1" >/dev/null 2>&1; then
+    echo "Missing required command: $1" >&2
+    exit 1
+  fi
+}
+
+require jq
+require python3
+
+case "$arch" in
+  arm64)
+    manifest_key="arm64"
+    archive_arch="arm64"
+    mirror_dir="mac/arm64"
+    ;;
+  x64)
+    manifest_key="x64"
+    archive_arch="x64"
+    mirror_dir="mac/intel"
+    ;;
+  *)
+    echo "Unknown arch '$arch' (expected arm64 or x64)." >&2
+    exit 2
+    ;;
+esac
+
+if [[ ! -f "$manifest" ]]; then
+  echo "Missing manifest: $manifest" >&2
+  exit 1
+fi
+
+# Strip any trailing slash (and an accidental trailing /latest) so we can build
+# a single canonical "<base>/latest/<dir>/<file>" enclosure URL.
+base="${public_base_url%/}"
+base="${base%/latest}"
+
+short_version="$(jq -r --arg a "$manifest_key" '.sources.macos[$a].appcast.shortVersionString // ""' "$manifest")"
+build_version="$(jq -r --arg a "$manifest_key" '.sources.macos[$a].appcast.version // ""' "$manifest")"
+enclosure_length="$(jq -r --arg a "$manifest_key" '.sources.macos[$a].appcast.enclosureLength // 0' "$manifest")"
+enclosure_signature="$(jq -r --arg a "$manifest_key" '.sources.macos[$a].appcast.enclosureSignature // ""' "$manifest")"
+minimum_system_version="$(jq -r --arg a "$manifest_key" '.sources.macos[$a].appcast.minimumSystemVersion // ""' "$manifest")"
+hardware_requirements="$(jq -r --arg a "$manifest_key" '.sources.macos[$a].appcast.hardwareRequirements // ""' "$manifest")"
+pub_date="$(jq -r --arg a "$manifest_key" '.sources.macos[$a].appcast.pubDate // ""' "$manifest")"
+title="$(jq -r --arg a "$manifest_key" '.sources.macos[$a].appcast.title // ""' "$manifest")"
+
+# These four are the bare minimum a valid, verifiable appcast item needs. Fail
+# loudly if upstream metadata is missing so a broken feed never ships silently.
+if [[ -z "$short_version" || -z "$build_version" || -z "$enclosure_signature" ]]; then
+  echo "Missing macOS $arch appcast metadata in $manifest (shortVersionString/version/enclosureSignature)." >&2
+  exit 1
+fi
+if [[ ! "$enclosure_length" =~ ^[0-9]+$ ]] || [[ "$enclosure_length" -le 0 ]]; then
+  echo "Invalid macOS $arch enclosure length in $manifest: '$enclosure_length'." >&2
+  exit 1
+fi
+
+# Title defaults to the short version (matches upstream behaviour).
+if [[ -z "$title" ]]; then
+  title="$short_version"
+fi
+
+enclosure_url="$base/latest/$mirror_dir/Codex-darwin-${archive_arch}-${short_version}.zip"
+
+python3 - \
+  "$output_path" \
+  "$title" \
+  "$pub_date" \
+  "$build_version" \
+  "$short_version" \
+  "$minimum_system_version" \
+  "$hardware_requirements" \
+  "$enclosure_url" \
+  "$enclosure_length" \
+  "$enclosure_signature" <<'PY'
+import sys
+from xml.sax.saxutils import escape, quoteattr
+
+(
+    out_path,
+    title,
+    pub_date,
+    build_version,
+    short_version,
+    minimum_system_version,
+    hardware_requirements,
+    enclosure_url,
+    enclosure_length,
+    enclosure_signature,
+) = sys.argv[1:]
+
+SPARKLE_NS = "http://www.andymatuschak.org/xml-namespaces/sparkle"
+
+lines = []
+lines.append("<?xml version='1.0' encoding='utf-8'?>")
+lines.append(f'<rss xmlns:sparkle="{SPARKLE_NS}" version="2.0">')
+lines.append("    <channel>")
+lines.append("        <title>Codex</title>")
+lines.append("        <item>")
+lines.append(f"            <title>{escape(title)}</title>")
+if pub_date:
+    lines.append(f"            <pubDate>{escape(pub_date)}</pubDate>")
+lines.append(f"            <sparkle:version>{escape(build_version)}</sparkle:version>")
+lines.append(
+    f"            <sparkle:shortVersionString>{escape(short_version)}</sparkle:shortVersionString>"
+)
+if minimum_system_version:
+    lines.append(
+        f"            <sparkle:minimumSystemVersion>{escape(minimum_system_version)}</sparkle:minimumSystemVersion>"
+    )
+if hardware_requirements:
+    lines.append(
+        f"            <sparkle:hardwareRequirements>{escape(hardware_requirements)}</sparkle:hardwareRequirements>"
+    )
+enclosure_attrs = " ".join(
+    [
+        f"url={quoteattr(enclosure_url)}",
+        f"length={quoteattr(str(enclosure_length))}",
+        'type="application/octet-stream"',
+        f"sparkle:edSignature={quoteattr(enclosure_signature)}",
+    ]
+)
+lines.append(f"            <enclosure {enclosure_attrs} />")
+lines.append("        </item>")
+lines.append("    </channel>")
+lines.append("</rss>")
+
+with open(out_path, "w", encoding="utf-8") as handle:
+    handle.write("\n".join(lines))
+    handle.write("\n")
+PY
+
+echo "Wrote $arch appcast to $output_path (enclosure: $enclosure_url)" >&2
+cat "$output_path"

--- a/scripts/download-macos.sh
+++ b/scripts/download-macos.sh
@@ -9,6 +9,12 @@ arm_url=""
 x64_url=""
 arm_expected_size=""
 x64_expected_size=""
+arm_zip_url=""
+x64_zip_url=""
+arm_zip_expected_size=""
+x64_zip_expected_size=""
+arm_zip_name=""
+x64_zip_name=""
 curl_retry_args=(
   --retry 5
   --retry-delay 2
@@ -68,6 +74,24 @@ if [[ -n "$manifest_path" ]]; then
   x64_url="$(jq -r '.sources.macos.x64.url' "$manifest_path")"
   arm_expected_size="$(jq -r '.sources.macos.arm64.contentLength' "$manifest_path")"
   x64_expected_size="$(jq -r '.sources.macos.x64.contentLength' "$manifest_path")"
+
+  # Sparkle update archives (.zip) referenced by the official appcast. These are
+  # what the macOS auto-updater (and the downstream Codex App Manager client)
+  # actually download, so the mirror must host them too. We name them by their
+  # official basename (Codex-darwin-<arch>-<shortVersion>.zip) so the generated
+  # appcast enclosure URL stays stable and predictable.
+  arm_zip_url="$(jq -r '.sources.macos.arm64.appcast.enclosureUrl // ""' "$manifest_path")"
+  x64_zip_url="$(jq -r '.sources.macos.x64.appcast.enclosureUrl // ""' "$manifest_path")"
+  arm_zip_expected_size="$(jq -r '.sources.macos.arm64.appcast.enclosureLength // 0' "$manifest_path")"
+  x64_zip_expected_size="$(jq -r '.sources.macos.x64.appcast.enclosureLength // 0' "$manifest_path")"
+  arm_zip_short_version="$(jq -r '.sources.macos.arm64.appcast.shortVersionString // ""' "$manifest_path")"
+  x64_zip_short_version="$(jq -r '.sources.macos.x64.appcast.shortVersionString // ""' "$manifest_path")"
+  if [[ -n "$arm_zip_short_version" ]]; then
+    arm_zip_name="Codex-darwin-arm64-${arm_zip_short_version}.zip"
+  fi
+  if [[ -n "$x64_zip_short_version" ]]; then
+    x64_zip_name="Codex-darwin-x64-${x64_zip_short_version}.zip"
+  fi
 else
   arm_url="https://persistent.oaistatic.com/codex-app-prod/Codex.dmg"
   x64_url="https://persistent.oaistatic.com/codex-app-prod/Codex-latest-x64.dmg"
@@ -79,7 +103,47 @@ validate_size "$out_dir/Codex-mac-arm64.dmg" "$arm_expected_size"
 download_file "macOS x64 DMG" "$x64_url" "$out_dir/Codex-mac-x64.dmg"
 validate_size "$out_dir/Codex-mac-x64.dmg" "$x64_expected_size"
 
+# Mirror the Sparkle update archives (.zip) so the appcast enclosure URLs are
+# downloadable from the mirror. The archive bytes are copied verbatim, which is
+# what keeps the official EdDSA signature valid. When a manifest provides an
+# enclosure URL the archive is mandatory; a missing one means a broken appcast,
+# so fail loudly rather than ship a feed that points at nothing.
+download_zip() {
+  local label="$1"
+  local url="$2"
+  local name="$3"
+  local expected_size="$4"
+
+  if [[ -z "$url" || "$url" == "null" ]]; then
+    if [[ -n "$manifest_path" ]]; then
+      echo "Missing $label enclosure URL in manifest; cannot mirror Sparkle archive." >&2
+      exit 1
+    fi
+    return 0
+  fi
+  if [[ -z "$name" ]]; then
+    echo "Missing $label archive name (no shortVersionString in manifest)." >&2
+    exit 1
+  fi
+
+  download_file "$label" "$url" "$out_dir/$name"
+  validate_size "$out_dir/$name" "$expected_size"
+}
+
+download_zip "macOS arm64 Sparkle archive" "$arm_zip_url" "$arm_zip_name" "$arm_zip_expected_size"
+download_zip "macOS x64 Sparkle archive" "$x64_zip_url" "$x64_zip_name" "$x64_zip_expected_size"
+
 (
   cd "$out_dir"
-  shasum -a 256 Codex-mac-arm64.dmg Codex-mac-x64.dmg > SHA256SUMS-macos.txt
+  # Always checksum both DMGs; append any mirrored Sparkle archives. Built as a
+  # positional list (not an array) so it stays safe under `set -u` on the macOS
+  # runner's bash 3.2, where expanding an empty array is an error.
+  set -- Codex-mac-arm64.dmg Codex-mac-x64.dmg
+  if [[ -n "$arm_zip_name" && -f "$arm_zip_name" ]]; then
+    set -- "$@" "$arm_zip_name"
+  fi
+  if [[ -n "$x64_zip_name" && -f "$x64_zip_name" ]]; then
+    set -- "$@" "$x64_zip_name"
+  fi
+  shasum -a 256 "$@" > SHA256SUMS-macos.txt
 )

--- a/scripts/sync-r2.sh
+++ b/scripts/sync-r2.sh
@@ -15,6 +15,8 @@ content_type_for() {
     *.dmg) printf '%s' 'application/x-apple-diskimage' ;;
     *.Msix|*.msix) printf '%s' 'application/vnd.ms-appx' ;;
     *.json) printf '%s' 'application/json' ;;
+    *.xml) printf '%s' 'application/xml' ;;
+    *.zip) printf '%s' 'application/octet-stream' ;;
     *.txt) printf '%s' 'text/plain; charset=utf-8' ;;
     *) printf '%s' 'application/octet-stream' ;;
   esac

--- a/scripts/sync-secondary-s3.sh
+++ b/scripts/sync-secondary-s3.sh
@@ -6,8 +6,8 @@ set -euo pipefail
 : "${SECONDARY_S3_ACCESS_KEY_ID:?SECONDARY_S3_ACCESS_KEY_ID must be set}"
 : "${SECONDARY_S3_SECRET_ACCESS_KEY:?SECONDARY_S3_SECRET_ACCESS_KEY must be set}"
 
-if [[ $# -ne 5 ]]; then
-  echo "Usage: sync-secondary-s3.sh <mac-arm64-dmg> <mac-intel-dmg> <windows-msix> <checksums> <manifest>" >&2
+if [[ $# -ne 9 ]]; then
+  echo "Usage: sync-secondary-s3.sh <mac-arm64-dmg> <mac-intel-dmg> <windows-msix> <checksums> <manifest> <mac-arm64-zip> <mac-intel-zip> <appcast-arm64> <appcast-x64>" >&2
   exit 2
 fi
 
@@ -55,9 +55,27 @@ mac_intel="$2"
 win_msix="$3"
 checksums="$4"
 manifest="$5"
+mac_arm64_zip="$6"
+mac_intel_zip="$7"
+appcast_arm64="$8"
+appcast_x64="$9"
+
+mac_arm64_zip_name="$(basename "$mac_arm64_zip")"
+mac_intel_zip_name="$(basename "$mac_intel_zip")"
 
 bash "$repo_root/scripts/sync-r2.sh" --object "$SECONDARY_S3_BUCKET" "$prefix/mac-arm64" "$mac_arm64" Codex-mac-arm64.dmg
 bash "$repo_root/scripts/sync-r2.sh" --object "$SECONDARY_S3_BUCKET" "$prefix/mac-intel" "$mac_intel" Codex-mac-intel.dmg
 bash "$repo_root/scripts/sync-r2.sh" --object "$SECONDARY_S3_BUCKET" "$prefix/win" "$win_msix" Codex-Windows-x64.msix
 bash "$repo_root/scripts/sync-r2.sh" --object "$SECONDARY_S3_BUCKET" "$prefix/checksums" "$checksums" SHA256SUMS.txt
 bash "$repo_root/scripts/sync-r2.sh" --object "$SECONDARY_S3_BUCKET" "$prefix/manifest" "$manifest" release-manifest.json
+
+# Sparkle update archives, keyed to match the appcast enclosure URLs. Upload the
+# archives before the appcasts so the feed never advertises a missing enclosure.
+bash "$repo_root/scripts/sync-r2.sh" --object "$SECONDARY_S3_BUCKET" "$prefix/mac/arm64/$mac_arm64_zip_name" "$mac_arm64_zip" "$mac_arm64_zip_name"
+bash "$repo_root/scripts/sync-r2.sh" --object "$SECONDARY_S3_BUCKET" "$prefix/mac/intel/$mac_intel_zip_name" "$mac_intel_zip" "$mac_intel_zip_name"
+
+# appcast feeds change every release; keep their CDN cache short.
+R2_CACHE_CONTROL="public, max-age=600" \
+  bash "$repo_root/scripts/sync-r2.sh" --object "$SECONDARY_S3_BUCKET" "$prefix/appcast.xml" "$appcast_arm64" appcast.xml
+R2_CACHE_CONTROL="public, max-age=600" \
+  bash "$repo_root/scripts/sync-r2.sh" --object "$SECONDARY_S3_BUCKET" "$prefix/appcast-x64.xml" "$appcast_x64" appcast-x64.xml

--- a/scripts/test-build-appcast.sh
+++ b/scripts/test-build-appcast.sh
@@ -1,0 +1,132 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Fixture test for build-appcast.sh: render arm64 + x64 appcasts from a synthetic
+# release manifest and assert the output is a valid Sparkle feed whose enclosure
+# points at the mirror while every upstream field (notably the EdDSA signature)
+# is preserved verbatim. Runs without secrets or a real release event.
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+tmp_dir="$(mktemp -d)"
+cleanup() {
+  rm -rf "$tmp_dir"
+}
+trap cleanup EXIT
+
+arm_sig="fQ7rDmk/lQGGg8JReeCvN+ct0Db3z6MFvV8FqgI9ZzpYNKpjWalf2vfLi8TqSCVBF+jXs20U3FGwTeaWocDYBg=="
+x64_sig="6OM9z2K/DXc05QidSyspEl9LXe1s5E8HesofMpw9vQ/nBNK39pSarOqGt6u1jA+VyDy4pbsphk4WAUH8D3eKDg=="
+
+cat > "$tmp_dir/release-manifest.json" <<JSON
+{
+  "schemaVersion": 2,
+  "sources": {
+    "macos": {
+      "arm64": {
+        "appcast": {
+          "title": "26.602.40724",
+          "pubDate": "Fri, 05 Jun 2026 17:00:22 +0000",
+          "version": "3593",
+          "shortVersionString": "26.602.40724",
+          "minimumSystemVersion": "12.0",
+          "hardwareRequirements": "arm64",
+          "enclosureUrl": "https://persistent.oaistatic.com/codex-app-prod/Codex-darwin-arm64-26.602.40724.zip",
+          "enclosureLength": 406585586,
+          "enclosureSignature": "$arm_sig"
+        }
+      },
+      "x64": {
+        "appcast": {
+          "title": "26.602.40724",
+          "pubDate": "Fri, 05 Jun 2026 17:00:20 +0000",
+          "version": "3593",
+          "shortVersionString": "26.602.40724",
+          "minimumSystemVersion": "12.0",
+          "hardwareRequirements": "",
+          "enclosureUrl": "https://persistent.oaistatic.com/codex-app-prod/Codex-darwin-x64-26.602.40724.zip",
+          "enclosureLength": 397428010,
+          "enclosureSignature": "$x64_sig"
+        }
+      }
+    }
+  }
+}
+JSON
+
+base="https://codexapp.agentsmirror.com"
+
+bash "$repo_root/scripts/build-appcast.sh" arm64 "$tmp_dir/release-manifest.json" "$base" "$tmp_dir/appcast.xml" >/dev/null
+bash "$repo_root/scripts/build-appcast.sh" x64 "$tmp_dir/release-manifest.json" "$base" "$tmp_dir/appcast-x64.xml" >/dev/null
+
+assert_contains() {
+  local file="$1"
+  local needle="$2"
+  if ! grep -Fq "$needle" "$file"; then
+    echo "Expected to find in $file: $needle" >&2
+    echo "--- actual ---" >&2
+    cat "$file" >&2
+    exit 1
+  fi
+}
+
+assert_absent() {
+  local file="$1"
+  local needle="$2"
+  if grep -Fq "$needle" "$file"; then
+    echo "Did not expect to find in $file: $needle" >&2
+    exit 1
+  fi
+}
+
+# arm64: enclosure rewritten to the mirror, signature/length/version preserved.
+assert_contains "$tmp_dir/appcast.xml" 'url="https://codexapp.agentsmirror.com/latest/mac/arm64/Codex-darwin-arm64-26.602.40724.zip"'
+assert_contains "$tmp_dir/appcast.xml" "sparkle:edSignature=\"$arm_sig\""
+assert_contains "$tmp_dir/appcast.xml" 'length="406585586"'
+assert_contains "$tmp_dir/appcast.xml" '<sparkle:version>3593</sparkle:version>'
+assert_contains "$tmp_dir/appcast.xml" '<sparkle:shortVersionString>26.602.40724</sparkle:shortVersionString>'
+assert_contains "$tmp_dir/appcast.xml" '<sparkle:minimumSystemVersion>12.0</sparkle:minimumSystemVersion>'
+assert_contains "$tmp_dir/appcast.xml" '<sparkle:hardwareRequirements>arm64</sparkle:hardwareRequirements>'
+assert_contains "$tmp_dir/appcast.xml" 'type="application/octet-stream"'
+# Never leak the upstream enclosure host into the mirror feed.
+assert_absent "$tmp_dir/appcast.xml" 'persistent.oaistatic.com'
+
+# x64: own enclosure name + signature, and no hardwareRequirements element.
+assert_contains "$tmp_dir/appcast-x64.xml" 'url="https://codexapp.agentsmirror.com/latest/mac/intel/Codex-darwin-x64-26.602.40724.zip"'
+assert_contains "$tmp_dir/appcast-x64.xml" "sparkle:edSignature=\"$x64_sig\""
+assert_contains "$tmp_dir/appcast-x64.xml" 'length="397428010"'
+assert_absent "$tmp_dir/appcast-x64.xml" 'hardwareRequirements'
+assert_absent "$tmp_dir/appcast-x64.xml" 'persistent.oaistatic.com'
+
+# Both feeds must be well-formed XML with exactly one <item>.
+for feed in "$tmp_dir/appcast.xml" "$tmp_dir/appcast-x64.xml"; do
+  python3 - "$feed" <<'PY'
+import sys
+import xml.etree.ElementTree as ET
+
+ns = {"sparkle": "http://www.andymatuschak.org/xml-namespaces/sparkle"}
+root = ET.parse(sys.argv[1]).getroot()
+items = root.findall("./channel/item")
+assert len(items) == 1, f"expected exactly one item, got {len(items)}"
+item = items[0]
+enclosure = item.find("enclosure")
+assert enclosure is not None, "missing enclosure"
+sig = enclosure.attrib.get(
+    "{http://www.andymatuschak.org/xml-namespaces/sparkle}edSignature", ""
+)
+assert sig, "missing edSignature"
+assert item.findtext("sparkle:version", namespaces=ns), "missing sparkle:version"
+assert item.findtext(
+    "sparkle:shortVersionString", namespaces=ns
+), "missing sparkle:shortVersionString"
+PY
+done
+
+# Missing appcast metadata must fail loudly (the guard against shipping a broken feed).
+cat > "$tmp_dir/empty-manifest.json" <<'JSON'
+{ "schemaVersion": 2, "sources": { "macos": { "arm64": {}, "x64": {} } } }
+JSON
+if bash "$repo_root/scripts/build-appcast.sh" arm64 "$tmp_dir/empty-manifest.json" "$base" "$tmp_dir/should-not-exist.xml" >/dev/null 2>&1; then
+  echo "build-appcast.sh should fail when appcast metadata is missing." >&2
+  exit 1
+fi
+
+echo "build-appcast fixture test PASS"


### PR DESCRIPTION
## Root cause

The publish pipeline (`mirror.yml` → `sync-r2.sh` + `sync-secondary-s3.sh`) only ever wrote **DMG / MSIX / checksums / manifest** to Cloudflare R2 and the secondary IHEP S3 mirror. It **never (re)generated** `latest/appcast.xml` or `latest/appcast-x64.xml`.

Those two objects were **orphans** from a one-time manual upload. So while releases advanced to **26.602.40724 (build 3593)** (and `latest/manifest` reflects that), the mirror appcast stayed pinned at **26.602.30954 (build 3575)**:

```
$ curl -s https://codexapp.agentsmirror.com/latest/appcast.xml | grep shortVersionString
  <sparkle:shortVersionString>26.602.30954</sparkle:shortVersionString>   # stale
$ curl -s https://codexapp.agentsmirror.com/latest/manifest | jq -r .derived.macosCommonShortVersion
26.602.40724                                                              # current
$ curl -s -o /dev/null -w '%{http_code}\n' https://codexapp.agentsmirror.com/latest/appcast-x64.xml
404                                                                       # never existed at all
```

The downstream macOS client (**Codex App Manager**, `crates/codex-mac-engine`) fetches `https://codexapp.agentsmirror.com/latest/appcast.xml` for Sparkle self-update, so domestic users were stuck on the old build indefinitely (and the x64 feed 404'd entirely).

## Fix

Make the appcast a first-class, auto-refreshed release output. **EdDSA signs the archive bytes**, so the official `sparkle:edSignature` stays valid against the client's pinned key (`mNfr1v9...`) as long as we mirror the archive byte-for-byte — we only rewrite the enclosure URL to the mirror.

- **`scripts/build-appcast.sh`** (new) — renders arm64 + x64 appcasts from `release-manifest.json`. The probe already captures everything needed (`shortVersionString`, `version`, `enclosureUrl/Length/Signature`, `minimumSystemVersion`, `pubDate`, `title`, `hardwareRequirements`). Every upstream field is copied verbatim; only the enclosure URL is rewritten to `…/latest/mac/{arm64,intel}/Codex-darwin-<arch>-<ver>.zip`. **Full-update-only** (the probe does not capture deltas; the client's `plan_update` cleanly falls back to the full archive when no delta matches). Missing metadata → hard failure.
- **`scripts/download-macos.sh`** — also mirrors the Sparkle update archives (`.zip`) the enclosures point at (official basename, size-validated, checksummed). Without these the feed would advertise an unreachable enclosure. The no-manifest dev path is unaffected; the `SHA256SUMS-macos.txt` builder is bash-3.2-safe (macOS runner).
- **`.github/workflows/mirror.yml`** — build both appcasts after metadata / before sync; upload the **archives first**, then the appcasts, to **both** R2 and the secondary mirror (`latest/mac/{arm64,intel}/…` + `latest/appcast{,-x64}.xml`). Both appcasts are **read back and `cmp`-verified** (R2 via the public CDN, secondary via the bucket) exactly like the existing manifest readback — so a future silent break **fails the workflow** instead of re-orphaning the feed. Archives are also attached to the GitHub Release (their hashes are already in `SHA256SUMS.txt`).
- **`scripts/sync-r2.sh`** — `.xml` → `application/xml`; appcasts upload with a short `max-age=600` cache (archives stay immutable). **`scripts/sync-secondary-s3.sh`** — pushes the archives + appcasts too.
- **`.github/workflows/ci.yml` + `scripts/test-build-appcast.sh`** (new) — fixture test for the generator (mirror-URL rewrite, signature preserved verbatim, well-formed single-item feed, x64 omits `hardwareRequirements`, no upstream host leak, missing-metadata failure). Runs in CI with no secrets.

## Verification done locally (no CI run — see below)

- `bash -n scripts/*.sh`, `actionlint`, and the existing `test-prepare-release-metadata.sh` fixture all pass; new `test-build-appcast.sh` passes (incl. the negative case).
- Generated appcasts were parsed through the **real downstream client engine** (`codex-mac-engine::parse_appcast` + `plan_update`): build 3593 / `26.602.40724`, enclosure → mirror URL, EdDSA signature preserved byte-for-byte, older build ⇒ `Full` plan, same build ⇒ up-to-date. Output is structurally identical to the official `appcast.xml` (minus deltas).
- `download-macos.sh` was integration-tested against a local HTTP server: DMGs + zips fetched with correct official basenames, sizes validated, all four checksummed; a manifest missing the enclosure URL fails loudly.
- Confirmed the Cloudflare `download-router` already forwards arbitrary `/latest/**` paths to R2/secondary, so the mirror enclosure URLs and `latest/appcast{,-x64}.xml` resolve (the existing 30954 arm64 zip GETs 200 today).

## Not yet validated

This **has not been run through CI** — it needs repo secrets and a real `release`/`workflow_dispatch` event, which I can't trigger. Static implementation + local self-checks only.

## Risks / notes

- **No hardcoded credentials** — all storage creds/endpoints still come from existing `${{ secrets.* }}`; nothing new was hardcoded.
- **No deltas** in the mirror feed (probe doesn't capture them). Strictly correct: clients download the full archive (≈400 MB) instead of a delta. Wiring delta capture/mirroring can be a follow-up.
- Each release now also uploads two ≈400 MB archives to R2 + secondary and attaches them to the Release (well within GitHub's 2 GB/asset limit).
- Existing objects, releases, and `main` are untouched; this only changes future release behavior.

## Owner: how to validate

1. Run the **Mirror** workflow via `workflow_dispatch` with `force_release=true` (or wait for a real upstream bump).
2. After it succeeds, confirm the feeds now match the release:
   ```
   curl -s https://codexapp.agentsmirror.com/latest/appcast.xml     | grep -E 'shortVersionString|enclosure url'
   curl -s https://codexapp.agentsmirror.com/latest/appcast-x64.xml | grep -E 'shortVersionString|enclosure url'   # should be 200, not 404
   curl -sIL "$(curl -s https://codexapp.agentsmirror.com/latest/appcast.xml | sed -n 's/.*enclosure url="\([^"]*\)".*/\1/p')" | grep -i '^HTTP'
   ```
3. Optionally point a real Codex App Manager (older build) at it and confirm it offers 26.602.40724 and passes EdDSA verification.