### PR TITLE
feat(mac): republish Sparkle delta enclosures (incremental updates)

### DIFF
--- a/.github/workflows/mirror.yml
+++ b/.github/workflows/mirror.yml
@@ -225,6 +225,20 @@ jobs:
           test -f appcast.xml
           test -f appcast-x64.xml
 
+          # Sparkle delta archives (.delta) advertised under <sparkle:deltas>.
+          # Their basenames come straight from release-manifest.json (the same
+          # source build-appcast.sh used), and they were downloaded verbatim into
+          # artifacts/codex-macos/. arm64 deltas key under latest/mac/arm64/ and
+          # x64 deltas under latest/mac/intel/, matching the mirror enclosure URLs.
+          # Listed into files (one basename per line) to avoid relying on bash
+          # array semantics, consistent with the other mirror scripts.
+          jq -r '.sources.macos.arm64.appcast.deltas[]?.basename // empty' release-manifest.json > /tmp/arm-delta-basenames.txt
+          jq -r '.sources.macos.x64.appcast.deltas[]?.basename // empty' release-manifest.json > /tmp/x64-delta-basenames.txt
+          while IFS= read -r bn; do
+            [[ -z "$bn" ]] && continue
+            test -f "artifacts/codex-macos/$bn"
+          done < <(cat /tmp/arm-delta-basenames.txt /tmp/x64-delta-basenames.txt)
+
           staging_prefix="staging/${{ steps.meta.outputs.tag }}-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
           cleanup_staging() {
             bash scripts/clear-r2-prefix.sh "$R2_BUCKET_NAME" "$staging_prefix" || true
@@ -263,9 +277,18 @@ jobs:
           bash scripts/sync-r2.sh --object "$R2_BUCKET_NAME" latest/manifest release-manifest.json release-manifest.json
 
           # Sparkle archives first, then the appcasts that reference them, so the
-          # feed never advertises an enclosure that is not yet downloadable.
+          # feed never advertises an enclosure that is not yet downloadable. The
+          # full .zip and every .delta go up before the appcasts are published.
           bash scripts/sync-r2.sh --object "$R2_BUCKET_NAME" "$arm_zip_key" "$mac_arm64_zip" "$(basename "$mac_arm64_zip")"
           bash scripts/sync-r2.sh --object "$R2_BUCKET_NAME" "$intel_zip_key" "$mac_intel_zip" "$(basename "$mac_intel_zip")"
+          while IFS= read -r bn; do
+            [[ -z "$bn" ]] && continue
+            bash scripts/sync-r2.sh --object "$R2_BUCKET_NAME" "latest/mac/arm64/$bn" "artifacts/codex-macos/$bn" "$bn"
+          done < /tmp/arm-delta-basenames.txt
+          while IFS= read -r bn; do
+            [[ -z "$bn" ]] && continue
+            bash scripts/sync-r2.sh --object "$R2_BUCKET_NAME" "latest/mac/intel/$bn" "artifacts/codex-macos/$bn" "$bn"
+          done < /tmp/x64-delta-basenames.txt
           upload_appcast latest/appcast.xml appcast.xml
           upload_appcast latest/appcast-x64.xml appcast-x64.xml
 
@@ -302,12 +325,16 @@ jobs:
           cmp appcast-x64.xml /tmp/r2-public-appcast-x64.xml
 
           # Keep latest/mac bounded without racing cached appcasts: only stale
-          # archives outside the grace window are removed.
+          # archives outside the grace window are removed. Pass the freshly built
+          # appcasts so the keep list protects the current full .zip AND every
+          # live .delta they reference (prune-mac-source.sh parses the feeds).
           bash scripts/prune-mac-source.sh \
             "$R2_BUCKET_NAME" \
             latest/mac \
             "$mac_arm64_zip" \
-            "$mac_intel_zip"
+            "$mac_intel_zip" \
+            appcast.xml \
+            appcast-x64.xml
 
       - name: Sync GitHub Release assets to secondary S3 mirror
         env:

--- a/scripts/build-appcast.sh
+++ b/scripts/build-appcast.sh
@@ -12,9 +12,15 @@ set -euo pipefail
 # This script therefore copies every upstream appcast field verbatim
 # (shortVersionString, version, minimumSystemVersion, pubDate, title,
 # hardwareRequirements, enclosureLength, enclosureSignature) and only rewrites
-# the enclosure URL to the mirrored archive location. It intentionally emits a
-# full-update-only appcast: the probe does not capture upstream deltas, and the
-# client gracefully falls back to the full archive when no delta matches.
+# the enclosure URL to the mirrored archive location.
+#
+# When the probe captured upstream <sparkle:deltas>, this script re-emits them
+# too: one delta <enclosure> per entry with the URL host swapped to the mirror
+# and every other attribute (notably each delta's own sparkle:edSignature) kept
+# byte-for-byte. The mirror never runs BinaryDelta and never recomputes a
+# signature; it copies the official delta bytes + signatures verbatim. The full
+# <enclosure> is always present, so a client with no matching delta still falls
+# back to the full archive.
 #
 # Usage:
 #   build-appcast.sh <arch> <manifest> <public-base-url> <output-path>
@@ -92,6 +98,14 @@ fi
 
 enclosure_url="$base/latest/$mirror_dir/Codex-darwin-${archive_arch}-${short_version}.zip"
 
+# Delta enclosures the official appcast advertises under <sparkle:deltas>. The
+# probe captured each one verbatim (every attribute, including the official
+# edSignature). We re-emit them unchanged except for swapping the enclosure URL
+# host to the mirror; the bytes (and therefore the signature) are untouched and
+# we never run BinaryDelta. Empty/missing array => a full-update-only feed, which
+# is exactly today's behaviour, so existing releases stay byte-identical.
+deltas_json="$(jq -c --arg a "$manifest_key" '.sources.macos[$a].appcast.deltas // []' "$manifest")"
+
 python3 - \
   "$output_path" \
   "$title" \
@@ -102,7 +116,11 @@ python3 - \
   "$hardware_requirements" \
   "$enclosure_url" \
   "$enclosure_length" \
-  "$enclosure_signature" <<'PY'
+  "$enclosure_signature" \
+  "$base" \
+  "$mirror_dir" \
+  "$deltas_json" <<'PY'
+import json
 import sys
 from xml.sax.saxutils import escape, quoteattr
 
@@ -117,9 +135,60 @@ from xml.sax.saxutils import escape, quoteattr
     enclosure_url,
     enclosure_length,
     enclosure_signature,
+    mirror_base,
+    mirror_dir,
+    deltas_json,
 ) = sys.argv[1:]
 
 SPARKLE_NS = "http://www.andymatuschak.org/xml-namespaces/sparkle"
+
+deltas = json.loads(deltas_json) if deltas_json else []
+
+
+def delta_enclosure_line(delta):
+    # Resolve the mirror URL from the official basename so URL resolution through
+    # the Worker stays stable. Preserve the basename exactly as published.
+    basename = delta.get("basename") or (delta.get("url", "").rsplit("/", 1)[-1])
+    if not basename:
+        raise SystemExit("delta enclosure missing basename/url")
+    mirror_url = f"{mirror_base}/latest/{mirror_dir}/{basename}"
+
+    # Start from every attribute the probe captured (verbatim, sparkle: prefixes
+    # preserved) so we faithfully reproduce OpenAI's enclosure, then override the
+    # URL with the mirror location. Fall back to the explicit prompt-named fields
+    # if an older manifest predates the full "attributes" map.
+    attrs = dict(delta.get("attributes") or {})
+    if not attrs:
+        attrs = {
+            "url": delta.get("url", ""),
+            "sparkle:deltaFrom": delta.get("deltaFrom", ""),
+            "length": str(delta.get("length", "")),
+            "type": delta.get("type", "") or "application/octet-stream",
+            "sparkle:edSignature": delta.get("edSignature", ""),
+        }
+        if delta.get("version"):
+            attrs["sparkle:version"] = delta["version"]
+        if delta.get("os"):
+            attrs["sparkle:os"] = delta["os"]
+        attrs = {k: v for k, v in attrs.items() if v != ""}
+    attrs["url"] = mirror_url
+
+    # Emit a stable, readable attribute order: url first, then the Sparkle
+    # delta-identifying / signature attributes, then any remaining official
+    # attributes (sorted) so nothing OpenAI published is dropped.
+    preferred = [
+        "url",
+        "sparkle:deltaFrom",
+        "sparkle:version",
+        "sparkle:os",
+        "length",
+        "type",
+        "sparkle:edSignature",
+    ]
+    ordered = [k for k in preferred if k in attrs]
+    ordered += [k for k in sorted(attrs) if k not in preferred]
+    rendered = " ".join(f"{k}={quoteattr(str(attrs[k]))}" for k in ordered)
+    return f"                <enclosure {rendered} />"
 
 lines = []
 lines.append("<?xml version='1.0' encoding='utf-8'?>")
@@ -151,6 +220,14 @@ enclosure_attrs = " ".join(
     ]
 )
 lines.append(f"            <enclosure {enclosure_attrs} />")
+# Delta enclosures (incremental updates). Emitted only when upstream advertised
+# them; the full <enclosure> above is always present so clients without a
+# matching delta still fall back to the full archive.
+if deltas:
+    lines.append("            <sparkle:deltas>")
+    for delta in deltas:
+        lines.append(delta_enclosure_line(delta))
+    lines.append("            </sparkle:deltas>")
 lines.append("        </item>")
 lines.append("    </channel>")
 lines.append("</rss>")

--- a/scripts/download-macos.sh
+++ b/scripts/download-macos.sh
@@ -133,11 +133,68 @@ download_zip() {
 download_zip "macOS arm64 Sparkle archive" "$arm_zip_url" "$arm_zip_name" "$arm_zip_expected_size"
 download_zip "macOS x64 Sparkle archive" "$x64_zip_url" "$x64_zip_name" "$x64_zip_expected_size"
 
+# Mirror the Sparkle delta archives (.delta) the official appcast advertises
+# under <sparkle:deltas>. Like the full .zip archives, the bytes are copied
+# verbatim so the official EdDSA signature stays valid; we NEVER run BinaryDelta
+# and NEVER touch the edSignature. The official basename is preserved exactly
+# (the enclosure URL the mirror publishes is resolved by basename), and the byte
+# length is checked against the appcast `length` as an integrity guard. Deltas
+# land alongside the full zips in $out_dir, the same staging layout the zips use.
+#
+# The downloaded delta basenames are recorded (one per line) so they can be
+# appended to SHA256SUMS-macos.txt without relying on bash arrays (the macOS
+# runner's bash 3.2 errors on expanding an empty array under `set -u`).
+mac_delta_names_file="$(mktemp)"
+trap 'rm -f "$mac_delta_names_file"' EXIT
+: > "$mac_delta_names_file"
+
+download_deltas() {
+  local arch_key="$1"
+  local count i
+  local url basename expected_size
+
+  if [[ -z "$manifest_path" ]]; then
+    return 0
+  fi
+
+  count="$(jq -r --arg a "$arch_key" '.sources.macos[$a].appcast.deltas | length // 0' "$manifest_path")"
+  if [[ -z "$count" || "$count" == "null" || "$count" -eq 0 ]]; then
+    return 0
+  fi
+
+  for ((i = 0; i < count; i++)); do
+    url="$(jq -r --arg a "$arch_key" --argjson i "$i" '.sources.macos[$a].appcast.deltas[$i].url // ""' "$manifest_path")"
+    basename="$(jq -r --arg a "$arch_key" --argjson i "$i" '.sources.macos[$a].appcast.deltas[$i].basename // ""' "$manifest_path")"
+    expected_size="$(jq -r --arg a "$arch_key" --argjson i "$i" '.sources.macos[$a].appcast.deltas[$i].length // 0' "$manifest_path")"
+
+    if [[ -z "$url" || "$url" == "null" ]]; then
+      echo "Missing macOS $arch_key delta[$i] URL in manifest; cannot mirror Sparkle delta." >&2
+      exit 1
+    fi
+    if [[ -z "$basename" || "$basename" == "null" ]]; then
+      # Preserve the official filename: fall back to the URL basename if the
+      # probe did not record one explicitly.
+      basename="${url##*/}"
+    fi
+    if [[ -z "$basename" ]]; then
+      echo "Could not determine macOS $arch_key delta[$i] basename." >&2
+      exit 1
+    fi
+
+    download_file "macOS $arch_key Sparkle delta ($basename)" "$url" "$out_dir/$basename"
+    validate_size "$out_dir/$basename" "$expected_size"
+    printf '%s\n' "$basename" >> "$mac_delta_names_file"
+  done
+}
+
+download_deltas arm64
+download_deltas x64
+
 (
   cd "$out_dir"
-  # Always checksum both DMGs; append any mirrored Sparkle archives. Built as a
-  # positional list (not an array) so it stays safe under `set -u` on the macOS
-  # runner's bash 3.2, where expanding an empty array is an error.
+  # Always checksum both DMGs; append any mirrored Sparkle archives + deltas.
+  # Built as a positional list (not an array) so it stays safe under `set -u` on
+  # the macOS runner's bash 3.2, where expanding an empty array is an error.
   set -- Codex-mac-arm64.dmg Codex-mac-x64.dmg
   if [[ -n "$arm_zip_name" && -f "$arm_zip_name" ]]; then
     set -- "$@" "$arm_zip_name"
@@ -145,5 +202,11 @@ download_zip "macOS x64 Sparkle archive" "$x64_zip_url" "$x64_zip_name" "$x64_zi
   if [[ -n "$x64_zip_name" && -f "$x64_zip_name" ]]; then
     set -- "$@" "$x64_zip_name"
   fi
+  while IFS= read -r delta_name; do
+    [[ -z "$delta_name" ]] && continue
+    if [[ -f "$delta_name" ]]; then
+      set -- "$@" "$delta_name"
+    fi
+  done < "$mac_delta_names_file"
   shasum -a 256 "$@" > SHA256SUMS-macos.txt
 )

--- a/scripts/probe-release.sh
+++ b/scripts/probe-release.sh
@@ -106,7 +106,23 @@ import json
 import sys
 import xml.etree.ElementTree as ET
 
-ns = {"sparkle": "http://www.andymatuschak.org/xml-namespaces/sparkle"}
+SPARKLE = "http://www.andymatuschak.org/xml-namespaces/sparkle"
+ns = {"sparkle": SPARKLE}
+
+
+def sparkle_attr(name):
+    return "{%s}%s" % (SPARKLE, name)
+
+
+def attr_key(raw):
+    # Render the official attribute name back into appcast form, mapping the
+    # ElementTree "{ns}local" spelling onto the "sparkle:local" prefix used in
+    # the feed so the build step can re-emit it verbatim.
+    if raw.startswith("{%s}" % SPARKLE):
+        return "sparkle:" + raw[len("{%s}" % SPARKLE):]
+    return raw
+
+
 root = ET.parse(sys.stdin).getroot()
 item = root.find("./channel/item")
 if item is None:
@@ -114,7 +130,35 @@ if item is None:
 enclosure = item.find("enclosure")
 if enclosure is None:
     raise SystemExit("appcast item has no enclosure")
-sparkle_sig_key = "{http://www.andymatuschak.org/xml-namespaces/sparkle}edSignature"
+sparkle_sig_key = sparkle_attr("edSignature")
+
+# Capture every <sparkle:deltas>/<enclosure> verbatim. The mirror reuses the
+# official bytes and the official edSignature untouched; it never runs
+# BinaryDelta and never recomputes a signature. We record the prompt-named
+# fields explicitly *and* a full "attributes" map (every attribute on the
+# enclosure, with sparkle: prefixes preserved) so the build step can re-emit
+# each delta exactly as OpenAI published it, swapping only the URL host.
+deltas = []
+deltas_el = item.find("sparkle:deltas", namespaces=ns)
+if deltas_el is not None:
+    for delta in deltas_el.findall("enclosure"):
+        url = delta.attrib.get("url", "")
+        basename = url.rsplit("/", 1)[-1] if url else ""
+        attributes = {attr_key(k): v for k, v in delta.attrib.items()}
+        deltas.append(
+            {
+                "basename": basename,
+                "url": url,
+                "length": int(delta.attrib.get("length", "0") or "0"),
+                "deltaFrom": delta.attrib.get(sparkle_attr("deltaFrom"), ""),
+                "version": delta.attrib.get(sparkle_attr("version"), ""),
+                "os": delta.attrib.get(sparkle_attr("os"), ""),
+                "type": delta.attrib.get("type", ""),
+                "edSignature": delta.attrib.get(sparkle_sig_key, ""),
+                "attributes": attributes,
+            }
+        )
+
 payload = {
     "title": item.findtext("title") or "",
     "pubDate": item.findtext("pubDate") or "",
@@ -125,6 +169,7 @@ payload = {
     "enclosureUrl": enclosure.attrib.get("url", ""),
     "enclosureLength": int(enclosure.attrib.get("length", "0") or "0"),
     "enclosureSignature": enclosure.attrib.get(sparkle_sig_key, ""),
+    "deltas": deltas,
 }
 print(json.dumps(payload, sort_keys=True))
 '

--- a/scripts/prune-mac-source.sh
+++ b/scripts/prune-mac-source.sh
@@ -10,13 +10,23 @@ set -euo pipefail
 #
 # Safety rules:
 # - keep every basename passed as an argument;
+# - keep every enclosure basename referenced by a Sparkle appcast passed as an
+#   argument: the full .zip AND every <sparkle:deltas> .delta. This is what makes
+#   the keep list delta-aware -- pass the freshly built appcast(s) and no live
+#   delta gets pruned. (PR #8's secondary-S3 prune reuses these rules, so adding
+#   the appcasts to its invocation protects deltas there too.)
 # - keep objects modified inside PRUNE_GRACE_DAYS, so clients with a cached
 #   previous appcast can finish downloading;
 # - keep objects with an unparsable timestamp;
 # - never delete directory marker keys.
 #
 # Usage:
-#   prune-mac-source.sh <bucket> <prefix> <keep-file-or-basename> [...]
+#   prune-mac-source.sh <bucket> <prefix> <keep-file-or-basename-or-appcast.xml> [...]
+#
+# A keep argument is interpreted as:
+#   - an appcast feed, if it is an existing file ending in .xml -> every
+#     enclosure basename it references (full + deltas) is kept;
+#   - otherwise a plain path/basename -> its basename is kept.
 
 : "${R2_S3_ENDPOINT:?R2_S3_ENDPOINT must be set}"
 : "${AWS_ACCESS_KEY_ID:?AWS_ACCESS_KEY_ID must be set}"
@@ -48,14 +58,51 @@ if [[ ! "$grace_days" =~ ^[0-9]+$ ]]; then
   exit 2
 fi
 
+# Print every enclosure basename (full .zip + each <sparkle:deltas> .delta) that
+# a Sparkle appcast references. Used to make the keep list delta-aware.
+appcast_enclosure_basenames() {
+  local appcast="$1"
+  python3 - "$appcast" <<'PY'
+import sys
+import xml.etree.ElementTree as ET
+
+SP = "{http://www.andymatuschak.org/xml-namespaces/sparkle}"
+item = ET.parse(sys.argv[1]).getroot().find("./channel/item")
+if item is None:
+    sys.exit(0)
+names = []
+top = item.find("enclosure")
+if top is not None and top.attrib.get("url"):
+    names.append(top.attrib["url"].rsplit("/", 1)[-1])
+deltas = item.find(SP + "deltas")
+if deltas is not None:
+    for enc in deltas.findall("enclosure"):
+        url = enc.attrib.get("url", "")
+        if url:
+            names.append(url.rsplit("/", 1)[-1])
+for name in names:
+    if name:
+        print(name)
+PY
+}
+
 keep_file="$(mktemp)"
 trap 'rm -f "$keep_file"' EXIT
 for item in "$@"; do
-  basename "$item"
+  if [[ -f "$item" && "$item" == *.xml ]]; then
+    # An appcast feed: keep every enclosure it references (full + deltas).
+    if ! command -v python3 >/dev/null 2>&1; then
+      echo "python3 is required to parse appcast keep argument: $item" >&2
+      exit 1
+    fi
+    appcast_enclosure_basenames "$item"
+  else
+    basename "$item"
+  fi
 done | sort -u > "$keep_file"
 
 if [[ ! -s "$keep_file" ]]; then
-  echo "At least one keep file or basename is required." >&2
+  echo "At least one keep file, basename, or appcast.xml is required." >&2
   exit 2
 fi
 

--- a/scripts/sync-secondary-s3.sh
+++ b/scripts/sync-secondary-s3.sh
@@ -63,6 +63,50 @@ appcast_x64="$9"
 mac_arm64_zip_name="$(basename "$mac_arm64_zip")"
 mac_intel_zip_name="$(basename "$mac_intel_zip")"
 
+# Extract the .delta enclosure basenames an appcast references. The mirror keeps
+# the official basenames verbatim, so the basename is enough to locate the file
+# (downloaded alongside the full .zip) and to build the object key.
+delta_basenames_from_appcast() {
+  local appcast="$1"
+  python3 - "$appcast" <<'PY'
+import sys
+import xml.etree.ElementTree as ET
+
+SP = "{http://www.andymatuschak.org/xml-namespaces/sparkle}"
+item = ET.parse(sys.argv[1]).getroot().find("./channel/item")
+if item is None:
+    sys.exit(0)
+deltas = item.find(SP + "deltas")
+if deltas is None:
+    sys.exit(0)
+for enc in deltas.findall("enclosure"):
+    url = enc.attrib.get("url", "")
+    if url:
+        print(url.rsplit("/", 1)[-1])
+PY
+}
+
+# Upload every .delta the given appcast references, from the same directory as
+# its full .zip, into <prefix>/mac/<dir>/<basename>. Done before the appcasts are
+# published so the feed never advertises a delta that is not yet downloadable.
+upload_deltas_for_appcast() {
+  local appcast="$1"
+  local zip_path="$2"
+  local mac_dir="$3"
+  local src_dir
+  local bn
+
+  src_dir="$(dirname "$zip_path")"
+  while IFS= read -r bn; do
+    [[ -z "$bn" ]] && continue
+    if [[ ! -f "$src_dir/$bn" ]]; then
+      echo "Missing delta archive $src_dir/$bn referenced by $appcast." >&2
+      exit 1
+    fi
+    bash "$repo_root/scripts/sync-r2.sh" --object "$SECONDARY_S3_BUCKET" "$prefix/mac/$mac_dir/$bn" "$src_dir/$bn" "$bn"
+  done < <(delta_basenames_from_appcast "$appcast")
+}
+
 bash "$repo_root/scripts/sync-r2.sh" --object "$SECONDARY_S3_BUCKET" "$prefix/mac-arm64" "$mac_arm64" Codex-mac-arm64.dmg
 bash "$repo_root/scripts/sync-r2.sh" --object "$SECONDARY_S3_BUCKET" "$prefix/mac-intel" "$mac_intel" Codex-mac-intel.dmg
 bash "$repo_root/scripts/sync-r2.sh" --object "$SECONDARY_S3_BUCKET" "$prefix/win" "$win_msix" Codex-Windows-x64.msix
@@ -70,9 +114,12 @@ bash "$repo_root/scripts/sync-r2.sh" --object "$SECONDARY_S3_BUCKET" "$prefix/ch
 bash "$repo_root/scripts/sync-r2.sh" --object "$SECONDARY_S3_BUCKET" "$prefix/manifest" "$manifest" release-manifest.json
 
 # Sparkle update archives, keyed to match the appcast enclosure URLs. Upload the
-# archives before the appcasts so the feed never advertises a missing enclosure.
+# archives (full .zip + every .delta) before the appcasts so the feed never
+# advertises a missing enclosure.
 bash "$repo_root/scripts/sync-r2.sh" --object "$SECONDARY_S3_BUCKET" "$prefix/mac/arm64/$mac_arm64_zip_name" "$mac_arm64_zip" "$mac_arm64_zip_name"
 bash "$repo_root/scripts/sync-r2.sh" --object "$SECONDARY_S3_BUCKET" "$prefix/mac/intel/$mac_intel_zip_name" "$mac_intel_zip" "$mac_intel_zip_name"
+upload_deltas_for_appcast "$appcast_arm64" "$mac_arm64_zip" arm64
+upload_deltas_for_appcast "$appcast_x64" "$mac_intel_zip" intel
 
 # appcast feeds change every release; keep their CDN cache short.
 R2_CACHE_CONTROL="public, max-age=600" \

--- a/scripts/test-build-appcast.sh
+++ b/scripts/test-build-appcast.sh
@@ -16,6 +16,12 @@ trap cleanup EXIT
 arm_sig="fQ7rDmk/lQGGg8JReeCvN+ct0Db3z6MFvV8FqgI9ZzpYNKpjWalf2vfLi8TqSCVBF+jXs20U3FGwTeaWocDYBg=="
 x64_sig="6OM9z2K/DXc05QidSyspEl9LXe1s5E8HesofMpw9vQ/nBNK39pSarOqGt6u1jA+VyDy4pbsphk4WAUH8D3eKDg=="
 
+# Delta enclosure fixtures (real upstream shape: each has its own edSignature and
+# the deltaFromSparkle* attributes Sparkle publishes). arm64 ships two deltas to
+# exercise the delta path; x64 ships none to exercise the full-update-only path.
+arm_delta1_sig="46z2mpw1xOZWuQ0rpQn+tZ5yRQL/GmJN2UJ7qpS7IC7NILk9xxHALGnGa8gRZvKK3lV9ni11AnXCCPbRQMKXDg=="
+arm_delta2_sig="uIgT0RouyKTkFMQ/MNFhITkvxyNhEfnsXgvKCKVWxv8FedrmWvLYWzwAFcz86UEx2JaszL2QfMIM5u3yOIrIBg=="
+
 cat > "$tmp_dir/release-manifest.json" <<JSON
 {
   "schemaVersion": 2,
@@ -31,7 +37,47 @@ cat > "$tmp_dir/release-manifest.json" <<JSON
           "hardwareRequirements": "arm64",
           "enclosureUrl": "https://persistent.oaistatic.com/codex-app-prod/Codex-darwin-arm64-26.602.40724.zip",
           "enclosureLength": 406585586,
-          "enclosureSignature": "$arm_sig"
+          "enclosureSignature": "$arm_sig",
+          "deltas": [
+            {
+              "basename": "Codex3593-3575-arm64.delta",
+              "url": "https://persistent.oaistatic.com/codex-app-prod/Codex3593-3575-arm64.delta",
+              "length": 195130,
+              "deltaFrom": "3575",
+              "version": "",
+              "os": "",
+              "type": "application/octet-stream",
+              "edSignature": "$arm_delta1_sig",
+              "attributes": {
+                "url": "https://persistent.oaistatic.com/codex-app-prod/Codex3593-3575-arm64.delta",
+                "length": "195130",
+                "type": "application/octet-stream",
+                "sparkle:deltaFrom": "3575",
+                "sparkle:deltaFromSparkleExecutableSize": "979952",
+                "sparkle:deltaFromSparkleLocales": "de,ar,el,ja,fa,uk,zh_CN",
+                "sparkle:edSignature": "$arm_delta1_sig"
+              }
+            },
+            {
+              "basename": "Codex3593-3511-arm64.delta",
+              "url": "https://persistent.oaistatic.com/codex-app-prod/Codex3593-3511-arm64.delta",
+              "length": 18255214,
+              "deltaFrom": "3511",
+              "version": "",
+              "os": "",
+              "type": "application/octet-stream",
+              "edSignature": "$arm_delta2_sig",
+              "attributes": {
+                "url": "https://persistent.oaistatic.com/codex-app-prod/Codex3593-3511-arm64.delta",
+                "length": "18255214",
+                "type": "application/octet-stream",
+                "sparkle:deltaFrom": "3511",
+                "sparkle:deltaFromSparkleExecutableSize": "979952",
+                "sparkle:deltaFromSparkleLocales": "de,ar,el,ja,fa,uk,zh_CN",
+                "sparkle:edSignature": "$arm_delta2_sig"
+              }
+            }
+          ]
         }
       },
       "x64": {
@@ -44,7 +90,8 @@ cat > "$tmp_dir/release-manifest.json" <<JSON
           "hardwareRequirements": "",
           "enclosureUrl": "https://persistent.oaistatic.com/codex-app-prod/Codex-darwin-x64-26.602.40724.zip",
           "enclosureLength": 397428010,
-          "enclosureSignature": "$x64_sig"
+          "enclosureSignature": "$x64_sig",
+          "deltas": []
         }
       }
     }
@@ -86,7 +133,21 @@ assert_contains "$tmp_dir/appcast.xml" '<sparkle:shortVersionString>26.602.40724
 assert_contains "$tmp_dir/appcast.xml" '<sparkle:minimumSystemVersion>12.0</sparkle:minimumSystemVersion>'
 assert_contains "$tmp_dir/appcast.xml" '<sparkle:hardwareRequirements>arm64</sparkle:hardwareRequirements>'
 assert_contains "$tmp_dir/appcast.xml" 'type="application/octet-stream"'
-# Never leak the upstream enclosure host into the mirror feed.
+
+# arm64 deltas: a <sparkle:deltas> block whose enclosures point at the mirror,
+# preserve the official basename, and reuse each delta's edSignature/length/
+# deltaFrom verbatim. The extra deltaFromSparkle* attributes are kept too.
+assert_contains "$tmp_dir/appcast.xml" '<sparkle:deltas>'
+assert_contains "$tmp_dir/appcast.xml" 'url="https://codexapp.agentsmirror.com/latest/mac/arm64/Codex3593-3575-arm64.delta"'
+assert_contains "$tmp_dir/appcast.xml" 'url="https://codexapp.agentsmirror.com/latest/mac/arm64/Codex3593-3511-arm64.delta"'
+assert_contains "$tmp_dir/appcast.xml" 'sparkle:deltaFrom="3575"'
+assert_contains "$tmp_dir/appcast.xml" 'sparkle:deltaFrom="3511"'
+assert_contains "$tmp_dir/appcast.xml" "sparkle:edSignature=\"$arm_delta1_sig\""
+assert_contains "$tmp_dir/appcast.xml" "sparkle:edSignature=\"$arm_delta2_sig\""
+assert_contains "$tmp_dir/appcast.xml" 'length="195130"'
+assert_contains "$tmp_dir/appcast.xml" 'sparkle:deltaFromSparkleExecutableSize="979952"'
+assert_contains "$tmp_dir/appcast.xml" 'sparkle:deltaFromSparkleLocales="de,ar,el,ja,fa,uk,zh_CN"'
+# Never leak the upstream enclosure host into the mirror feed (full or delta).
 assert_absent "$tmp_dir/appcast.xml" 'persistent.oaistatic.com'
 
 # x64: own enclosure name + signature, and no hardwareRequirements element.
@@ -95,6 +156,10 @@ assert_contains "$tmp_dir/appcast-x64.xml" "sparkle:edSignature=\"$x64_sig\""
 assert_contains "$tmp_dir/appcast-x64.xml" 'length="397428010"'
 assert_absent "$tmp_dir/appcast-x64.xml" 'hardwareRequirements'
 assert_absent "$tmp_dir/appcast-x64.xml" 'persistent.oaistatic.com'
+# x64 has no upstream deltas: the feed must stay full-update-only (no empty
+# <sparkle:deltas> element, no .delta enclosures).
+assert_absent "$tmp_dir/appcast-x64.xml" '<sparkle:deltas>'
+assert_absent "$tmp_dir/appcast-x64.xml" '.delta"'
 
 # Both feeds must be well-formed XML with exactly one <item>.
 for feed in "$tmp_dir/appcast.xml" "$tmp_dir/appcast-x64.xml"; do
@@ -119,6 +184,42 @@ assert item.findtext(
 ), "missing sparkle:shortVersionString"
 PY
 done
+
+# Structural delta checks: arm64 has exactly the two upstream deltas (each a
+# mirror URL with its own verbatim edSignature); x64 has no <sparkle:deltas>.
+python3 - "$tmp_dir/appcast.xml" "$arm_delta1_sig" "$arm_delta2_sig" <<'PY'
+import sys
+import xml.etree.ElementTree as ET
+
+SP = "{http://www.andymatuschak.org/xml-namespaces/sparkle}"
+feed, sig1, sig2 = sys.argv[1:]
+item = ET.parse(feed).getroot().find("./channel/item")
+deltas = item.find(SP + "deltas")
+assert deltas is not None, "arm64 feed must have <sparkle:deltas>"
+encs = deltas.findall("enclosure")
+assert len(encs) == 2, f"expected 2 deltas, got {len(encs)}"
+by_from = {e.attrib.get(SP + "deltaFrom"): e for e in encs}
+assert set(by_from) == {"3575", "3511"}, sorted(by_from)
+for e in encs:
+    url = e.attrib["url"]
+    assert url.startswith(
+        "https://codexapp.agentsmirror.com/latest/mac/arm64/"
+    ), url
+    assert url.endswith(".delta"), url
+    assert e.attrib.get(SP + "edSignature"), "delta missing edSignature"
+    assert e.attrib.get("length"), "delta missing length"
+assert by_from["3575"].attrib[SP + "edSignature"] == sig1
+assert by_from["3511"].attrib[SP + "edSignature"] == sig2
+PY
+
+python3 - "$tmp_dir/appcast-x64.xml" <<'PY'
+import sys
+import xml.etree.ElementTree as ET
+
+SP = "{http://www.andymatuschak.org/xml-namespaces/sparkle}"
+item = ET.parse(sys.argv[1]).getroot().find("./channel/item")
+assert item.find(SP + "deltas") is None, "x64 feed must not have <sparkle:deltas>"
+PY
 
 # Missing appcast metadata must fail loudly (the guard against shipping a broken feed).
 cat > "$tmp_dir/empty-manifest.json" <<'JSON'

--- a/scripts/test-prune-mac-source.sh
+++ b/scripts/test-prune-mac-source.sh
@@ -16,9 +16,16 @@ cat > "$tmp_dir/bin/aws" <<'AWS'
 set -euo pipefail
 
 if [[ "$1" == "s3api" && "$2" == "list-objects-v2" ]]; then
+  # Old, timestamped objects (2020) are prune candidates unless kept; the 2099
+  # object is inside any sane grace window so it must always survive. The
+  # *-live-*.delta entries are old by timestamp but referenced by the appcast,
+  # so they must be kept; old-3000-arm64.delta is old AND unreferenced -> pruned.
   cat <<'OBJECTS'
 latest/mac/arm64/Codex-darwin-arm64-current.zip	2020-01-01T00:00:00.000Z
 latest/mac/intel/Codex-darwin-x64-current.zip	2020-01-01T00:00:00.000Z
+latest/mac/arm64/Codex9999-live-arm64.delta	2020-01-01T00:00:00.000Z
+latest/mac/intel/Codex9999-live-x64.delta	2020-01-01T00:00:00.000Z
+latest/mac/arm64/old-3000-arm64.delta	2020-01-01T00:00:00.000Z
 latest/mac/arm64/old.zip	2020-01-01T00:00:00.000Z
 latest/mac/intel/recent.zip	2099-01-01T00:00:00.000Z
 latest/mac/arm64/	2020-01-01T00:00:00.000Z
@@ -40,6 +47,36 @@ touch \
   "$tmp_dir/keep/Codex-darwin-arm64-current.zip" \
   "$tmp_dir/keep/Codex-darwin-x64-current.zip"
 
+# Freshly built appcasts that reference the current full .zip plus the live
+# deltas. Passing these to prune-mac-source.sh must protect the deltas from the
+# grace-window prune (the delta-aware keep list).
+cat > "$tmp_dir/keep/appcast.xml" <<'XML'
+<?xml version='1.0' encoding='utf-8'?>
+<rss xmlns:sparkle="http://www.andymatuschak.org/xml-namespaces/sparkle" version="2.0">
+    <channel>
+        <item>
+            <enclosure url="https://m/latest/mac/arm64/Codex-darwin-arm64-current.zip" length="1" type="application/octet-stream" sparkle:edSignature="S==" />
+            <sparkle:deltas>
+                <enclosure url="https://m/latest/mac/arm64/Codex9999-live-arm64.delta" sparkle:deltaFrom="3575" length="1" type="application/octet-stream" sparkle:edSignature="D==" />
+            </sparkle:deltas>
+        </item>
+    </channel>
+</rss>
+XML
+cat > "$tmp_dir/keep/appcast-x64.xml" <<'XML'
+<?xml version='1.0' encoding='utf-8'?>
+<rss xmlns:sparkle="http://www.andymatuschak.org/xml-namespaces/sparkle" version="2.0">
+    <channel>
+        <item>
+            <enclosure url="https://m/latest/mac/intel/Codex-darwin-x64-current.zip" length="1" type="application/octet-stream" sparkle:edSignature="S==" />
+            <sparkle:deltas>
+                <enclosure url="https://m/latest/mac/intel/Codex9999-live-x64.delta" sparkle:deltaFrom="3575" length="1" type="application/octet-stream" sparkle:edSignature="D==" />
+            </sparkle:deltas>
+        </item>
+    </channel>
+</rss>
+XML
+
 PATH="$tmp_dir/bin:$PATH" \
 AWS_RM_LOG="$rm_log" \
 R2_S3_ENDPOINT="https://example.invalid" \
@@ -50,14 +87,28 @@ PRUNE_GRACE_DAYS=7 \
     test-bucket \
     latest/mac \
     "$tmp_dir/keep/Codex-darwin-arm64-current.zip" \
-    "$tmp_dir/keep/Codex-darwin-x64-current.zip"
+    "$tmp_dir/keep/Codex-darwin-x64-current.zip" \
+    "$tmp_dir/keep/appcast.xml" \
+    "$tmp_dir/keep/appcast-x64.xml"
 
 if ! grep -q 's3://test-bucket/latest/mac/arm64/old.zip' "$rm_log"; then
   echo "expected old.zip to be pruned" >&2
   exit 1
 fi
+# An old, unreferenced delta must still be pruned.
+if ! grep -q 's3://test-bucket/latest/mac/arm64/old-3000-arm64.delta' "$rm_log"; then
+  echo "expected old-3000-arm64.delta (old + unreferenced) to be pruned" >&2
+  exit 1
+fi
 if grep -Eq 'current\.zip|recent\.zip|latest/mac/arm64/ ' "$rm_log"; then
   echo "pruned a current, recent, or directory marker object" >&2
+  cat "$rm_log" >&2
+  exit 1
+fi
+# Live deltas referenced by the freshly built appcasts must NOT be pruned, even
+# though their timestamps are outside the grace window.
+if grep -Eq 'Codex9999-live-arm64\.delta|Codex9999-live-x64\.delta' "$rm_log"; then
+  echo "pruned a live delta still referenced by the appcast" >&2
   cat "$rm_log" >&2
   exit 1
 fi


### PR DESCRIPTION
## Summary

Republish OpenAI's per-arch Sparkle **delta (incremental) update** enclosures, so macOS clients update with a small delta (~18–66 MB) and fall back to the full ~400 MB archive when no matching delta exists.

**Correctness guarantee:** the mirror has no OpenAI EdDSA private key, so it **copies official payload bytes verbatim and reuses OpenAI's `sparkle:edSignature` verbatim** for both full archives and every delta. This PR **never runs `BinaryDelta`, never generates/recomputes/alters any `edSignature` or other signature, and never re-signs anything.** It only copies official bytes + official signatures and rewrites enclosure URLs to point at the mirror (host swap only).

Backward-compatible end to end: a release with no upstream deltas (or an older manifest without the `deltas` key) yields an empty list everywhere and behaves exactly like today (full-update-only feed, byte-identical output).

## Per-task changes

### M1 — probe captures deltas — `scripts/probe-release.sh`
Extended the `appcast_latest()` inline parser to walk `<sparkle:deltas>/<enclosure>` for each arch and record, into the existing `release-manifest.json` appcast block (`.sources.macos.<arch>.appcast.deltas[]`): `basename`, official `url`, `length`, `sparkle:deltaFrom`, `sparkle:version`, `sparkle:os`, `type`, `sparkle:edSignature` (verbatim) — **plus** a full `attributes` map of every attribute on the enclosure (with `sparkle:` prefixes preserved). The attributes map future-proofs against OpenAI's extra attributes (e.g. `sparkle:deltaFromSparkleExecutableSize`, `sparkle:deltaFromSparkleLocales`, which the live feed ships) so the build step reproduces each delta exactly. Schema stays additive/backward-compatible.
*Verified:* ran the parser against the live `appcast.xml`/`appcast-x64.xml` — captured all 5 deltas/arch with verbatim signatures; `bash -n` clean.

### M2 — mirror the delta bytes — `scripts/download-macos.sh`
New `download_deltas <arch>` iterates the manifest's `deltas[]`, downloads each `.delta` verbatim **preserving the official basename exactly** (falls back to the URL basename, per the existing filename-preservation rule), verifies the downloaded byte length equals the official `length` (reusing `validate_size`) as an integrity guard, and places deltas alongside the full zips in `$out_dir`. Delta basenames are appended to `SHA256SUMS-macos.txt`. The `edSignature` is never touched. Avoids bash arrays (macOS runner is bash 3.2).
*Verified:* local HTTP-server test — happy path (basenames preserved, files present, checksummed) and the integrity guard (deliberate length mismatch → loud non-zero exit). The deltas flow into `artifacts/codex-macos/` via the existing `codex-macos` artifact, and into `release-manifest.json` via `prepare-release-metadata.sh`'s existing jq passthrough (no change needed there — confirmed the `deltas` array survives).

### M3 — emit delta block — `scripts/build-appcast.sh` (+ inline python rewriter)
Under each arch `<item>`, when the manifest carries deltas, emit a `<sparkle:deltas>` element with one `<enclosure>` per delta: `url` = the **mirror** URL for the delta basename (same `<base>/latest/mac/{arm64,intel}/<basename>` scheme the full zip uses, routed via the Worker), and every other attribute copied verbatim from upstream (`sparkle:deltaFrom`, `length`, `type`, `sparkle:edSignature`, and the official `deltaFromSparkle*` attributes). The existing full `<enclosure>` is unchanged and always present.

Exact XML shape emitted (real build 40724 arm64 example):
```xml
<enclosure url="https://codexapp.agentsmirror.com/latest/mac/arm64/Codex-darwin-arm64-26.602.40724.zip" length="406585586" type="application/octet-stream" sparkle:edSignature="fQ7rDmk/...DYBg==" />
<sparkle:deltas>
    <enclosure url="https://codexapp.agentsmirror.com/latest/mac/arm64/Codex3593-3575-arm64.delta" sparkle:deltaFrom="3575" length="195130" type="application/octet-stream" sparkle:edSignature="46z2mpw1...MKXDg==" sparkle:deltaFromSparkleExecutableSize="979952" sparkle:deltaFromSparkleLocales="de,ar,el,ja,fa,uk,zh_CN" />
    <!-- one <enclosure> per deltaFrom: 3575, 3511, 3497, 3437, 3390 -->
</sparkle:deltas>
```
(Attribute order: `url` first, then `sparkle:deltaFrom`/`length`/`type`/`sparkle:edSignature`, then remaining official attributes — XML attribute order is not semantically significant; Sparkle parses by name.)
*Verified:* extended `scripts/test-build-appcast.sh` (arm64 emits 2 deltas, x64 stays full-only); plus an end-to-end check building from the **live** feed confirming each delta's `edSignature`/`length`/`deltaFrom`/`type`/`deltaFromSparkle*` are byte-identical to upstream and only the URL host is swapped, with no `persistent.oaistatic.com` leak.

### M4 — upload order — `.github/workflows/mirror.yml` (R2 step) + `scripts/sync-secondary-s3.sh`
Every `.delta` is uploaded to **both** R2 and the secondary S3 mirror **before** the appcasts are published, under the same `latest/mac/{arm64,intel}/<basename>` keys and filename-preservation the full zips use. R2 keys derive from `release-manifest.json` (same source `build-appcast.sh` reads); the secondary step derives them by parsing the appcast feeds it's already handed (keeps its rigid 9-arg signature). All credentials/endpoints continue to come only from existing env / GitHub Secrets — nothing hardcoded, no secret values logged. The Cloudflare `download-router` worker already routes any `/latest/...` path generically, so `.delta` URLs resolve with no worker change.
*Verified:* stubbed-`aws` test of `sync-secondary-s3.sh` asserts all deltas upload to the correct `mac/{arm64,intel}` keys and strictly **before** both appcasts; `actionlint` clean on `mirror.yml`; every `run:` block `bash -n` clean.

### M5 — prune keep-list includes live deltas — `scripts/prune-mac-source.sh`
Made the **shared** prune script delta-aware: any keep argument that is an existing `.xml` file is parsed as a Sparkle appcast, and **every** enclosure basename it references (full `.zip` + every `<sparkle:deltas>` `.delta`) is added to the keep-list. The R2 prune call now passes `appcast.xml appcast-x64.xml`, so live deltas are protected during the grace window instead of being 404'd out from under clients. Plain path/basename arguments still work unchanged.
*Verified:* extended `scripts/test-prune-mac-source.sh` — live deltas referenced by the appcasts are kept (even with old timestamps), an old **unreferenced** delta is still pruned, and current/recent/dir-marker objects are untouched.

## M5 ↔ PR #8 coupling (action required at merge time)

PR #8 (`feat/prune-secondary-s3-mac`) adds a *"Prune stale macOS Sparkle archives on secondary S3 mirror"* step to `mirror.yml` that calls this same shared `prune-mac-source.sh` with an **inline keep-list of only the two full-zip paths** (`$mac_arm64_zip`, `$mac_intel_zip`) — it does **not** pass the appcasts, so it would **not** pick up deltas.

Per the task constraints, **I did not modify or merge PR #8's branch.** This PR is based on `origin/main`. Making the *shared* script delta-aware (this PR) is the enabling half; the secondary prune only benefits once it passes the feeds.

**When merging PR #8**, add the appcasts to its `prune-mac-source.sh` invocation so its keep-list is delta-aware too:
```sh
  bash scripts/prune-mac-source.sh \
    "$SECONDARY_S3_BUCKET" \
    "$secondary_prefix/mac" \
    "$mac_arm64_zip" \
    "$mac_intel_zip" \
    appcast.xml \
    appcast-x64.xml
```
Without this, the IHEP secondary mirror would delete live deltas after the grace period while R2 keeps them. (The order of merge doesn't matter as long as the final secondary-prune invocation passes the appcasts.)

## Storage estimate (added per release)

Deltas are republished in addition to the full zips. For build 40724 (5 deltas/arch): **≈333 MB added per release across both arches** (~161 MB arm64 + ~171 MB x64), vs ~804 MB for the two full zips. With `PRUNE_GRACE_DAYS=7`, expect up to ~2 releases' worth of deltas resident transiently (~0.7 GB) before stale, unreferenced deltas are pruned. Uploaded to both R2 and the secondary S3 mirror.

## Verification summary
- `bash -n` on every modified script — clean.
- `scripts/test-build-appcast.sh`, `scripts/test-prune-mac-source.sh`, `scripts/test-prepare-release-metadata.sh` — all PASS (extended the first two with delta assertions).
- `actionlint .github/workflows/mirror.yml` and `ci.yml` — clean; all `run:` blocks `bash -n` clean.
- End-to-end check against OpenAI's **live** appcasts: probe → manifest passthrough → build-appcast → prune keep-list, confirming verbatim signatures and mirror-only URL rewrite.

> Draft: opening for review before enabling. No secrets touched; existing env/Secrets plumbing reused throughout.
