### PR TITLE
fix(release): harden mirror republish flow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,6 +51,10 @@ jobs:
         shell: bash
         run: scripts/test-prepare-release-metadata.sh
 
+      - name: Test release probe fixture
+        shell: bash
+        run: scripts/test-probe-release.sh
+
       - name: Test appcast generation fixture
         shell: bash
         run: scripts/test-build-appcast.sh

--- a/.github/workflows/mirror.yml
+++ b/.github/workflows/mirror.yml
@@ -124,6 +124,8 @@ jobs:
 
       - name: Prepare release metadata
         id: meta
+        env:
+          RELEASE_TAG: ${{ needs.probe.outputs.release_tag }}
         shell: bash
         run: |
           set -euo pipefail
@@ -136,7 +138,7 @@ jobs:
             artifacts/codex-macos/macos-metadata.json \
             artifacts \
             "$R2_PUBLIC_BASE_URL" \
-            "${{ needs.probe.outputs.release_tag }}"
+            "$RELEASE_TAG"
 
       - name: Build macOS Sparkle appcasts
         shell: bash
@@ -149,6 +151,8 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           GH_REPO: ${{ github.repository }}
+          RELEASE_TAG: ${{ steps.meta.outputs.tag }}
+          RELEASE_TITLE: ${{ steps.meta.outputs.title }}
         shell: bash
         run: |
           set -euo pipefail
@@ -162,27 +166,106 @@ jobs:
           test -f "$mac_arm64_zip"
           test -f "$mac_intel_zip"
 
-          gh release create "${{ steps.meta.outputs.tag }}" \
-            --title "${{ steps.meta.outputs.title }}" \
-            --notes-file release-notes.md \
-            artifacts/codex-macos/Codex-mac-arm64.dmg \
-            artifacts/codex-macos/Codex-mac-x64.dmg \
-            "$mac_arm64_zip" \
-            "$mac_intel_zip" \
-            artifacts/codex-macos/SHA256SUMS-macos.txt \
-            artifacts/codex-windows/* \
-            assets/status.png \
-            release-manifest.json \
+          mapfile -d '' windows_assets < <(find artifacts/codex-windows -maxdepth 1 -type f -print0 | sort -z)
+          if [[ "${#windows_assets[@]}" -eq 0 ]]; then
+            echo "No Windows release assets found." >&2
+            exit 1
+          fi
+
+          release_assets=(
+            artifacts/codex-macos/Codex-mac-arm64.dmg
+            artifacts/codex-macos/Codex-mac-x64.dmg
+            "$mac_arm64_zip"
+            "$mac_intel_zip"
+            artifacts/codex-macos/SHA256SUMS-macos.txt
+            "${windows_assets[@]}"
+            assets/status.png
+            release-manifest.json
             SHA256SUMS.txt
+          )
+
+          while IFS= read -r bn; do
+            [[ -z "$bn" ]] && continue
+            release_assets+=("artifacts/codex-macos/$bn")
+          done < <(
+            jq -r '
+              .sources.macos.arm64.appcast.deltas[]?.basename // empty,
+              .sources.macos.x64.appcast.deltas[]?.basename // empty
+            ' release-manifest.json
+          )
+
+          for asset in "${release_assets[@]}"; do
+            test -f "$asset"
+          done
+
+          if existing_assets_json="$(gh release view "$RELEASE_TAG" --json assets --jq '.assets' 2>/dev/null)"; then
+            missing_assets=()
+            replacement_assets=()
+            mismatched_assets=()
+            for asset in "${release_assets[@]}"; do
+              name="$(basename "$asset")"
+              local_size="$(wc -c < "$asset" | tr -d '[:space:]')"
+              local_sha="$(sha256sum "$asset" | awk '{print $1}')"
+              existing_size="$(jq -r --arg name "$name" '.[] | select(.name == $name) | .size' <<<"$existing_assets_json" | head -n 1)"
+              existing_digest="$(jq -r --arg name "$name" '.[] | select(.name == $name) | .digest // ""' <<<"$existing_assets_json" | head -n 1)"
+              existing_sha="${existing_digest#sha256:}"
+              if [[ -z "$existing_size" || "$existing_size" == "null" ]]; then
+                missing_assets+=("$asset")
+              elif [[ "$existing_sha" == "$existing_digest" || -z "$existing_sha" ]]; then
+                mismatched_assets+=("$name (release asset has no sha256 digest)")
+              elif [[ "$existing_sha" != "$local_sha" ]]; then
+                case "$name" in
+                  release-manifest.json|SHA256SUMS.txt|SHA256SUMS-macos.txt|SHA256SUMS-windows.txt|status.png)
+                    replacement_assets+=("$asset")
+                    ;;
+                  *)
+                    mismatched_assets+=("$name (release=$existing_size/$existing_sha local=$local_size/$local_sha)")
+                    ;;
+                esac
+              fi
+            done
+
+            if [[ "${#mismatched_assets[@]}" -gt 0 ]]; then
+              echo "Existing release assets differ from the newly built assets; refusing to overwrite them without operator review." >&2
+              printf '  %s\n' "${mismatched_assets[@]}" >&2
+              exit 1
+            fi
+
+            gh release edit "$RELEASE_TAG" \
+              --title "$RELEASE_TITLE" \
+              --latest \
+              --notes-file release-notes.md
+            if [[ "${#missing_assets[@]}" -gt 0 ]]; then
+              gh release upload "$RELEASE_TAG" "${missing_assets[@]}"
+            fi
+            if [[ "${#replacement_assets[@]}" -gt 0 ]]; then
+              for asset in "${replacement_assets[@]}"; do
+                gh release delete-asset "$RELEASE_TAG" "$(basename "$asset")" --yes
+                gh release upload "$RELEASE_TAG" "$asset"
+              done
+            fi
+            if [[ "${#missing_assets[@]}" -eq 0 && "${#replacement_assets[@]}" -eq 0 ]]; then
+              echo "All release assets already exist with matching SHA-256 digests."
+            else
+              echo "Release assets were reconciled without bulk clobbering existing downloads."
+            fi
+          else
+            gh release create "$RELEASE_TAG" \
+              --title "$RELEASE_TITLE" \
+              --latest \
+              --notes-file release-notes.md \
+              "${release_assets[@]}"
+          fi
 
       - name: Remove latest links from previous release notes
-        if: needs.probe.outputs.latest_tag != ''
+        if: needs.probe.outputs.latest_tag != '' && needs.probe.outputs.latest_tag != steps.meta.outputs.tag
         continue-on-error: true
         env:
           GH_TOKEN: ${{ github.token }}
           GH_REPO: ${{ github.repository }}
+          LATEST_TAG: ${{ needs.probe.outputs.latest_tag }}
         shell: bash
-        run: bash scripts/remove-latest-links-from-release-notes.sh "${{ needs.probe.outputs.latest_tag }}"
+        run: bash scripts/remove-latest-links-from-release-notes.sh "$LATEST_TAG"
 
       - name: Ensure AWS CLI
         shell: bash
@@ -199,6 +282,7 @@ jobs:
           AWS_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
           AWS_DEFAULT_REGION: auto
           R2_S3_ENDPOINT: https://${{ secrets.CLOUDFLARE_ACCOUNT_ID }}.r2.cloudflarestorage.com
+          RELEASE_TAG: ${{ steps.meta.outputs.tag }}
         shell: bash
         run: |
           set -euo pipefail
@@ -239,7 +323,7 @@ jobs:
             test -f "artifacts/codex-macos/$bn"
           done < <(cat /tmp/arm-delta-basenames.txt /tmp/x64-delta-basenames.txt)
 
-          staging_prefix="staging/${{ steps.meta.outputs.tag }}-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+          staging_prefix="staging/${RELEASE_TAG}-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
           cleanup_staging() {
             bash scripts/clear-r2-prefix.sh "$R2_BUCKET_NAME" "$staging_prefix" || true
           }
@@ -499,7 +583,10 @@ jobs:
     if: needs.probe.outputs.should_release != 'true'
     steps:
       - name: Report current state
+        env:
+          SKIP_REASON: ${{ needs.probe.outputs.skip_reason }}
+          VERSION_SUMMARY: ${{ needs.probe.outputs.version_summary }}
         run: |
           echo "No new Codex app version detected."
-          echo "${{ needs.probe.outputs.skip_reason }}"
-          echo "${{ needs.probe.outputs.version_summary }}"
+          echo "$SKIP_REASON"
+          echo "$VERSION_SUMMARY"

--- a/scripts/prepare-release-metadata.sh
+++ b/scripts/prepare-release-metadata.sh
@@ -22,6 +22,23 @@ sanitize_tag_part() {
   tr -cs 'A-Za-z0-9._-' '-' <<<"$1" | sed -E 's/^-+//; s/-+$//'
 }
 
+validate_release_tag() {
+  local tag="$1"
+
+  if [[ ! "$tag" =~ ^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$ ]]; then
+    echo "Invalid release tag '$tag'. Use 1-128 ASCII letters, numbers, dots, underscores, or hyphens; the first character must be alphanumeric." >&2
+    exit 1
+  fi
+}
+
+github_output_value() {
+  local name="$1"
+  local value="$2"
+  local delimiter="__codex_output_${name}_$$_$(date +%s%N)__"
+
+  printf '%s<<%s\n%s\n%s\n' "$name" "$delimiter" "$value" "$delimiter"
+}
+
 require find
 require jq
 require sha256sum
@@ -95,6 +112,8 @@ else
   fi
   tag="codex-app-win-${windows_tag}-${mac_tag}"
 fi
+
+validate_release_tag "$tag"
 
 windows_major_minor="$(major_minor "$windows_version")"
 mac_major_minor="$(major_minor "${mac_common_version:-$mac_arm_version}")"
@@ -246,8 +265,8 @@ mac_x64_etag="$(jq -r '.sources.macos.x64.etag // empty' release-manifest.json)"
 
 if [[ -n "${GITHUB_OUTPUT:-}" ]]; then
   {
-    echo "tag=$tag"
-    echo "title=$title"
+    github_output_value "tag" "$tag"
+    github_output_value "title" "$title"
   } >> "$GITHUB_OUTPUT"
 fi
 

--- a/scripts/probe-release.sh
+++ b/scripts/probe-release.sh
@@ -6,6 +6,7 @@ architecture="x64"
 arm_appcast_url="https://persistent.oaistatic.com/codex-app-prod/appcast.xml"
 x64_appcast_url="https://persistent.oaistatic.com/codex-app-prod/appcast-x64.xml"
 windows_update_manifest_url="https://persistent.oaistatic.com/codex-app-prod/windows-store-update.json"
+r2_public_base_url="${R2_PUBLIC_BASE_URL:-https://codexapp.agentsmirror.com}"
 force_release="${FORCE_RELEASE:-false}"
 release_tag_input="${RELEASE_TAG:-}"
 manifest_path="${MANIFEST_PATH:-release-manifest.json}"
@@ -45,6 +46,27 @@ curl_head() {
   curl -fsSI -L "${curl_retry_args[@]}" "$url"
 }
 
+curl_range_headers() {
+  local label="$1"
+  local url="$2"
+  local headers_file
+
+  headers_file="$(mktemp)"
+  echo "Fetching $label range headers: $(redact_url "$url")" >&2
+  if curl -fsSL -L "${curl_retry_args[@]}" \
+    --range 0-0 \
+    -D "$headers_file" \
+    -o /dev/null \
+    "$url"; then
+    cat "$headers_file"
+    rm -f "$headers_file"
+    return 0
+  fi
+
+  rm -f "$headers_file"
+  return 1
+}
+
 header_value() {
   local headers="$1"
   local name="$2"
@@ -71,6 +93,26 @@ json_number() {
   else
     printf '0'
   fi
+}
+
+object_size_from_range_headers() {
+  local headers="$1"
+  local content_range
+  local content_length
+
+  content_range="$(header_value "$headers" "content-range")"
+  if [[ "$content_range" =~ /([0-9]+)$ ]]; then
+    printf '%s' "${BASH_REMATCH[1]}"
+    return 0
+  fi
+
+  content_length="$(header_value "$headers" "content-length")"
+  if [[ "$content_length" =~ ^[0-9]+$ ]]; then
+    printf '%s' "$content_length"
+    return 0
+  fi
+
+  return 1
 }
 
 version_gt() {
@@ -268,6 +310,15 @@ sanitize_tag_part() {
   tr -cs 'A-Za-z0-9._-' '-' <<<"$1" | sed -E 's/^-+//; s/-+$//'
 }
 
+validate_release_tag() {
+  local tag="$1"
+
+  if [[ ! "$tag" =~ ^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$ ]]; then
+    echo "Invalid release tag '$tag'. Use 1-128 ASCII letters, numbers, dots, underscores, or hyphens; the first character must be alphanumeric." >&2
+    exit 1
+  fi
+}
+
 predicted_release_tag() {
   local windows_version="$1"
   local arm_version="$2"
@@ -309,15 +360,13 @@ manifest_key() {
     },
     macos: {
       arm64: {
-        appcastVersion: .sources.macos.arm64.appcast.shortVersionString,
-        appcastBuild: .sources.macos.arm64.appcast.version,
+        appcast: .sources.macos.arm64.appcast,
         contentLength: .sources.macos.arm64.contentLength,
         etag: .sources.macos.arm64.etag,
         lastModified: .sources.macos.arm64.lastModified
       },
       x64: {
-        appcastVersion: .sources.macos.x64.appcast.shortVersionString,
-        appcastBuild: .sources.macos.x64.appcast.version,
+        appcast: .sources.macos.x64.appcast,
         contentLength: .sources.macos.x64.contentLength,
         etag: .sources.macos.x64.etag,
         lastModified: .sources.macos.x64.lastModified
@@ -325,6 +374,193 @@ manifest_key() {
     }
   }' "$1"
 }
+
+public_mirror_manifest_key_matches() {
+  local manifest="$1"
+  local live_manifest
+  local current_key
+  local live_key
+
+  live_manifest="$(mktemp)"
+  if ! curl_get "public mirror manifest" "$r2_public_base_url/latest/manifest?probe=$$" > "$live_manifest"; then
+    rm -f "$live_manifest"
+    return 1
+  fi
+
+  if ! current_key="$(manifest_key "$manifest")" || ! live_key="$(manifest_key "$live_manifest")"; then
+    rm -f "$live_manifest"
+    return 1
+  fi
+
+  rm -f "$live_manifest"
+  [[ "$current_key" == "$live_key" ]]
+}
+
+public_mirror_appcasts_match() {
+  local manifest="$1"
+  local dir
+
+  dir="$(mktemp -d)"
+  if ! bash scripts/build-appcast.sh arm64 "$manifest" "$r2_public_base_url" "$dir/appcast.xml" >/dev/null; then
+    rm -rf "$dir"
+    return 1
+  fi
+  if ! bash scripts/build-appcast.sh x64 "$manifest" "$r2_public_base_url" "$dir/appcast-x64.xml" >/dev/null; then
+    rm -rf "$dir"
+    return 1
+  fi
+
+  if ! curl_get "public mirror arm64 appcast" "$r2_public_base_url/latest/appcast.xml?probe=$$" > "$dir/live-appcast.xml"; then
+    rm -rf "$dir"
+    return 1
+  fi
+  if ! curl_get "public mirror x64 appcast" "$r2_public_base_url/latest/appcast-x64.xml?probe=$$" > "$dir/live-appcast-x64.xml"; then
+    rm -rf "$dir"
+    return 1
+  fi
+
+  if cmp -s "$dir/appcast.xml" "$dir/live-appcast.xml" &&
+     cmp -s "$dir/appcast-x64.xml" "$dir/live-appcast-x64.xml"; then
+    rm -rf "$dir"
+    return 0
+  fi
+
+  rm -rf "$dir"
+  return 1
+}
+
+public_mirror_object_exists() {
+  local label="$1"
+  local object_path="$2"
+
+  curl_range_headers "$label" "$r2_public_base_url/$object_path?probe=$$" >/dev/null
+}
+
+public_mirror_object_size_matches() {
+  local label="$1"
+  local object_path="$2"
+  local expected_size="$3"
+  local headers
+  local actual_size
+
+  if [[ ! "$expected_size" =~ ^[1-9][0-9]*$ ]]; then
+    public_mirror_object_exists "$label" "$object_path"
+    return
+  fi
+
+  if ! headers="$(curl_range_headers "$label" "$r2_public_base_url/$object_path?probe=$$")"; then
+    return 1
+  fi
+  if ! actual_size="$(object_size_from_range_headers "$headers")"; then
+    return 1
+  fi
+
+  [[ "$actual_size" == "$expected_size" ]]
+}
+
+public_mirror_checksums_match() {
+  local tag="$1"
+  local dir
+
+  [[ -n "$tag" ]] || return 1
+
+  dir="$(mktemp -d)"
+  if ! download_release_asset "$tag" SHA256SUMS.txt "$dir" >/dev/null 2>&1; then
+    rm -rf "$dir"
+    return 1
+  fi
+
+  if ! curl_get "public mirror checksums" "$r2_public_base_url/latest/checksums?probe=$$" > "$dir/live-SHA256SUMS.txt"; then
+    rm -rf "$dir"
+    return 1
+  fi
+
+  if cmp -s "$dir/SHA256SUMS.txt" "$dir/live-SHA256SUMS.txt"; then
+    rm -rf "$dir"
+    return 0
+  fi
+
+  rm -rf "$dir"
+  return 1
+}
+
+public_mirror_delta_objects_match() {
+  local manifest="$1"
+  local arch_key="$2"
+  local mirror_dir="$3"
+  local basename
+  local expected_size
+
+  while IFS=$'\t' read -r basename expected_size; do
+    [[ -n "$basename" ]] || return 1
+    public_mirror_object_size_matches \
+      "public mirror macOS $arch_key delta $basename" \
+      "latest/mac/$mirror_dir/$basename" \
+      "$expected_size" || return 1
+  done < <(
+    jq -r --arg a "$arch_key" '
+      .sources.macos[$a].appcast.deltas[]?
+      | [(.basename // ((.url // "") | split("/")[-1]) // ""), (.length // 0)]
+      | @tsv
+    ' "$manifest"
+  )
+}
+
+public_mirror_objects_match() {
+  local manifest="$1"
+  local arm_short_version
+  local x64_short_version
+
+  arm_short_version="$(jq -r '.sources.macos.arm64.appcast.shortVersionString // ""' "$manifest")"
+  x64_short_version="$(jq -r '.sources.macos.x64.appcast.shortVersionString // ""' "$manifest")"
+
+  [[ -n "$arm_short_version" && -n "$x64_short_version" ]] || return 1
+
+  public_mirror_object_size_matches \
+    "public mirror Windows alias" \
+    "latest/win" \
+    "$(jq -r '.sources.windows.contentLength // 0' "$manifest")" &&
+  public_mirror_object_size_matches \
+    "public mirror macOS arm64 DMG alias" \
+    "latest/mac-arm64" \
+    "$(jq -r '.sources.macos.arm64.contentLength // 0' "$manifest")" &&
+  public_mirror_object_size_matches \
+    "public mirror macOS x64 DMG alias" \
+    "latest/mac-intel" \
+    "$(jq -r '.sources.macos.x64.contentLength // 0' "$manifest")" &&
+  public_mirror_object_size_matches \
+    "public mirror macOS arm64 Sparkle archive" \
+    "latest/mac/arm64/Codex-darwin-arm64-${arm_short_version}.zip" \
+    "$(jq -r '.sources.macos.arm64.appcast.enclosureLength // 0' "$manifest")" &&
+  public_mirror_object_size_matches \
+    "public mirror macOS x64 Sparkle archive" \
+    "latest/mac/intel/Codex-darwin-x64-${x64_short_version}.zip" \
+    "$(jq -r '.sources.macos.x64.appcast.enclosureLength // 0' "$manifest")" &&
+  public_mirror_delta_objects_match "$manifest" arm64 arm64 &&
+  public_mirror_delta_objects_match "$manifest" x64 intel
+}
+
+public_mirror_latest_matches() {
+  local manifest="$1"
+  local tag="$2"
+
+  public_mirror_manifest_key_matches "$manifest" &&
+    public_mirror_appcasts_match "$manifest" &&
+    public_mirror_checksums_match "$tag" &&
+    public_mirror_objects_match "$manifest"
+}
+
+github_output_value() {
+  local name="$1"
+  local value="$2"
+  local delimiter="__codex_output_${name}_$$_$(date +%s%N)__"
+
+  printf '%s<<%s\n%s\n%s\n' "$name" "$delimiter" "$value" "$delimiter"
+}
+
+if [[ -n "$release_tag_input" ]]; then
+  validate_release_tag "$release_tag_input"
+fi
 
 require curl
 require dotnet
@@ -468,6 +704,7 @@ jq -n \
 should_release="true"
 skip_reason=""
 latest_tag=""
+release_tag_fallback=""
 tmp_dir="$(mktemp -d)"
 trap 'rm -rf "$tmp_dir"' EXIT
 
@@ -488,12 +725,17 @@ else
       current_key="$(manifest_key "$manifest_path")"
       previous_key="$(manifest_key "$tmp_dir/release-manifest.json")"
       if [[ "$current_key" == "$previous_key" ]]; then
-        should_release="false"
-        update_notice="$(windows_update_wait_notice "$manifest_path")"
-        if [[ -n "$update_notice" ]]; then
-          skip_reason="$update_notice Latest mirrored package still matches $latest_tag."
+        if public_mirror_latest_matches "$manifest_path" "$latest_tag"; then
+          should_release="false"
+          update_notice="$(windows_update_wait_notice "$manifest_path")"
+          if [[ -n "$update_notice" ]]; then
+            skip_reason="$update_notice Latest mirrored package still matches $latest_tag."
+          else
+            skip_reason="manifest matches latest release $latest_tag"
+          fi
         else
-          skip_reason="manifest matches latest release $latest_tag"
+          release_tag_fallback="$latest_tag"
+          skip_reason="latest release $latest_tag matches current sources, but public mirror aliases or appcasts are stale; republishing"
         fi
       fi
     else
@@ -504,22 +746,32 @@ else
       if [[ "$windows_asset_size" == "$windows_content_length" &&
             "$arm_asset_size" == "$arm_content_length" &&
             "$x64_asset_size" == "$x64_content_length" ]]; then
-        should_release="false"
-        skip_reason="asset names and sizes match latest release $latest_tag"
+        if public_mirror_latest_matches "$manifest_path" "$latest_tag"; then
+          should_release="false"
+          skip_reason="asset names and sizes match latest release $latest_tag"
+        else
+          release_tag_fallback="$latest_tag"
+          skip_reason="latest release $latest_tag asset sizes match current sources, but public mirror aliases or appcasts are stale; republishing"
+        fi
       fi
     fi
   fi
 fi
 
-if [[ "$should_release" == "true" && "$force_release" != "true" && -z "$release_tag_input" ]]; then
+if [[ "$should_release" == "true" && "$force_release" != "true" && -z "$release_tag_input" && -z "$release_tag_fallback" ]]; then
   predicted_tag="$(predicted_release_tag "$windows_version" "$arm_appcast_version" "$arm_appcast_build" "$x64_appcast_version" "$x64_appcast_build")"
   if release_exists "$predicted_tag"; then
-    should_release="false"
-    update_notice="$(windows_update_wait_notice "$manifest_path")"
-    if [[ -n "$update_notice" ]]; then
-      skip_reason="$update_notice Release tag $predicted_tag already exists."
+    if public_mirror_latest_matches "$manifest_path" "$predicted_tag"; then
+      should_release="false"
+      update_notice="$(windows_update_wait_notice "$manifest_path")"
+      if [[ -n "$update_notice" ]]; then
+        skip_reason="$update_notice Release tag $predicted_tag already exists."
+      else
+        skip_reason="release tag $predicted_tag already exists"
+      fi
     else
-      skip_reason="release tag $predicted_tag already exists"
+      release_tag_fallback="$predicted_tag"
+      skip_reason="release tag $predicted_tag already exists, but public mirror aliases or appcasts are stale; republishing"
     fi
   fi
 fi
@@ -528,22 +780,26 @@ if [[ -n "$release_tag_input" ]]; then
   release_tag="$release_tag_input"
 elif [[ "$force_release" == "true" ]]; then
   release_tag="codex-app-force-$(date -u +'%Y%m%d-%H%M%S')"
+elif [[ -n "$release_tag_fallback" ]]; then
+  release_tag="$release_tag_fallback"
 else
   release_tag=""
+fi
+
+if [[ -n "$release_tag" ]]; then
+  validate_release_tag "$release_tag"
 fi
 
 version_summary="windows=$windows_version ($windows_package; updateManifest=$windows_update_version); mac-arm64=$arm_appcast_version-b$arm_appcast_build/$arm_etag/$arm_content_length; mac-x64=$x64_appcast_version-b$x64_appcast_build/$x64_etag/$x64_content_length"
 
 if [[ -n "${GITHUB_OUTPUT:-}" ]]; then
   {
-    echo "should_release=$should_release"
-    echo "release_tag=$release_tag"
-    echo "latest_tag=$latest_tag"
-    echo "skip_reason=$skip_reason"
-    echo "version_summary=$version_summary"
-    echo "manifest<<EOF"
-    cat "$manifest_path"
-    echo "EOF"
+    github_output_value "should_release" "$should_release"
+    github_output_value "release_tag" "$release_tag"
+    github_output_value "latest_tag" "$latest_tag"
+    github_output_value "skip_reason" "$skip_reason"
+    github_output_value "version_summary" "$version_summary"
+    github_output_value "manifest" "$(cat "$manifest_path")"
   } >> "$GITHUB_OUTPUT"
 fi
 

--- a/scripts/test-prepare-release-metadata.sh
+++ b/scripts/test-prepare-release-metadata.sh
@@ -83,4 +83,15 @@ JSON
     echo "SHA256SUMS.txt should use basenames, not CI artifact paths." >&2
     exit 1
   fi
+
+  if "$repo_root/scripts/prepare-release-metadata.sh" \
+    probe-manifest.json \
+    macos-metadata.json \
+    artifacts \
+    https://example.com \
+    $'bad-tag\nrelease_tag=evil' > "$tmp_dir/invalid-tag-output.txt" 2>&1; then
+    echo "prepare-release-metadata.sh should reject multiline release tags." >&2
+    exit 1
+  fi
+  grep -F 'Invalid release tag' "$tmp_dir/invalid-tag-output.txt"
 )

--- a/scripts/test-probe-release.sh
+++ b/scripts/test-probe-release.sh
@@ -1,0 +1,341 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Fixture test for probe-release.sh: when the latest release already matches the
+# current upstream sources but the public mirror checksum alias is stale,
+# probe-release.sh must republish that exact latest tag. A version-derived tag
+# may also exist, but it must not override the latest-tag fallback selected for
+# mirror repair.
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+tmp_dir="$(mktemp -d)"
+cleanup() {
+  rm -rf "$tmp_dir"
+}
+trap cleanup EXIT
+
+mkdir -p "$tmp_dir/bin"
+
+latest_tag="codex-app-force-20260611-010101"
+predicted_tag="codex-app-win-1.2.3.4-mac-1.2.3-b5"
+package="OpenAI.Codex_1.2.3.4_x64__2p2nqsd0c76g0"
+gh_log="$tmp_dir/gh.log"
+: > "$gh_log"
+
+cat > "$tmp_dir/latest-release-manifest.json" <<JSON
+{
+  "schemaVersion": 1,
+  "sources": {
+    "windows": {
+      "version": "1.2.3.4",
+      "packageMoniker": "$package",
+      "contentLength": 3
+    },
+    "macos": {
+      "arm64": {
+        "appcast": {
+          "title": "1.2.3",
+          "pubDate": "Thu, 11 Jun 2026 00:00:00 +0000",
+          "version": "5",
+          "shortVersionString": "1.2.3",
+          "minimumSystemVersion": "12.0",
+          "hardwareRequirements": "arm64",
+          "enclosureUrl": "https://persistent.oaistatic.com/codex-app-prod/Codex-darwin-arm64-1.2.3.zip",
+          "enclosureLength": 3,
+          "enclosureSignature": "arm-signature",
+          "deltas": []
+        },
+        "contentLength": 3,
+        "lastModified": "Thu, 11 Jun 2026 00:00:00 GMT",
+        "etag": "arm-etag"
+      },
+      "x64": {
+        "appcast": {
+          "title": "1.2.3",
+          "pubDate": "Thu, 11 Jun 2026 00:00:00 +0000",
+          "version": "5",
+          "shortVersionString": "1.2.3",
+          "minimumSystemVersion": "12.0",
+          "hardwareRequirements": "",
+          "enclosureUrl": "https://persistent.oaistatic.com/codex-app-prod/Codex-darwin-x64-1.2.3.zip",
+          "enclosureLength": 3,
+          "enclosureSignature": "x64-signature",
+          "deltas": []
+        },
+        "contentLength": 3,
+        "lastModified": "Thu, 11 Jun 2026 00:00:00 GMT",
+        "etag": "x64-etag"
+      }
+    }
+  }
+}
+JSON
+
+cat > "$tmp_dir/public-manifest.json" <<JSON
+{
+  "schemaVersion": 1,
+  "sources": {
+    "windows": {
+      "version": "1.2.3.4",
+      "packageMoniker": "$package",
+      "contentLength": 3
+    },
+    "macos": {
+      "arm64": {
+        "appcast": {
+          "title": "1.2.3",
+          "pubDate": "Thu, 11 Jun 2026 00:00:00 +0000",
+          "version": "5",
+          "shortVersionString": "1.2.3",
+          "minimumSystemVersion": "12.0",
+          "hardwareRequirements": "arm64",
+          "enclosureUrl": "https://persistent.oaistatic.com/codex-app-prod/Codex-darwin-arm64-1.2.3.zip",
+          "enclosureLength": 3,
+          "enclosureSignature": "arm-signature",
+          "deltas": []
+        },
+        "contentLength": 3,
+        "lastModified": "Thu, 11 Jun 2026 00:00:00 GMT",
+        "etag": "arm-etag"
+      },
+      "x64": {
+        "appcast": {
+          "title": "1.2.3",
+          "pubDate": "Thu, 11 Jun 2026 00:00:00 +0000",
+          "version": "5",
+          "shortVersionString": "1.2.3",
+          "minimumSystemVersion": "12.0",
+          "hardwareRequirements": "",
+          "enclosureUrl": "https://persistent.oaistatic.com/codex-app-prod/Codex-darwin-x64-1.2.3.zip",
+          "enclosureLength": 3,
+          "enclosureSignature": "x64-signature",
+          "deltas": []
+        },
+        "contentLength": 3,
+        "lastModified": "Thu, 11 Jun 2026 00:00:00 GMT",
+        "etag": "x64-etag"
+      }
+    }
+  }
+}
+JSON
+
+cat > "$tmp_dir/latest-SHA256SUMS.txt" <<'SUMS'
+current-checksum  release-manifest.json
+SUMS
+
+bash "$repo_root/scripts/build-appcast.sh" arm64 "$tmp_dir/latest-release-manifest.json" "https://codexapp.agentsmirror.com" "$tmp_dir/public-appcast.xml" >/dev/null
+bash "$repo_root/scripts/build-appcast.sh" x64 "$tmp_dir/latest-release-manifest.json" "https://codexapp.agentsmirror.com" "$tmp_dir/public-appcast-x64.xml" >/dev/null
+
+cat > "$tmp_dir/bin/dotnet" <<'DOTNET'
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ "${1:-}" == "run" ]]; then
+  printf 'OpenAI.Codex_1.2.3.4_x64__2p2nqsd0c76g0\thttps://download.example/OpenAI.Codex_1.2.3.4_x64__2p2nqsd0c76g0.Msix\n'
+  exit 0
+fi
+
+echo "unexpected dotnet invocation: $*" >&2
+exit 1
+DOTNET
+chmod +x "$tmp_dir/bin/dotnet"
+
+cat > "$tmp_dir/bin/gh" <<'GH'
+#!/usr/bin/env bash
+set -euo pipefail
+
+printf '%s\n' "$*" >> "${TEST_GH_LOG:?TEST_GH_LOG must be set}"
+
+if [[ "${1:-}" != "api" ]]; then
+  echo "unexpected gh invocation: $*" >&2
+  exit 1
+fi
+
+shift
+url="${*: -1}"
+
+case "$url" in
+  repos/\{owner\}/\{repo\}/releases/latest)
+    printf '{"tag_name":"%s"}\n' "${TEST_LATEST_TAG:?TEST_LATEST_TAG must be set}"
+    ;;
+  repos/\{owner\}/\{repo\}/releases/tags/"${TEST_LATEST_TAG}")
+    printf '{"tag_name":"%s","assets":[{"name":"release-manifest.json","url":"https://api.example/assets/release-manifest"},{"name":"SHA256SUMS.txt","url":"https://api.example/assets/checksums"}]}\n' "$TEST_LATEST_TAG"
+    ;;
+  repos/\{owner\}/\{repo\}/releases/tags/"${TEST_PREDICTED_TAG}")
+    printf '{"tag_name":"%s","assets":[]}\n' "$TEST_PREDICTED_TAG"
+    ;;
+  https://api.example/assets/release-manifest)
+    cat "${TEST_LATEST_MANIFEST:?TEST_LATEST_MANIFEST must be set}"
+    ;;
+  https://api.example/assets/checksums)
+    cat "${TEST_LATEST_CHECKSUMS:?TEST_LATEST_CHECKSUMS must be set}"
+    ;;
+  *)
+    echo "unexpected gh api URL: $url" >&2
+    exit 1
+    ;;
+esac
+GH
+chmod +x "$tmp_dir/bin/gh"
+
+cat > "$tmp_dir/bin/curl" <<'CURL'
+#!/usr/bin/env bash
+set -euo pipefail
+
+head_request=false
+headers_file=""
+url=""
+while (($#)); do
+  case "$1" in
+    -D)
+      headers_file="$2"
+      shift
+      ;;
+    -o)
+      shift
+      ;;
+    --range)
+      shift
+      ;;
+    -I|-*I*)
+      head_request=true
+      ;;
+    http://*|https://*)
+      url="$1"
+      ;;
+  esac
+  shift
+done
+
+emit_headers() {
+  local etag="$1"
+  printf 'HTTP/2 200\r\n'
+  printf 'content-range: bytes 0-0/3\r\n'
+  printf 'content-length: 3\r\n'
+  printf 'last-modified: Thu, 11 Jun 2026 00:00:00 GMT\r\n'
+  printf 'etag: %s\r\n' "$etag"
+  printf '\r\n'
+}
+
+emit_appcast() {
+  local arch="$1"
+  local sig="$2"
+  local hardware="$3"
+
+  cat <<XML
+<?xml version="1.0" encoding="utf-8"?>
+<rss xmlns:sparkle="http://www.andymatuschak.org/xml-namespaces/sparkle" version="2.0">
+  <channel>
+    <item>
+      <title>1.2.3</title>
+      <pubDate>Thu, 11 Jun 2026 00:00:00 +0000</pubDate>
+      <sparkle:version>5</sparkle:version>
+      <sparkle:shortVersionString>1.2.3</sparkle:shortVersionString>
+      <sparkle:minimumSystemVersion>12.0</sparkle:minimumSystemVersion>
+      <sparkle:hardwareRequirements>${hardware}</sparkle:hardwareRequirements>
+      <enclosure url="https://persistent.oaistatic.com/codex-app-prod/Codex-darwin-${arch}-1.2.3.zip" length="3" type="application/octet-stream" sparkle:edSignature="${sig}" />
+    </item>
+  </channel>
+</rss>
+XML
+}
+
+headers_for_url() {
+  case "$url" in
+    *OpenAI.Codex_1.2.3.4_x64__2p2nqsd0c76g0.Msix)
+      emit_headers "windows-etag"
+      ;;
+    *Codex-1.2.3-arm64.dmg)
+      emit_headers "arm-etag"
+      ;;
+    *Codex-1.2.3-x64.dmg)
+      emit_headers "x64-etag"
+      ;;
+    *codexapp.agentsmirror.com/latest/win*|\
+    *codexapp.agentsmirror.com/latest/mac-arm64*|\
+    *codexapp.agentsmirror.com/latest/mac-intel*|\
+    *codexapp.agentsmirror.com/latest/mac/arm64/Codex-darwin-arm64-1.2.3.zip*|\
+    *codexapp.agentsmirror.com/latest/mac/intel/Codex-darwin-x64-1.2.3.zip*)
+      emit_headers "public-etag"
+      ;;
+    *)
+      echo "unexpected curl headers URL: $url" >&2
+      exit 1
+      ;;
+  esac
+}
+
+if [[ -n "$headers_file" ]]; then
+  headers_for_url > "$headers_file"
+  exit 0
+fi
+
+if $head_request; then
+  headers_for_url
+  exit 0
+fi
+
+case "$url" in
+  *windows-store-update.json)
+    printf '{"buildVersion":"1.2.3.4","storeProductId":"9PLM9XGG6VKS","packageIdentity":"OpenAI.Codex_2p2nqsd0c76g0"}\n'
+    ;;
+  *codexapp.agentsmirror.com/latest/appcast.xml*)
+    cat "${TEST_PUBLIC_APPCAST:?TEST_PUBLIC_APPCAST must be set}"
+    ;;
+  *codexapp.agentsmirror.com/latest/appcast-x64.xml*)
+    cat "${TEST_PUBLIC_APPCAST_X64:?TEST_PUBLIC_APPCAST_X64 must be set}"
+    ;;
+  *codexapp.agentsmirror.com/latest/checksums*)
+    printf 'stale-checksum  release-manifest.json\n'
+    ;;
+  *appcast.xml)
+    emit_appcast arm64 arm-signature arm64
+    ;;
+  *appcast-x64.xml)
+    emit_appcast x64 x64-signature ""
+    ;;
+  *codexapp.agentsmirror.com/latest/manifest*)
+    cat "${TEST_PUBLIC_MANIFEST:?TEST_PUBLIC_MANIFEST must be set}"
+    ;;
+  *)
+    echo "unexpected curl URL: $url" >&2
+    exit 1
+    ;;
+esac
+CURL
+chmod +x "$tmp_dir/bin/curl"
+
+(
+  cd "$repo_root"
+  PATH="$tmp_dir/bin:$PATH" \
+  TEST_GH_LOG="$gh_log" \
+  TEST_LATEST_TAG="$latest_tag" \
+  TEST_PREDICTED_TAG="$predicted_tag" \
+  TEST_LATEST_MANIFEST="$tmp_dir/latest-release-manifest.json" \
+  TEST_LATEST_CHECKSUMS="$tmp_dir/latest-SHA256SUMS.txt" \
+  TEST_PUBLIC_MANIFEST="$tmp_dir/public-manifest.json" \
+  TEST_PUBLIC_APPCAST="$tmp_dir/public-appcast.xml" \
+  TEST_PUBLIC_APPCAST_X64="$tmp_dir/public-appcast-x64.xml" \
+  STORE_LINK_MAX_ATTEMPTS=1 \
+  MANIFEST_PATH="$tmp_dir/probe-manifest.json" \
+    scripts/probe-release.sh > "$tmp_dir/output.txt"
+)
+
+grep -F "should_release=true" "$tmp_dir/output.txt"
+grep -F "release_tag=$latest_tag" "$tmp_dir/output.txt"
+grep -F "latest_tag=$latest_tag" "$tmp_dir/output.txt"
+grep -F "latest release $latest_tag matches current sources, but public mirror aliases or appcasts are stale; republishing" "$tmp_dir/output.txt"
+
+if grep -F "release_tag=$predicted_tag" "$tmp_dir/output.txt"; then
+  echo "probe-release.sh overwrote the latest-tag fallback with the predicted tag." >&2
+  exit 1
+fi
+
+if grep -F "releases/tags/$predicted_tag" "$gh_log"; then
+  echo "probe-release.sh should not query the predicted tag after selecting a latest-tag fallback." >&2
+  cat "$gh_log" >&2
+  exit 1
+fi
+
+echo "probe-release fixture test PASS"


### PR DESCRIPTION
## Summary
- validate release tags before writing GitHub Actions outputs or passing them to release tooling
- include complete Sparkle appcast and delta metadata in the release fingerprint
- republish existing releases when public mirror aliases or appcasts are stale, and make GitHub Release publishing idempotent
- attach every mirrored Sparkle delta listed in SHA256SUMS.txt to the GitHub Release

## Validation
- bash -n scripts/*.sh
- scripts/test-prepare-release-metadata.sh
- scripts/test-build-appcast.sh
- scripts/test-prune-mac-source.sh
- actionlint
- MANIFEST_PATH=/tmp/codex-app-mirror-release-hardening-probe.json scripts/probe-release.sh
- dotnet build scripts/store-link/StoreLink.csproj --configuration Release