### PR TITLE
fix(release): prune stale macOS Sparkle archives

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,5 +55,9 @@ jobs:
         shell: bash
         run: scripts/test-build-appcast.sh
 
+      - name: Test macOS Sparkle prune fixture
+        shell: bash
+        run: scripts/test-prune-mac-source.sh
+
       - name: Build Microsoft Store resolver
         run: dotnet build scripts/store-link/StoreLink.csproj --configuration Release

--- a/.github/workflows/mirror.yml
+++ b/.github/workflows/mirror.yml
@@ -301,6 +301,14 @@ jobs:
             -o /tmp/r2-public-appcast-x64.xml
           cmp appcast-x64.xml /tmp/r2-public-appcast-x64.xml
 
+          # Keep latest/mac bounded without racing cached appcasts: only stale
+          # archives outside the grace window are removed.
+          bash scripts/prune-mac-source.sh \
+            "$R2_BUCKET_NAME" \
+            latest/mac \
+            "$mac_arm64_zip" \
+            "$mac_intel_zip"
+
       - name: Sync GitHub Release assets to secondary S3 mirror
         env:
           SECONDARY_S3_ENDPOINT: ${{ secrets.SECONDARY_S3_ENDPOINT }}

--- a/scripts/prune-mac-source.sh
+++ b/scripts/prune-mac-source.sh
@@ -1,0 +1,99 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Prune stale macOS Sparkle archives from the public mirror.
+#
+# The release workflow publishes the current appcast archives under
+# latest/mac/{arm64,intel}/. Those files are versioned by filename, so old
+# archives would accumulate forever unless we remove objects that are no longer
+# referenced by the freshly published appcasts.
+#
+# Safety rules:
+# - keep every basename passed as an argument;
+# - keep objects modified inside PRUNE_GRACE_DAYS, so clients with a cached
+#   previous appcast can finish downloading;
+# - keep objects with an unparsable timestamp;
+# - never delete directory marker keys.
+#
+# Usage:
+#   prune-mac-source.sh <bucket> <prefix> <keep-file-or-basename> [...]
+
+: "${R2_S3_ENDPOINT:?R2_S3_ENDPOINT must be set}"
+: "${AWS_ACCESS_KEY_ID:?AWS_ACCESS_KEY_ID must be set}"
+: "${AWS_SECRET_ACCESS_KEY:?AWS_SECRET_ACCESS_KEY must be set}"
+
+if ! command -v aws >/dev/null 2>&1; then
+  echo "aws CLI is required for pruning." >&2
+  exit 1
+fi
+
+if [[ $# -lt 3 ]]; then
+  echo "Usage: prune-mac-source.sh <bucket> <prefix> <keep-file-or-basename> [...]" >&2
+  exit 2
+fi
+
+bucket="$1"
+prefix="${2#/}"
+prefix="${prefix%/}"
+shift 2
+region="${AWS_DEFAULT_REGION:-auto}"
+grace_days="${PRUNE_GRACE_DAYS:-7}"
+
+if [[ -z "$bucket" || -z "$prefix" ]]; then
+  echo "Bucket and prefix are required." >&2
+  exit 2
+fi
+if [[ ! "$grace_days" =~ ^[0-9]+$ ]]; then
+  echo "PRUNE_GRACE_DAYS must be a non-negative integer." >&2
+  exit 2
+fi
+
+keep_file="$(mktemp)"
+trap 'rm -f "$keep_file"' EXIT
+for item in "$@"; do
+  basename "$item"
+done | sort -u > "$keep_file"
+
+if [[ ! -s "$keep_file" ]]; then
+  echo "At least one keep file or basename is required." >&2
+  exit 2
+fi
+
+object_epoch() {
+  local lastmod="$1"
+  local ts
+  ts="${lastmod%%.*}"
+  ts="${ts%%+*}"
+  ts="${ts%Z}"
+  date -u -d "$lastmod" +%s 2>/dev/null \
+    || date -u -jf '%Y-%m-%dT%H:%M:%S' "$ts" +%s 2>/dev/null \
+    || echo 0
+}
+
+cutoff_epoch=$(( $(date -u +%s) - grace_days * 86400 ))
+
+aws s3api list-objects-v2 \
+  --bucket "$bucket" \
+  --prefix "$prefix/" \
+  --endpoint-url "$R2_S3_ENDPOINT" \
+  --region "$region" \
+  --query 'Contents[].[Key,LastModified]' \
+  --output text 2>/dev/null | while read -r key lastmod _rest; do
+  [[ -z "$key" || "$key" == "None" ]] && continue
+  [[ "$key" == */ ]] && continue
+
+  if grep -qxF "$(basename "$key")" "$keep_file"; then
+    continue
+  fi
+
+  obj_epoch="$(object_epoch "$lastmod")"
+  if [[ "$obj_epoch" -eq 0 || "$obj_epoch" -ge "$cutoff_epoch" ]]; then
+    continue
+  fi
+
+  echo "prune s3://$bucket/$key"
+  aws s3 rm "s3://$bucket/$key" \
+    --endpoint-url "$R2_S3_ENDPOINT" \
+    --region "$region" \
+    --only-show-errors
+done

--- a/scripts/test-prune-mac-source.sh
+++ b/scripts/test-prune-mac-source.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+tmp_dir="$(mktemp -d)"
+cleanup() {
+  rm -rf "$tmp_dir"
+}
+trap cleanup EXIT
+
+mkdir -p "$tmp_dir/bin" "$tmp_dir/keep"
+rm_log="$tmp_dir/rm.log"
+: > "$rm_log"
+
+cat > "$tmp_dir/bin/aws" <<'AWS'
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ "$1" == "s3api" && "$2" == "list-objects-v2" ]]; then
+  cat <<'OBJECTS'
+latest/mac/arm64/Codex-darwin-arm64-current.zip	2020-01-01T00:00:00.000Z
+latest/mac/intel/Codex-darwin-x64-current.zip	2020-01-01T00:00:00.000Z
+latest/mac/arm64/old.zip	2020-01-01T00:00:00.000Z
+latest/mac/intel/recent.zip	2099-01-01T00:00:00.000Z
+latest/mac/arm64/	2020-01-01T00:00:00.000Z
+OBJECTS
+  exit 0
+fi
+
+if [[ "$1" == "s3" && "$2" == "rm" ]]; then
+  echo "$*" >> "${AWS_RM_LOG:?AWS_RM_LOG must be set}"
+  exit 0
+fi
+
+echo "unexpected aws invocation: $*" >&2
+exit 1
+AWS
+chmod +x "$tmp_dir/bin/aws"
+
+touch \
+  "$tmp_dir/keep/Codex-darwin-arm64-current.zip" \
+  "$tmp_dir/keep/Codex-darwin-x64-current.zip"
+
+PATH="$tmp_dir/bin:$PATH" \
+AWS_RM_LOG="$rm_log" \
+R2_S3_ENDPOINT="https://example.invalid" \
+AWS_ACCESS_KEY_ID="test" \
+AWS_SECRET_ACCESS_KEY="test" \
+PRUNE_GRACE_DAYS=7 \
+  bash scripts/prune-mac-source.sh \
+    test-bucket \
+    latest/mac \
+    "$tmp_dir/keep/Codex-darwin-arm64-current.zip" \
+    "$tmp_dir/keep/Codex-darwin-x64-current.zip"
+
+if ! grep -q 's3://test-bucket/latest/mac/arm64/old.zip' "$rm_log"; then
+  echo "expected old.zip to be pruned" >&2
+  exit 1
+fi
+if grep -Eq 'current\.zip|recent\.zip|latest/mac/arm64/ ' "$rm_log"; then
+  echo "pruned a current, recent, or directory marker object" >&2
+  cat "$rm_log" >&2
+  exit 1
+fi
+
+echo "prune-mac-source fixture test PASS"


### PR DESCRIPTION
## Summary
- add a guarded R2 prune script for stale `latest/mac` Sparkle archives
- keep current archive basenames and recently modified objects to avoid racing cached appcasts
- run the prune after public appcast readback succeeds, with a fixture test in CI

## Tests
- `scripts/test-prune-mac-source.sh`
- `scripts/test-build-appcast.sh`
- `scripts/test-prepare-release-metadata.sh`
- `bash -n scripts/*.sh`
- `actionlint`
- `dotnet build scripts/store-link/StoreLink.csproj --configuration Release`

Note: local `pwsh` was unavailable/timed out, so the PowerShell parser check is left to GitHub CI.