### PR TITLE
fix: stop the Windows Store rollout wait-gate from blocking macOS releases

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,6 +55,10 @@ jobs:
         shell: bash
         run: scripts/test-probe-release.sh
 
+      - name: Test release probe Windows-rollout fixture
+        shell: bash
+        run: scripts/test-probe-release-windows-rollout.sh
+
       - name: Test appcast generation fixture
         shell: bash
         run: scripts/test-build-appcast.sh

--- a/scripts/probe-release.sh
+++ b/scripts/probe-release.sh
@@ -703,11 +703,11 @@ else
   # veto a release: `should_release` gates the combined win+mac publish, so a
   # veto here also blocks a macOS update that is already downloadable (mac ships
   # from persistent.oaistatic.com, independent of the Microsoft Store rollout).
-  # The generated manifest always records the DOWNLOADABLE Windows version (never
-  # the advertised one — see parse_manifest consumers), so the manifest-key
-  # comparison below releases only when real downloadable bytes change (macOS
-  # now, or Windows once its MSIX lands) and no-ops otherwise. The notice is woven
-  # into the skip/release messaging purely as context.
+  # The generated manifest always records the DOWNLOADABLE Windows version in
+  # sources.windows.version (never the advertised updateManifest.buildVersion),
+  # so the manifest-key comparison below releases only when real downloadable
+  # bytes change (macOS now, or Windows once its MSIX lands) and no-ops otherwise.
+  # The notice is woven into the skip/release messaging purely as context.
   if [[ -n "$latest_tag" ]]; then
     if download_release_asset "$latest_tag" release-manifest.json "$tmp_dir" >/dev/null 2>&1; then
       current_key="$(manifest_key "$manifest_path")"

--- a/scripts/probe-release.sh
+++ b/scripts/probe-release.sh
@@ -115,30 +115,6 @@ object_size_from_range_headers() {
   return 1
 }
 
-version_gt() {
-  python3 - "$1" "$2" <<'PY'
-import sys
-
-
-def parse(version):
-    parts = []
-    for part in version.split("."):
-        try:
-            parts.append(int(part))
-        except ValueError:
-            parts.append(part)
-    return parts
-
-
-left = parse(sys.argv[1])
-right = parse(sys.argv[2])
-length = max(len(left), len(right))
-left.extend([0] * (length - len(left)))
-right.extend([0] * (length - len(right)))
-raise SystemExit(0 if left > right else 1)
-PY
-}
-
 appcast_latest() {
   local label="$1"
   local url="$2"
@@ -233,9 +209,12 @@ github_api_json_allow_404() {
     rm -f "$err_file"
     printf '%s\n' "$output"
     return 0
+  else
+    # Capture gh's real exit status here: `$?` taken after the closing `fi` would
+    # be the if-statement's status (0 when the condition is false and there is no
+    # else), masking the failure.
+    status=$?
   fi
-
-  status=$?
   if grep -q 'HTTP 404' "$err_file"; then
     rm -f "$err_file"
     return 1
@@ -253,9 +232,11 @@ latest_release_tag() {
   if release_json="$(github_api_json_allow_404 'repos/{owner}/{repo}/releases/latest')"; then
     jq -r '.tag_name // ""' <<<"$release_json"
     return 0
+  else
+    # `$?` after the closing `fi` is the if-statement's status (0 on a false
+    # condition with no else), not the helper's — capture it in the else branch.
+    status=$?
   fi
-
-  status=$?
   if [[ "$status" -eq 1 ]]; then
     printf ''
     return 0
@@ -296,9 +277,13 @@ release_exists() {
 
   if github_api_json_allow_404 "repos/{owner}/{repo}/releases/tags/$1" >/dev/null; then
     return 0
+  else
+    # `$?` after the closing `fi` is the if-statement's status (0 on a false
+    # condition with no else), not the helper's — capture it in the else branch
+    # so a 404 (status 1) is treated as "absent" instead of falling through to
+    # `exit "$status"` and silently terminating the whole probe.
+    status=$?
   fi
-
-  status=$?
   if [[ "$status" -eq 1 ]]; then
     return 1
   fi
@@ -713,14 +698,17 @@ if [[ "$force_release" == "true" ]]; then
 else
   latest_tag="$(latest_release_tag)"
   update_notice="$(windows_update_wait_notice "$manifest_path")"
-  if [[ -n "$windows_update_version" && -n "$windows_version" ]] && version_gt "$windows_update_version" "$windows_version"; then
-    should_release="false"
-    if [[ -n "$latest_tag" ]]; then
-      skip_reason="$update_notice Latest release remains $latest_tag."
-    else
-      skip_reason="$update_notice"
-    fi
-  elif [[ -n "$latest_tag" ]]; then
+  # The Windows Store update manifest can advertise a new build before its MSIX
+  # bytes are downloadable. `update_notice` captures that wait, but it must NOT
+  # veto a release: `should_release` gates the combined win+mac publish, so a
+  # veto here also blocks a macOS update that is already downloadable (mac ships
+  # from persistent.oaistatic.com, independent of the Microsoft Store rollout).
+  # The generated manifest always records the DOWNLOADABLE Windows version (never
+  # the advertised one — see parse_manifest consumers), so the manifest-key
+  # comparison below releases only when real downloadable bytes change (macOS
+  # now, or Windows once its MSIX lands) and no-ops otherwise. The notice is woven
+  # into the skip/release messaging purely as context.
+  if [[ -n "$latest_tag" ]]; then
     if download_release_asset "$latest_tag" release-manifest.json "$tmp_dir" >/dev/null 2>&1; then
       current_key="$(manifest_key "$manifest_path")"
       previous_key="$(manifest_key "$tmp_dir/release-manifest.json")"

--- a/scripts/test-probe-release-windows-rollout.sh
+++ b/scripts/test-probe-release-windows-rollout.sh
@@ -1,0 +1,252 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Regression test for the win+mac release coupling fix.
+#
+# Scenario: the Microsoft Store advertises a newer Windows build than is actually
+# downloadable yet (updateManifest.buildVersion 26.609.4994.0 vs the resolved,
+# downloadable Store package 26.608.1337.0), while macOS has already advanced to
+# 26.609.41114 on persistent.oaistatic.com. The previous behavior vetoed the
+# whole release ("waiting for downloadable MSIX"), which also blocked the
+# already-downloadable macOS update. probe-release.sh must now release (the
+# combined manifest carries the current downloadable Windows 26.608 plus macOS
+# 26.609) instead of holding mac hostage to the Windows Store rollout.
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+tmp_dir="$(mktemp -d)"
+cleanup() {
+  rm -rf "$tmp_dir"
+}
+trap cleanup EXIT
+
+mkdir -p "$tmp_dir/bin"
+
+latest_tag="codex-app-win-26.608.1337.0-mac-26.608.12217-b3722"
+# win (downloadable 26.608) + mac (advanced 26.609) -> a brand-new combination
+# whose predicted tag does not exist yet, so release_exists must 404.
+predicted_tag="codex-app-win-26.608.1337.0-mac-26.609.41114-b3888"
+package="OpenAI.Codex_26.608.1337.0_x64__2p2nqsd0c76g0"
+gh_log="$tmp_dir/gh.log"
+: > "$gh_log"
+
+# The latest release still mirrors win 26.608 + mac 26.608.12217 (build 3722).
+cat > "$tmp_dir/latest-release-manifest.json" <<JSON
+{
+  "schemaVersion": 1,
+  "sources": {
+    "windows": {
+      "version": "26.608.1337.0",
+      "packageMoniker": "$package",
+      "contentLength": 3
+    },
+    "macos": {
+      "arm64": {
+        "appcast": {
+          "title": "26.608.12217",
+          "pubDate": "Tue, 09 Jun 2026 21:26:49 +0000",
+          "version": "3722",
+          "shortVersionString": "26.608.12217",
+          "minimumSystemVersion": "12.0",
+          "hardwareRequirements": "arm64",
+          "enclosureUrl": "https://persistent.oaistatic.com/codex-app-prod/Codex-darwin-arm64-26.608.12217.zip",
+          "enclosureLength": 3,
+          "enclosureSignature": "arm-signature-608",
+          "deltas": []
+        },
+        "contentLength": 3,
+        "lastModified": "Tue, 09 Jun 2026 21:51:54 GMT",
+        "etag": "arm-etag-608"
+      },
+      "x64": {
+        "appcast": {
+          "title": "26.608.12217",
+          "pubDate": "Tue, 09 Jun 2026 21:26:53 +0000",
+          "version": "3722",
+          "shortVersionString": "26.608.12217",
+          "minimumSystemVersion": "12.0",
+          "hardwareRequirements": "",
+          "enclosureUrl": "https://persistent.oaistatic.com/codex-app-prod/Codex-darwin-x64-26.608.12217.zip",
+          "enclosureLength": 3,
+          "enclosureSignature": "x64-signature-608",
+          "deltas": []
+        },
+        "contentLength": 3,
+        "lastModified": "Tue, 09 Jun 2026 21:50:56 GMT",
+        "etag": "x64-etag-608"
+      }
+    }
+  }
+}
+JSON
+
+# Store resolver: the downloadable Store package is still 26.608.1337.0.
+cat > "$tmp_dir/bin/dotnet" <<'DOTNET'
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ "${1:-}" == "run" ]]; then
+  printf 'OpenAI.Codex_26.608.1337.0_x64__2p2nqsd0c76g0\thttps://download.example/OpenAI.Codex_26.608.1337.0_x64__2p2nqsd0c76g0.Msix\n'
+  exit 0
+fi
+
+echo "unexpected dotnet invocation: $*" >&2
+exit 1
+DOTNET
+chmod +x "$tmp_dir/bin/dotnet"
+
+cat > "$tmp_dir/bin/gh" <<'GH'
+#!/usr/bin/env bash
+set -euo pipefail
+
+printf '%s\n' "$*" >> "${TEST_GH_LOG:?TEST_GH_LOG must be set}"
+
+if [[ "${1:-}" != "api" ]]; then
+  echo "unexpected gh invocation: $*" >&2
+  exit 1
+fi
+
+shift
+url="${*: -1}"
+
+case "$url" in
+  repos/\{owner\}/\{repo\}/releases/latest)
+    printf '{"tag_name":"%s"}\n' "${TEST_LATEST_TAG:?TEST_LATEST_TAG must be set}"
+    ;;
+  repos/\{owner\}/\{repo\}/releases/tags/"${TEST_LATEST_TAG}")
+    printf '{"tag_name":"%s","assets":[{"name":"release-manifest.json","url":"https://api.example/assets/release-manifest"},{"name":"SHA256SUMS.txt","url":"https://api.example/assets/checksums"}]}\n' "$TEST_LATEST_TAG"
+    ;;
+  repos/\{owner\}/\{repo\}/releases/tags/"${TEST_PREDICTED_TAG}")
+    # The win608+mac609 combination has never been released; behave like GitHub's
+    # 404 so release_exists() reports "does not exist" and does not veto.
+    echo "gh: Not Found (HTTP 404)" >&2
+    exit 1
+    ;;
+  https://api.example/assets/release-manifest)
+    cat "${TEST_LATEST_MANIFEST:?TEST_LATEST_MANIFEST must be set}"
+    ;;
+  *)
+    echo "unexpected gh api URL: $url" >&2
+    exit 1
+    ;;
+esac
+GH
+chmod +x "$tmp_dir/bin/gh"
+
+cat > "$tmp_dir/bin/curl" <<'CURL'
+#!/usr/bin/env bash
+set -euo pipefail
+
+head_request=false
+url=""
+while (($#)); do
+  case "$1" in
+    -o)
+      shift
+      ;;
+    -I|-*I*)
+      head_request=true
+      ;;
+    http://*|https://*)
+      url="$1"
+      ;;
+  esac
+  shift
+done
+
+emit_headers() {
+  printf 'HTTP/2 200\r\n'
+  printf 'content-length: 3\r\n'
+  printf 'last-modified: Fri, 12 Jun 2026 22:15:02 GMT\r\n'
+  printf 'etag: %s\r\n' "$1"
+  printf '\r\n'
+}
+
+emit_appcast() {
+  local arch="$1"
+  local sig="$2"
+  local hardware="$3"
+
+  cat <<XML
+<?xml version="1.0" encoding="utf-8"?>
+<rss xmlns:sparkle="http://www.andymatuschak.org/xml-namespaces/sparkle" version="2.0">
+  <channel>
+    <item>
+      <title>26.609.41114</title>
+      <pubDate>Fri, 12 Jun 2026 22:15:02 +0000</pubDate>
+      <sparkle:version>3888</sparkle:version>
+      <sparkle:shortVersionString>26.609.41114</sparkle:shortVersionString>
+      <sparkle:minimumSystemVersion>12.0</sparkle:minimumSystemVersion>
+      <sparkle:hardwareRequirements>${hardware}</sparkle:hardwareRequirements>
+      <enclosure url="https://persistent.oaistatic.com/codex-app-prod/Codex-darwin-${arch}-26.609.41114.zip" length="3" type="application/octet-stream" sparkle:edSignature="${sig}" />
+    </item>
+  </channel>
+</rss>
+XML
+}
+
+if $head_request; then
+  case "$url" in
+    *OpenAI.Codex_26.608.1337.0_x64__2p2nqsd0c76g0.Msix) emit_headers "windows-etag-608" ;;
+    *Codex-26.609.41114-arm64.dmg) emit_headers "arm-etag-609" ;;
+    *Codex-26.609.41114-x64.dmg) emit_headers "x64-etag-609" ;;
+    *) echo "unexpected curl headers URL: $url" >&2; exit 1 ;;
+  esac
+  exit 0
+fi
+
+case "$url" in
+  *windows-store-update.json)
+    # Advertised build (26.609.4994.0) is AHEAD of the downloadable package (608).
+    printf '{"buildVersion":"26.609.4994.0","storeProductId":"9PLM9XGG6VKS","packageIdentity":"OpenAI.Codex"}\n'
+    ;;
+  *appcast-x64.xml)
+    emit_appcast x64 x64-signature-609 ""
+    ;;
+  *appcast.xml)
+    emit_appcast arm64 arm-signature-609 arm64
+    ;;
+  *)
+    echo "unexpected curl URL: $url" >&2
+    exit 1
+    ;;
+esac
+CURL
+chmod +x "$tmp_dir/bin/curl"
+
+(
+  cd "$repo_root"
+  PATH="$tmp_dir/bin:$PATH" \
+  TEST_GH_LOG="$gh_log" \
+  TEST_LATEST_TAG="$latest_tag" \
+  TEST_PREDICTED_TAG="$predicted_tag" \
+  TEST_LATEST_MANIFEST="$tmp_dir/latest-release-manifest.json" \
+  STORE_LINK_MAX_ATTEMPTS=1 \
+  MANIFEST_PATH="$tmp_dir/probe-manifest.json" \
+    scripts/probe-release.sh > "$tmp_dir/output.txt"
+)
+
+# macOS advanced to 26.609 -> the combined release must go out even though the
+# Windows Store still only serves the 26.608 MSIX.
+grep -F "should_release=true" "$tmp_dir/output.txt"
+
+if grep -F "should_release=false" "$tmp_dir/output.txt"; then
+  echo "Windows Store rollout vetoed a macOS update that was already downloadable." >&2
+  cat "$tmp_dir/output.txt" >&2
+  exit 1
+fi
+
+# The generated manifest must carry the DOWNLOADABLE Windows version (26.608),
+# never the advertised-but-undownloadable 26.609.4994.0.
+manifest_windows_version="$(jq -r '.sources.windows.version' "$tmp_dir/probe-manifest.json")"
+if [[ "$manifest_windows_version" != "26.608.1337.0" ]]; then
+  echo "Expected manifest windows.version 26.608.1337.0, got '$manifest_windows_version'." >&2
+  exit 1
+fi
+
+manifest_mac_version="$(jq -r '.sources.macos.arm64.appcast.shortVersionString' "$tmp_dir/probe-manifest.json")"
+if [[ "$manifest_mac_version" != "26.609.41114" ]]; then
+  echo "Expected manifest macOS arm64 shortVersionString 26.609.41114, got '$manifest_mac_version'." >&2
+  exit 1
+fi
+
+echo "probe-release windows-rollout test PASS"


### PR DESCRIPTION
## 问题

`probe-release.sh` 在「微软商店宣称的 Windows 版本 > 实际可下载的 MSIX 版本」时,会把**整条合并发布**(win+mac 共用一个 `should_release`)一票否决为 `waiting for downloadable MSIX`。结果是:macOS 明明已有可下载的新版(走 `persistent.oaistatic.com`,与微软商店滚动无关),却被 Windows 商店的上架节奏连坐。

实测 2026-06-13:上游 mac 已 `26.609.41114`、Windows advertised `26.609.4994.0`,但商店可下载 MSIX 仍是 `26.608`,于是 mirror 卡在 `26.608` 不动(cron 每 15 分钟全绿但持续判 `No new version`),Manager 一直显示「已是最新」。

## 改动

1. **解耦 win/mac 发布门**:删掉 advertised>downloadable 的硬否决。生成的 manifest 记录的始终是**可下载**的 Windows 版本,`manifest_key` 比对本就只在真实可下载字节变化时才发布——交给它判定即可;Windows 的等待仅作为 skip/release 文案上下文保留。这样 mac 进版即可发布(携带当前可下载的 Windows),Windows 待商店上架 MSIX 后由下一轮自动补上。

2. **修复被否决门长期遮挡的潜伏 bug**:`release_exists()`(以及 `github_api_json_allow_404`、`latest_release_tag` 中相同的 `if helper; then …; fi; status=$?` 写法)取到的是 **if 复合语句**的退出码(假分支无 else 时为 0),而非 helper 的真实返回。于是新 predicted tag 命中 404 时会走到 `exit "$status"` → `exit 0`,**静默终止整个 probe**、不输出 `should_release`。改为在 `else` 分支捕获 `$?`。

3. **新增回归测试** `scripts/test-probe-release-windows-rollout.sh`:advertised(`26.609.4994.0`) > 可下载(`26.608.1337.0`) 且 macOS 已进版到 `26.609.41114` 的场景,断言 `should_release=true` 且生成的 manifest 携带可下载的 Windows 版本(608),并接入 CI。

4. 顺手删除因否决门移除而变成死代码的 `version_gt` helper。

## 验证

- `scripts/test-probe-release.sh`(原回归)PASS
- `scripts/test-probe-release-windows-rollout.sh`(新增)PASS
- `test-prepare-release-metadata.sh` / `test-build-appcast.sh` / `test-prepare-windows-portable.sh` / `test-prune-mac-source.sh` 均 PASS
- `bash -n scripts/*.sh` 通过

## 备注

下游 Manager(codex-app-manager)的 `parse_manifest` 读取的是 `sources.windows.version`(可下载版本),**不读** `updateManifest.buildVersion`(宣称版本),因此「win 较旧 + mac 较新」的混搭 manifest 对 Windows 端不会误报、不会下到不匹配的包。