### PR TITLE
fix(cloudflare): harden mirror routing and dispatch

### DIFF
--- a/cloudflare/download-router/src/index.js
+++ b/cloudflare/download-router/src/index.js
@@ -5,7 +5,7 @@ export default {
   async fetch(request, env) {
     const url = new URL(request.url);
 
-    if (!url.pathname.startsWith("/latest/")) {
+    if (!isAllowedLatestPath(url.pathname)) {
       return new Response("Not found", { status: 404 });
     }
 
@@ -18,34 +18,64 @@ export default {
     );
 
     if (secondaryCountryCodes.has(country.toUpperCase()) && hasSecondaryS3Config(env)) {
-      const objectKey = objectKeyForPath(url.pathname, env.SECONDARY_S3_PREFIX || "");
-      const downloadMetadata = downloadMetadataForPath(url.pathname);
-      const signedUrl = await presignS3GetUrl({
-        endpoint: env.SECONDARY_S3_ENDPOINT,
-        bucket: env.SECONDARY_S3_BUCKET,
-        key: objectKey,
-        region: env.SECONDARY_S3_REGION || "auto",
-        accessKeyId: env.SECONDARY_S3_ACCESS_KEY_ID,
-        secretAccessKey: env.SECONDARY_S3_SECRET_ACCESS_KEY,
-        expiresInSeconds: ttlSeconds(env.SECONDARY_S3_SIGNED_URL_TTL_SECONDS),
-        responseHeaders: downloadMetadata
-          ? {
-              "response-content-disposition": `attachment; filename="${downloadMetadata.filename}"`,
-              "response-content-type": downloadMetadata.contentType,
-            }
-          : {},
-      });
+      try {
+        const objectKey = objectKeyForPath(url.pathname, env.SECONDARY_S3_PREFIX || "");
+        const downloadMetadata = downloadMetadataForPath(url.pathname);
+        const signedUrl = await presignS3GetUrl({
+          endpoint: env.SECONDARY_S3_ENDPOINT,
+          bucket: env.SECONDARY_S3_BUCKET,
+          key: objectKey,
+          region: env.SECONDARY_S3_REGION || "auto",
+          accessKeyId: env.SECONDARY_S3_ACCESS_KEY_ID,
+          secretAccessKey: env.SECONDARY_S3_SECRET_ACCESS_KEY,
+          expiresInSeconds: ttlSeconds(env.SECONDARY_S3_SIGNED_URL_TTL_SECONDS),
+          responseHeaders: downloadMetadata
+            ? {
+                "response-content-disposition": `attachment; filename="${downloadMetadata.filename}"`,
+                "response-content-type": downloadMetadata.contentType,
+              }
+            : {},
+        });
 
-      return redirect(signedUrl);
+        return redirect(signedUrl);
+      } catch (error) {
+        console.error(
+          JSON.stringify({
+            event: "secondary_s3_presign_failed",
+            path: url.pathname,
+            country,
+            error: error instanceof Error ? error.message : String(error),
+          }),
+        );
+      }
     }
 
     if (!env.GLOBAL_MIRROR_BASE_URL) {
       return new Response("Missing GLOBAL_MIRROR_BASE_URL", { status: 500 });
     }
 
-    return redirect(withPathAndSearch(env.GLOBAL_MIRROR_BASE_URL, url.pathname, url.search).toString());
+    return redirect(withPathAndSearch(env.GLOBAL_MIRROR_BASE_URL, url.pathname, url.search).toString(), {
+      "X-Mirror-Fallback": "global",
+    });
   },
 };
+
+function isAllowedLatestPath(pathname) {
+  const aliases = new Set([
+    "/latest/win",
+    "/latest/mac-arm64",
+    "/latest/mac-intel",
+    "/latest/checksums",
+    "/latest/manifest",
+    "/latest/appcast.xml",
+    "/latest/appcast-x64.xml",
+  ]);
+  if (aliases.has(pathname)) {
+    return true;
+  }
+
+  return /^\/latest\/mac\/(arm64|intel)\/[^/]+\.(zip|delta)$/.test(pathname);
+}
 
 function hasSecondaryS3Config(env) {
   return Boolean(
@@ -64,12 +94,13 @@ function ttlSeconds(value) {
   return Math.min(Math.max(parsed, 1), 604800);
 }
 
-function redirect(location) {
+function redirect(location, extraHeaders = {}) {
   return new Response(null, {
     status: 302,
     headers: {
       Location: location,
       "Cache-Control": "private, no-store",
+      ...extraHeaders,
     },
   });
 }
@@ -96,7 +127,7 @@ function downloadMetadataForPath(pathname) {
       contentType: "application/x-apple-diskimage",
     },
     "mac-intel": {
-      filename: "Codex-mac-intel.dmg",
+      filename: "Codex-mac-x64.dmg",
       contentType: "application/x-apple-diskimage",
     },
     win: {

--- a/cloudflare/github-dispatcher/README.md
+++ b/cloudflare/github-dispatcher/README.md
@@ -1,8 +1,9 @@
 # codex-app-mirror Cloudflare dispatcher
 
 This Worker uses Cloudflare Cron Triggers as the primary 15-minute scheduler for
-`codex-app-mirror`. It does not mirror files itself. It only calls the GitHub
-Actions `workflow_dispatch` API for `.github/workflows/mirror.yml`.
+`codex-app-mirror` and `agents-cli-mirror`. It does not mirror files itself. It
+only calls the GitHub Actions `workflow_dispatch` API for the configured mirror
+workflows.
 
 GitHub Actions `schedule` remains in the repository as a low-frequency fallback.
 
@@ -16,7 +17,7 @@ GitHub Actions release pipeline unchanged.
 
 Create a fine-grained personal access token:
 
-- Repository access: `Wangnov/codex-app-mirror` only
+- Repository access: `Wangnov/codex-app-mirror` and `Wangnov/agents-cli-mirror`
 - Repository permissions: `Actions` -> `Read and write`
 - Expiration: 90 or 180 days recommended
 

--- a/cloudflare/github-dispatcher/package.json
+++ b/cloudflare/github-dispatcher/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "wrangler dev --test-scheduled",
     "deploy": "wrangler deploy",
-    "check": "wrangler check"
+    "check": "node --check src/index.js && wrangler deploy --dry-run"
   },
   "devDependencies": {
     "wrangler": "^4.0.0"

--- a/cloudflare/github-dispatcher/src/index.js
+++ b/cloudflare/github-dispatcher/src/index.js
@@ -21,17 +21,28 @@ async function dispatchWorkflow(controller, env) {
   const forceRelease = env.GITHUB_FORCE_RELEASE || "false";
 
   const targets = [
-    { owner, repo, workflow, ref },
+    {
+      owner,
+      repo,
+      workflow,
+      ref,
+      inputs: {
+        force_release: forceRelease,
+      },
+      required: true,
+    },
     {
       owner: "Wangnov",
       repo: "agents-cli-mirror",
       workflow: "mirror.yml",
       ref: "main",
+      inputs: {},
+      required: true,
     },
   ];
 
   const settled = await Promise.allSettled(
-    targets.map((target) => dispatchWorkflowTarget(controller, env, target, forceRelease)),
+    targets.map((target) => dispatchWorkflowTarget(controller, env, target)),
   );
 
   const results = settled.map((entry, index) => {
@@ -44,7 +55,6 @@ async function dispatchWorkflow(controller, env) {
         event: "github_workflow_dispatch",
         cron: controller.cron,
         ...targets[index],
-        force_release: forceRelease,
         ok: false,
         error: entry.reason.message,
         at: new Date().toISOString(),
@@ -54,19 +64,21 @@ async function dispatchWorkflow(controller, env) {
 
   const succeeded = results.filter((result) => result.ok).length;
   const failed = results.length - succeeded;
+  const failedRequired = results.filter((result) => result.required && !result.ok).length;
   const result = {
     event: "github_workflow_dispatch_batch",
     cron: controller.cron,
-    ok: succeeded > 0,
+    ok: failedRequired === 0,
     succeeded,
     failed,
+    failed_required: failedRequired,
     targets: results,
     at: new Date().toISOString(),
   };
 
   if (!result.ok) {
     console.error(JSON.stringify(result));
-    throw new Error("All GitHub workflow dispatches failed.");
+    throw new Error("One or more required GitHub workflow dispatches failed.");
   }
 
   if (failed > 0) {
@@ -76,8 +88,8 @@ async function dispatchWorkflow(controller, env) {
   return result;
 }
 
-async function dispatchWorkflowTarget(controller, env, target, forceRelease) {
-  const { owner, repo, workflow, ref } = target;
+async function dispatchWorkflowTarget(controller, env, target) {
+  const { owner, repo, workflow, ref, inputs = {}, required = true } = target;
   const url = new URL(
     `https://api.github.com/repos/${encodeURIComponent(owner)}/${encodeURIComponent(repo)}/actions/workflows/${encodeURIComponent(workflow)}/dispatches`,
   );
@@ -93,9 +105,7 @@ async function dispatchWorkflowTarget(controller, env, target, forceRelease) {
     },
     body: JSON.stringify({
       ref,
-      inputs: {
-        force_release: forceRelease,
-      },
+      inputs,
     }),
   });
 
@@ -106,7 +116,8 @@ async function dispatchWorkflowTarget(controller, env, target, forceRelease) {
     repo,
     workflow,
     ref,
-    force_release: forceRelease,
+    inputs,
+    required,
     status: response.status,
     ok: response.ok,
     at: new Date().toISOString(),


### PR DESCRIPTION
## Summary
- route only known latest aliases and Sparkle archive paths before signing secondary S3 URLs
- fall back to the global mirror if secondary S3 presigning fails, and keep Intel DMG downloads named Codex-mac-x64.dmg
- dispatch codex-app-mirror and agents-cli-mirror with per-target workflow inputs, failing the cron batch when a required target fails
- make npm run check perform a real Worker dry-run

## Validation
- node --check cloudflare/download-router/src/index.js cloudflare/github-dispatcher/src/index.js
- npm run check (cloudflare/github-dispatcher)
- cloudflare/github-dispatcher/node_modules/.bin/wrangler deploy --dry-run --config cloudflare/download-router/wrangler.jsonc
- git diff --check