### PR TITLE
fix(windows): harden portable launcher generation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,5 +63,9 @@ jobs:
         shell: bash
         run: scripts/test-prune-mac-source.sh
 
+      - name: Test Windows portable fixture
+        shell: bash
+        run: scripts/test-prepare-windows-portable.sh
+
       - name: Build Microsoft Store resolver
         run: dotnet build scripts/store-link/StoreLink.csproj --configuration Release

--- a/scripts/prepare-windows-portable.sh
+++ b/scripts/prepare-windows-portable.sh
@@ -44,8 +44,12 @@ cp -R "$tmp_dir/app/." "$package_dir/"
 cat > "$package_dir/Run-Codex.cmd" <<'EOF'
 @echo off
 setlocal
-set "CODEX_DIR=%~dp0"
-start "" "%CODEX_DIR%Codex.exe" %*
+set "CODEX_EXE=%~dp0Codex.exe"
+if not exist "%CODEX_EXE%" (
+  echo Codex.exe was not found next to this script.
+  exit /b 1
+)
+start "" "%CODEX_EXE%" %*
 EOF
 
 cat > "$package_dir/Install-Current-User.cmd" <<'EOF'
@@ -57,13 +61,14 @@ set "SHORTCUT_DIR=%APPDATA%\Microsoft\Windows\Start Menu\Programs"
 set "SHORTCUT=%SHORTCUT_DIR%\Codex.lnk"
 
 if not exist "%TARGET_DIR%" mkdir "%TARGET_DIR%"
+if not exist "%SHORTCUT_DIR%" mkdir "%SHORTCUT_DIR%"
 robocopy "%SOURCE_DIR%" "%TARGET_DIR%" /MIR /XF "Install-Current-User.cmd" >nul
 if errorlevel 8 (
   echo Copy failed.
   exit /b 1
 )
 
-powershell -NoProfile -Command "$w=New-Object -ComObject WScript.Shell; $s=$w.CreateShortcut('%SHORTCUT%'); $s.TargetPath='%TARGET_DIR%\Codex.exe'; $s.WorkingDirectory='%TARGET_DIR%'; $s.IconLocation='%TARGET_DIR%\resources\icon.ico'; $s.Save()"
+powershell -NoProfile -Command "$w=New-Object -ComObject WScript.Shell; $s=$w.CreateShortcut($env:SHORTCUT); $s.TargetPath=(Join-Path $env:TARGET_DIR 'Codex.exe'); $s.WorkingDirectory=$env:TARGET_DIR; $s.IconLocation=(Join-Path $env:TARGET_DIR 'resources\icon.ico'); $s.Save()"
 
 echo Codex was installed for the current user:
 echo %TARGET_DIR%

--- a/scripts/test-prepare-windows-portable.sh
+++ b/scripts/test-prepare-windows-portable.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+tmp_dir="$(mktemp -d)"
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cleanup() {
+  rm -rf "$tmp_dir"
+}
+trap cleanup EXIT
+
+payload_dir="$tmp_dir/msix payload"
+mkdir -p "$payload_dir/app"
+cat > "$payload_dir/AppxManifest.xml" <<'XML'
+<?xml version="1.0" encoding="utf-8"?>
+<Package>
+  <Identity Name="OpenAI.Codex" Publisher="CN=OpenAI" Version="1.2.3.4" />
+</Package>
+XML
+printf 'fake exe' > "$payload_dir/app/Codex.exe"
+printf 'fake icon' > "$payload_dir/app/resources.ico"
+
+(
+  cd "$payload_dir"
+  zip -qr "$tmp_dir/Codex test.msix" AppxManifest.xml app
+)
+
+output_dir="$tmp_dir/output with spaces"
+outputs_path="$tmp_dir/outputs.txt"
+"$repo_root/scripts/prepare-windows-portable.sh" "$tmp_dir/Codex test.msix" "$output_dir" > "$outputs_path"
+zip_path="$(sed -n '1p' "$outputs_path")"
+checksum_path="$(sed -n '2p' "$outputs_path")"
+package_dir="$output_dir/Codex-Windows-x64-portable-1.2.3.4"
+
+test -f "$zip_path"
+test -f "$checksum_path"
+test -f "$package_dir/Run-Codex.cmd"
+test -f "$package_dir/Install-Current-User.cmd"
+test -f "$package_dir/Uninstall-Current-User.cmd"
+test -f "$package_dir/Codex.exe"
+
+grep -F 'set "CODEX_EXE=%~dp0Codex.exe"' "$package_dir/Run-Codex.cmd"
+grep -F 'start "" "%CODEX_EXE%" %*' "$package_dir/Run-Codex.cmd"
+grep -F 'if not exist "%SHORTCUT_DIR%" mkdir "%SHORTCUT_DIR%"' "$package_dir/Install-Current-User.cmd"
+grep -F '$s=$w.CreateShortcut($env:SHORTCUT)' "$package_dir/Install-Current-User.cmd"
+grep -F '$s.TargetPath=(Join-Path $env:TARGET_DIR '"'"'Codex.exe'"'"')' "$package_dir/Install-Current-User.cmd"
+
+unzip -l "$zip_path" | grep -F 'Codex-Windows-x64-portable-1.2.3.4/Run-Codex.cmd'
+grep -F 'Codex-Windows-x64-portable-1.2.3.4.zip' "$checksum_path"
+
+echo "prepare-windows-portable fixture test PASS"


### PR DESCRIPTION
## Summary
- make the generated Run-Codex.cmd fail clearly when Codex.exe is missing
- avoid embedding user profile paths directly into the generated PowerShell shortcut command
- create the Start Menu directory before writing the shortcut
- add a fixture that builds a fake MSIX into an output path with spaces and checks generated CMD content

## Validation
- scripts/test-prepare-windows-portable.sh
- bash -n scripts/*.sh
- actionlint
- git diff --check