### PR TITLE
Use canonical Codex versions for mirror releases

### DIFF
--- a/.github/workflows/mirror.yml
+++ b/.github/workflows/mirror.yml
@@ -141,6 +141,7 @@ jobs:
             "$RELEASE_TAG"
 
       - name: Build macOS Sparkle appcasts
+        if: steps.meta.outputs.include_macos == 'true'
         shell: bash
         run: |
           set -euo pipefail
@@ -153,50 +154,82 @@ jobs:
           GH_REPO: ${{ github.repository }}
           RELEASE_TAG: ${{ steps.meta.outputs.tag }}
           RELEASE_TITLE: ${{ steps.meta.outputs.title }}
+          INCLUDE_WINDOWS: ${{ steps.meta.outputs.include_windows }}
+          INCLUDE_MACOS: ${{ steps.meta.outputs.include_macos }}
+          PRERELEASE: ${{ steps.meta.outputs.prerelease }}
+          PUBLISH_LATEST: ${{ steps.meta.outputs.publish_latest }}
         shell: bash
         run: |
           set -euo pipefail
-          # The Sparkle .zip archives are checksummed in SHA256SUMS.txt, so attach
-          # them to the Release too (keeps every listed checksum downloadable and
-          # gives the archives a canonical immutable home alongside the mirror).
-          arm_short_version="$(jq -r '.sources.macos.arm64.appcast.shortVersionString' release-manifest.json)"
-          x64_short_version="$(jq -r '.sources.macos.x64.appcast.shortVersionString' release-manifest.json)"
-          mac_arm64_zip="artifacts/codex-macos/Codex-darwin-arm64-${arm_short_version}.zip"
-          mac_intel_zip="artifacts/codex-macos/Codex-darwin-x64-${x64_short_version}.zip"
-          test -f "$mac_arm64_zip"
-          test -f "$mac_intel_zip"
-
-          mapfile -d '' windows_assets < <(find artifacts/codex-windows -maxdepth 1 -type f -print0 | sort -z)
-          if [[ "${#windows_assets[@]}" -eq 0 ]]; then
-            echo "No Windows release assets found." >&2
-            exit 1
-          fi
-
           release_assets=(
-            artifacts/codex-macos/Codex-mac-arm64.dmg
-            artifacts/codex-macos/Codex-mac-x64.dmg
-            "$mac_arm64_zip"
-            "$mac_intel_zip"
-            artifacts/codex-macos/SHA256SUMS-macos.txt
-            "${windows_assets[@]}"
             assets/status.png
             release-manifest.json
             SHA256SUMS.txt
           )
 
-          while IFS= read -r bn; do
-            [[ -z "$bn" ]] && continue
-            release_assets+=("artifacts/codex-macos/$bn")
-          done < <(
-            jq -r '
-              .sources.macos.arm64.appcast.deltas[]?.basename // empty,
-              .sources.macos.x64.appcast.deltas[]?.basename // empty
-            ' release-manifest.json
-          )
+          if [[ "$INCLUDE_MACOS" == "true" ]]; then
+            # The Sparkle .zip archives are checksummed in SHA256SUMS.txt, so
+            # attach them to the Release too. This keeps every listed checksum
+            # downloadable and gives the archives a canonical immutable home.
+            arm_short_version="$(jq -r '.sources.macos.arm64.appcast.shortVersionString' release-manifest.json)"
+            x64_short_version="$(jq -r '.sources.macos.x64.appcast.shortVersionString' release-manifest.json)"
+            mac_arm64_zip="artifacts/codex-macos/Codex-darwin-arm64-${arm_short_version}.zip"
+            mac_intel_zip="artifacts/codex-macos/Codex-darwin-x64-${x64_short_version}.zip"
+            test -f "$mac_arm64_zip"
+            test -f "$mac_intel_zip"
+
+            release_assets+=(
+              artifacts/codex-macos/Codex-mac-arm64.dmg
+              artifacts/codex-macos/Codex-mac-x64.dmg
+              "$mac_arm64_zip"
+              "$mac_intel_zip"
+              artifacts/codex-macos/SHA256SUMS-macos.txt
+            )
+
+            while IFS= read -r bn; do
+              [[ -z "$bn" ]] && continue
+              release_assets+=("artifacts/codex-macos/$bn")
+            done < <(
+              jq -r '
+                .sources.macos.arm64.appcast.deltas[]?.basename // empty,
+                .sources.macos.x64.appcast.deltas[]?.basename // empty
+              ' release-manifest.json
+            )
+          fi
+
+          if [[ "$INCLUDE_WINDOWS" == "true" ]]; then
+            mapfile -d '' windows_assets < <(find artifacts/codex-windows -maxdepth 1 -type f -print0 | sort -z)
+            if [[ "${#windows_assets[@]}" -eq 0 ]]; then
+              echo "No Windows release assets found." >&2
+              exit 1
+            fi
+            release_assets+=("${windows_assets[@]}")
+          fi
+
+          if [[ "$INCLUDE_MACOS" != "true" && "$INCLUDE_WINDOWS" != "true" ]]; then
+            echo "No platform assets were selected for release." >&2
+            exit 1
+          fi
 
           for asset in "${release_assets[@]}"; do
             test -f "$asset"
           done
+
+          edit_args=(
+            --title "$RELEASE_TITLE"
+            --notes-file release-notes.md
+          )
+          create_args=(
+            --title "$RELEASE_TITLE"
+            --notes-file release-notes.md
+          )
+          if [[ "$PRERELEASE" == "true" ]]; then
+            edit_args+=(--prerelease)
+            create_args+=(--prerelease --latest=false)
+          else
+            edit_args+=(--prerelease=false --latest)
+            create_args+=(--latest)
+          fi
 
           if existing_assets_json="$(gh release view "$RELEASE_TAG" --json assets --jq '.assets' 2>/dev/null)"; then
             missing_assets=()
@@ -231,10 +264,7 @@ jobs:
               exit 1
             fi
 
-            gh release edit "$RELEASE_TAG" \
-              --title "$RELEASE_TITLE" \
-              --latest \
-              --notes-file release-notes.md
+            gh release edit "$RELEASE_TAG" "${edit_args[@]}"
             if [[ "${#missing_assets[@]}" -gt 0 ]]; then
               gh release upload "$RELEASE_TAG" "${missing_assets[@]}"
             fi
@@ -250,15 +280,11 @@ jobs:
               echo "Release assets were reconciled without bulk clobbering existing downloads."
             fi
           else
-            gh release create "$RELEASE_TAG" \
-              --title "$RELEASE_TITLE" \
-              --latest \
-              --notes-file release-notes.md \
-              "${release_assets[@]}"
+            gh release create "$RELEASE_TAG" "${create_args[@]}" "${release_assets[@]}"
           fi
 
       - name: Remove latest links from previous release notes
-        if: needs.probe.outputs.latest_tag != '' && needs.probe.outputs.latest_tag != steps.meta.outputs.tag
+        if: steps.meta.outputs.publish_latest == 'true' && needs.probe.outputs.latest_tag != '' && needs.probe.outputs.latest_tag != steps.meta.outputs.tag
         continue-on-error: true
         env:
           GH_TOKEN: ${{ github.token }}
@@ -268,6 +294,7 @@ jobs:
         run: bash scripts/remove-latest-links-from-release-notes.sh "$LATEST_TAG"
 
       - name: Ensure AWS CLI
+        if: steps.meta.outputs.publish_latest == 'true'
         shell: bash
         run: |
           set -euo pipefail
@@ -277,6 +304,7 @@ jobs:
           fi
 
       - name: Sync GitHub Release assets to Cloudflare R2
+        if: steps.meta.outputs.publish_latest == 'true'
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
@@ -365,6 +393,11 @@ jobs:
           bash scripts/sync-r2.sh --object "$R2_BUCKET_NAME" latest/win-x64 "$win_x64_msix" Codex-Windows-x64.msix
           if [[ -n "$win_arm64_msix" && -f "$win_arm64_msix" ]]; then
             bash scripts/sync-r2.sh --object "$R2_BUCKET_NAME" latest/win-arm64 "$win_arm64_msix" Codex-Windows-arm64.msix
+          else
+            aws s3 rm "s3://$R2_BUCKET_NAME/latest/win-arm64" \
+              --endpoint-url "$R2_S3_ENDPOINT" \
+              --region "${AWS_DEFAULT_REGION:-auto}" \
+              --only-show-errors
           fi
           bash scripts/sync-r2.sh --object "$R2_BUCKET_NAME" latest/checksums SHA256SUMS.txt SHA256SUMS.txt
           bash scripts/sync-r2.sh --object "$R2_BUCKET_NAME" latest/manifest release-manifest.json release-manifest.json
@@ -430,6 +463,7 @@ jobs:
             appcast-x64.xml
 
       - name: Trigger Cloudflare secondary S3 sync
+        if: steps.meta.outputs.publish_latest == 'true'
         env:
           CF_SECONDARY_SYNC_URL: ${{ secrets.CF_SECONDARY_SYNC_URL }}
           CF_SECONDARY_SYNC_TOKEN: ${{ secrets.CF_SECONDARY_SYNC_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@
 |---|---|
 | Windows x64（兼容别名） | <https://codexapp.agentsmirror.com/latest/win> |
 | Windows x64 | <https://codexapp.agentsmirror.com/latest/win-x64> |
-| Windows ARM64 | <https://codexapp.agentsmirror.com/latest/win-arm64> |
+| Windows ARM64（当前版本可用时） | <https://codexapp.agentsmirror.com/latest/win-arm64> |
 | Apple Silicon Mac | <https://codexapp.agentsmirror.com/latest/mac-arm64> |
 | Intel Mac | <https://codexapp.agentsmirror.com/latest/mac-intel> |
 | 校验和 | <https://codexapp.agentsmirror.com/latest/checksums> |
@@ -140,13 +140,18 @@ macOS 版除了手动下载 DMG，还支持 **Sparkle 增量自动更新**。下
 
 ## 版本号说明
 
-Windows 和 macOS 的版本号来自不同上游包，不保证完全一致。Windows MSIX 使用 Microsoft Store 包名里的四段版本，例如 `26.513.3673.0`；macOS 使用 DMG 内 `Codex.app/Contents/Info.plist` 的 `CFBundleShortVersionString` 和 `CFBundleVersion`，例如 `26.513.31313` build `2867`。
+Release 以 Codex 应用内部版本聚合，而不是以 Windows Store 的四段 MSIX 包版本命名。Windows MSIX 包名里的四段版本（例如 `26.623.5175.0`）仍会记录在 release body 和 `release-manifest.json` 的平台包字段里；Codex 内部版本来自 Windows 包内的应用 `package.json`，并与 macOS `CFBundleShortVersionString` 对齐，例如 `26.623.41415`。
 
-Release tag 会同时写明两边版本：
+Release tag 与标题使用内部版本：
 
 ```text
-codex-app-win-26.513.3673.0-mac-26.513.31313-b2867
+codex-app-26.623.41415
+Codex App Mirror 26.623.41415
 ```
+
+当某个平台尚未发布同一内部版本时，会先创建该内部版本的 prerelease，并在 body 的“版本与发布时间”表格中把缺失平台标记为待官方发布。平台补齐后，同一个 Release 会被补全并提升为正式 latest。
+
+Windows x64 是 Windows 平台的必需包；Windows ARM64 是可选架构。如果 Microsoft Store 在探测和下载之间发生 ARM64 rollout 漂移，本轮会跳过 ARM64、清理 `latest/win-arm64` 短链，并在后续探测到稳定包时补上。
 
 当前 Windows 包名形如：
 
@@ -244,7 +249,7 @@ Or use the CDN short links (recommended — **auto-routed to the fastest node**:
 |---|---|
 | Windows x64 (compat alias) | <https://codexapp.agentsmirror.com/latest/win> |
 | Windows x64 | <https://codexapp.agentsmirror.com/latest/win-x64> |
-| Windows ARM64 | <https://codexapp.agentsmirror.com/latest/win-arm64> |
+| Windows ARM64 (when available for the current version) | <https://codexapp.agentsmirror.com/latest/win-arm64> |
 | Apple Silicon Mac | <https://codexapp.agentsmirror.com/latest/mac-arm64> |
 | Intel Mac | <https://codexapp.agentsmirror.com/latest/mac-intel> |
 | Checksums | <https://codexapp.agentsmirror.com/latest/checksums> |
@@ -297,13 +302,18 @@ This mirror isn't only for manual downloads — it's the update backend for the 
 
 ## Version numbers
 
-Windows and macOS versions come from different upstream packages and are not guaranteed to match. The Windows MSIX version comes from the Microsoft Store package moniker, e.g. `26.513.3673.0`. The macOS version comes from `Codex.app/Contents/Info.plist` inside the DMG (`CFBundleShortVersionString` / `CFBundleVersion`), e.g. `26.513.31313` build `2867`.
+Releases are grouped by the Codex app's internal version, not by the four-part Windows Store MSIX package version. The Windows package version from the MSIX moniker (for example `26.623.5175.0`) is still recorded in the release body and `release-manifest.json` as platform package metadata. The Codex app version is read from the Windows package's app `package.json` and aligned with macOS `CFBundleShortVersionString`, for example `26.623.41415`.
 
-Release tags include both:
+Release tags and titles use the internal version:
 
 ```text
-codex-app-win-26.513.3673.0-mac-26.513.31313-b2867
+codex-app-26.623.41415
+Codex App Mirror 26.623.41415
 ```
+
+If one platform has not yet published the same internal version, the mirror creates a prerelease for that internal version and marks the missing platform as waiting in the "Versions and publish times" table. Once the missing platform arrives, the same Release is completed and promoted to latest.
+
+Windows x64 is the required Windows package; Windows ARM64 is an optional architecture. If the Microsoft Store ARM64 rollout drifts between probe and download, that run skips ARM64, removes the `latest/win-arm64` short link, and fills it back in once a stable ARM64 package is detected.
 
 ## Windows "blocked by your system administrator"
 

--- a/cloudflare/secondary-sync/README.md
+++ b/cloudflare/secondary-sync/README.md
@@ -11,7 +11,8 @@ hosted runner.
 3. The Workflow reads R2 in ranges and uploads objects to an IHEP staging prefix.
 4. It copies staging objects to `latest/*` on IHEP, committing `latest/manifest`
    after installers, Sparkle archives, checksums, and appcasts.
-5. It prunes stale `latest/mac/*` Sparkle archives outside the grace window and
+5. It removes stale latest aliases that are absent from the current manifest,
+   prunes stale `latest/mac/*` Sparkle archives outside the grace window, and
    removes staging objects.
 
 ## Required secrets
@@ -41,7 +42,7 @@ Start a sync:
 curl -fsS "$CF_SECONDARY_SYNC_URL/sync/start" \
   -H "Authorization: Bearer $CF_SECONDARY_SYNC_TOKEN" \
   -H "Content-Type: application/json" \
-  -d '{"releaseTag":"codex-app-win-...","force":false}'
+  -d '{"releaseTag":"codex-app-26.623.41415","force":false}'
 ```
 
 Check status:

--- a/cloudflare/secondary-sync/src/core.js
+++ b/cloudflare/secondary-sync/src/core.js
@@ -55,6 +55,7 @@ export async function handleApiRequest(request, env) {
         aliases: item.aliasKeys,
         role: item.role,
       })),
+      staleAliases: plan.staleAliasKeys,
     });
   }
 
@@ -201,6 +202,7 @@ export function buildObjectPlan(manifest, releaseTag) {
   const windows = manifest?.sources?.windows || {};
   const macos = manifest?.sources?.macos || {};
   const items = [];
+  const staleAliasKeys = [];
 
   addItem(items, {
     id: "win-x64",
@@ -224,6 +226,8 @@ export function buildObjectPlan(manifest, releaseTag) {
       role: "installer",
       required: true,
     });
+  } else {
+    staleAliasKeys.push("latest/win-arm64");
   }
 
   addItem(items, {
@@ -329,6 +333,7 @@ export function buildObjectPlan(manifest, releaseTag) {
   return {
     releaseTag,
     items,
+    staleAliasKeys,
     keepLatestMacKeys: items
       .flatMap((item) => item.aliasKeys)
       .filter((key) => key.startsWith("latest/mac/")),
@@ -458,6 +463,16 @@ export async function cleanupStageObjects(env, items) {
       await s3.deleteObject(marker);
       deleted.push(marker);
     }
+  }
+  return { deleted };
+}
+
+export async function deleteStaleAliasObjects(env, keys) {
+  const s3 = createS3Client(env);
+  const deleted = [];
+  for (const key of keys) {
+    await s3.deleteObject(key);
+    deleted.push(key);
   }
   return { deleted };
 }
@@ -878,22 +893,22 @@ async function assertOk(response, operation, key) {
 }
 
 export function deriveReleaseTag(manifest) {
-  const windowsVersion = manifest?.sources?.windows?.version || "";
+  const explicitVersion = manifest?.codexVersion || manifest?.derived?.codexVersion || "";
+  if (explicitVersion) {
+    return `codex-app-${sanitizeTagPart(explicitVersion)}`;
+  }
+
+  const windowsAppVersion =
+    manifest?.sources?.windows?.appVersion || manifest?.sources?.windows?.architectures?.x64?.appVersion || "";
   const arm = manifest?.sources?.macos?.arm64?.appcast || {};
   const x64 = manifest?.sources?.macos?.x64?.appcast || {};
-  if (!windowsVersion || !arm.shortVersionString || !arm.version || !x64.shortVersionString || !x64.version) {
-    return "";
+  if (arm.shortVersionString && arm.shortVersionString === x64.shortVersionString) {
+    return `codex-app-${sanitizeTagPart(arm.shortVersionString)}`;
   }
-  const windowsTag = sanitizeTagPart(windowsVersion);
-  let macTag;
-  if (arm.shortVersionString === x64.shortVersionString && arm.version === x64.version) {
-    macTag = `mac-${sanitizeTagPart(arm.shortVersionString)}-b${sanitizeTagPart(arm.version)}`;
-  } else {
-    macTag = `mac-arm64-${sanitizeTagPart(arm.shortVersionString)}-b${sanitizeTagPart(
-      arm.version,
-    )}-x64-${sanitizeTagPart(x64.shortVersionString)}-b${sanitizeTagPart(x64.version)}`;
+  if (windowsAppVersion) {
+    return `codex-app-${sanitizeTagPart(windowsAppVersion)}`;
   }
-  return `codex-app-win-${windowsTag}-${macTag}`;
+  return "";
 }
 
 export function sanitizeTagPart(value) {

--- a/cloudflare/secondary-sync/src/index.js
+++ b/cloudflare/secondary-sync/src/index.js
@@ -5,6 +5,7 @@ import {
   cleanupStageObjects,
   commitObjectToAliases,
   commitOrder,
+  deleteStaleAliasObjects,
   decoratePlanWithStage,
   discoverSourceManifest,
   handleApiRequest,
@@ -67,6 +68,10 @@ export class SecondaryMirrorWorkflow extends WorkflowEntrypoint {
       );
     }
 
+    const staleAliasResult = await step.do("delete stale latest aliases", HOUSEKEEPING_STEP, () =>
+      nonRetryableGuard(() => deleteStaleAliasObjects(this.env, plan.staleAliasKeys)),
+    );
+
     const pruneResult = await step.do("prune stale Sparkle archives", HOUSEKEEPING_STEP, () =>
       nonRetryableGuard(() => pruneStaleLatestMacObjects(this.env, plan.keepLatestMacKeys)),
     );
@@ -81,6 +86,7 @@ export class SecondaryMirrorWorkflow extends WorkflowEntrypoint {
       stagePrefix: plan.stagePrefix,
       uploaded: uploadResults.length,
       committed: commitResults.reduce((count, result) => count + result.aliases.length, 0),
+      staleAliasesDeleted: staleAliasResult.deleted.length,
       pruned: pruneResult.pruned.length,
       cleaned: cleanupResult.deleted.length,
       completedAt: new Date().toISOString(),

--- a/cloudflare/secondary-sync/test/core.test.mjs
+++ b/cloudflare/secondary-sync/test/core.test.mjs
@@ -4,6 +4,7 @@ import {
   buildObjectPlan,
   cleanupStageObjects,
   commitObjectToAliases,
+  deleteStaleAliasObjects,
   decoratePlanWithStage,
   deriveReleaseTag,
   pruneStaleLatestMacObjects,
@@ -23,7 +24,7 @@ test("buildObjectPlan derives release tag and shares the Windows x64 upload", ()
   const tag = deriveReleaseTag(manifest);
   const plan = buildObjectPlan(manifest, tag);
 
-  assert.equal(tag, "codex-app-win-1.2.3.4-mac-2.0.0-b100");
+  assert.equal(tag, "codex-app-2.0.0");
   assert.equal(plan.items.filter((item) => item.id === "win-x64").length, 1);
   assert.deepEqual(plan.items.find((item) => item.id === "win-x64").aliasKeys, [
     "latest/win-x64",
@@ -31,6 +32,16 @@ test("buildObjectPlan derives release tag and shares the Windows x64 upload", ()
   ]);
   assert.ok(plan.items.some((item) => item.id === "win-arm64"));
   assert.ok(plan.keepLatestMacKeys.includes("latest/mac/arm64/Codex9999-live-arm64.delta"));
+});
+
+test("buildObjectPlan omits unavailable Windows ARM64 and marks stale alias", () => {
+  const manifest = fixtureManifest();
+  manifest.sources.windows.architectures.arm64.downloadable = false;
+
+  const plan = buildObjectPlan(manifest, deriveReleaseTag(manifest));
+
+  assert.equal(plan.items.some((item) => item.id === "win-arm64"), false);
+  assert.deepEqual(plan.staleAliasKeys, ["latest/win-arm64"]);
 });
 
 test("uploads a ranged multipart object to staging and commits both Windows aliases", async () => {
@@ -65,6 +76,19 @@ test("uploads a ranged multipart object to staging and commits both Windows alia
 
   await cleanupStageObjects(env, [item]);
   assert.equal(s3.objects.has(item.stageKey), false);
+});
+
+test("deletes stale latest aliases from the secondary mirror", async () => {
+  const s3 = createMockS3();
+  s3.objects.set("latest/win-arm64", objectEntry("old-arm64"));
+  s3.objects.set("latest/win-x64", objectEntry("current-x64"));
+  globalThis.fetch = s3.fetch;
+
+  const result = await deleteStaleAliasObjects(fixtureEnv(new Map()), ["latest/win-arm64"]);
+
+  assert.deepEqual(result.deleted, ["latest/win-arm64"]);
+  assert.equal(s3.objects.has("latest/win-arm64"), false);
+  assert.equal(s3.objects.has("latest/win-x64"), true);
 });
 
 test("prunes stale unreferenced Sparkle archives but keeps current and recent objects", async () => {
@@ -137,10 +161,12 @@ test("falls back to ListObjectsV2 when HEAD reports zero bytes for a non-empty o
 
 function fixtureManifest() {
   return {
-    schemaVersion: 2,
+    schemaVersion: 3,
+    codexVersion: "2.0.0",
     sources: {
       windows: {
         version: "1.2.3.4",
+        appVersion: "2.0.0",
         architectures: {
           x64: { downloadable: true },
           arm64: { downloadable: true },

--- a/scripts/build-appcast.sh
+++ b/scripts/build-appcast.sh
@@ -26,7 +26,7 @@ set -euo pipefail
 # Usage:
 #   build-appcast.sh <arch> <manifest> <public-base-url> <output-path>
 #     arch             arm64 | x64
-#     manifest         path to release-manifest.json (schemaVersion 2)
+#     manifest         path to release-manifest.json (schemaVersion 2+)
 #     public-base-url  e.g. https://codexapp.agentsmirror.com (no trailing /latest)
 #     output-path      where to write the appcast XML
 

--- a/scripts/download-windows.ps1
+++ b/scripts/download-windows.ps1
@@ -39,6 +39,7 @@ if ($ManifestPath) {
           Architecture = $property.Name
           ExpectedPackageMoniker = $entry.packageMoniker
           ExpectedContentLength = [int64] ($entry.contentLength ?? 0)
+          Required = ($property.Name -eq "x64")
         }
       }
     }
@@ -49,6 +50,7 @@ if ($ManifestPath) {
       Architecture = "x64"
       ExpectedPackageMoniker = $manifest.sources.windows.packageMoniker
       ExpectedContentLength = [int64] ($manifest.sources.windows.contentLength ?? 0)
+      Required = $true
     }
   }
 
@@ -60,13 +62,15 @@ if ($ManifestPath) {
     Architecture = "x64"
     ExpectedPackageMoniker = $null
     ExpectedContentLength = 0
+    Required = $true
   }
 }
 
 function Resolve-StorePackageLink {
   param(
     [string] $Architecture,
-    [string] $ExpectedPackageMoniker
+    [string] $ExpectedPackageMoniker,
+    [bool] $Required = $true
   )
 
   $lastError = "No Microsoft Store package link was resolved."
@@ -94,6 +98,10 @@ function Resolve-StorePackageLink {
 
           if ($ExpectedPackageMoniker -and $packageMoniker -ne $ExpectedPackageMoniker) {
             $lastError = "Microsoft Store package changed after probe. Expected $ExpectedPackageMoniker, got $packageMoniker."
+            if (-not $Required) {
+              Write-Warning "$lastError Skipping optional Windows $Architecture package for this run."
+              return $null
+            }
           } else {
             return [pscustomobject]@{
               PackageMoniker = $packageMoniker
@@ -112,6 +120,11 @@ function Resolve-StorePackageLink {
     }
   }
 
+  if (-not $Required) {
+    Write-Warning "$lastError Skipping optional Windows $Architecture package for this run."
+    return $null
+  }
+
   throw $lastError
 }
 
@@ -119,7 +132,12 @@ $downloadedTargets = @()
 foreach ($windowsPackage in $windowsPackages) {
   $resolvedPackage = Resolve-StorePackageLink `
     -Architecture $windowsPackage.Architecture `
-    -ExpectedPackageMoniker $windowsPackage.ExpectedPackageMoniker
+    -ExpectedPackageMoniker $windowsPackage.ExpectedPackageMoniker `
+    -Required $windowsPackage.Required
+  if ($null -eq $resolvedPackage) {
+    continue
+  }
+
   $packageMoniker = $resolvedPackage.PackageMoniker
   $downloadUrl = $resolvedPackage.DownloadUrl
 
@@ -136,11 +154,20 @@ foreach ($windowsPackage in $windowsPackages) {
   if ($windowsPackage.ExpectedContentLength -gt 0) {
     $actualLength = (Get-Item -LiteralPath $target).Length
     if ($actualLength -ne $windowsPackage.ExpectedContentLength) {
+      if (-not $windowsPackage.Required) {
+        Remove-Item -LiteralPath $target -Force -ErrorAction SilentlyContinue
+        Write-Warning "Downloaded size mismatch for optional Windows $($windowsPackage.Architecture) package. Expected $($windowsPackage.ExpectedContentLength) bytes, got $actualLength bytes. Skipping this optional package for this run."
+        continue
+      }
       throw "Downloaded size mismatch for $target. Expected $($windowsPackage.ExpectedContentLength) bytes, got $actualLength bytes."
     }
   }
 
   $downloadedTargets += $target
+}
+
+if ($downloadedTargets.Count -eq 0) {
+  throw "No Windows packages were downloaded."
 }
 
 Get-FileHash -Algorithm SHA256 -Path $downloadedTargets |

--- a/scripts/prepare-release-metadata.sh
+++ b/scripts/prepare-release-metadata.sh
@@ -6,16 +6,13 @@ macos_metadata="${2:-artifacts/codex-macos/macos-metadata.json}"
 artifacts_dir="${3:-artifacts}"
 r2_public_base_url="${4:-https://codexapp.agentsmirror.com}"
 release_tag_override="${5:-}"
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 require() {
   if ! command -v "$1" >/dev/null 2>&1; then
     echo "Missing required command: $1" >&2
     exit 1
   fi
-}
-
-major_minor() {
-  awk -F. '{ if (NF >= 2) print $1 "." $2; else print $0 }' <<<"$1"
 }
 
 sanitize_tag_part() {
@@ -39,8 +36,59 @@ github_output_value() {
   printf '%s<<%s\n%s\n%s\n' "$name" "$delimiter" "$value" "$delimiter"
 }
 
+max_codex_version() {
+  python3 - "$1" "$2" <<'PY'
+import sys
+
+
+def key(version):
+    parts = []
+    for raw in version.split("."):
+        if raw.isdigit():
+            parts.append((0, int(raw)))
+        else:
+            parts.append((1, raw))
+    return parts
+
+
+left, right = sys.argv[1], sys.argv[2]
+print(max([left, right], key=key))
+PY
+}
+
+find_windows_x64_msix() {
+  local dir="$1"
+
+  find "$dir" -maxdepth 1 -type f \( -name '*_x64__*.Msix' -o -name '*_x64__*.msix' \) | sort | head -n 1
+}
+
+find_windows_arm64_msix() {
+  local dir="$1"
+
+  find "$dir" -maxdepth 1 -type f \( -name '*_arm64__*.Msix' -o -name '*_arm64__*.msix' \) | sort | head -n 1
+}
+
+write_checksum() {
+  local file="$1"
+  local name="${2:-$(basename "$file")}"
+  local hash
+
+  hash="$(sha256sum "$file" | awk '{print $1}')"
+  printf '%s  %s\n' "$hash" "$name"
+}
+
+table_cell() {
+  local value="${1:-}"
+  if [[ -n "$value" && "$value" != "null" ]]; then
+    printf '%s' "$value"
+  else
+    printf ''
+  fi
+}
+
 require find
 require jq
+require python3
 require sha256sum
 
 tmp_manifest="$(mktemp)"
@@ -59,15 +107,19 @@ if [[ ! -f "$macos_metadata" ]]; then
   exit 1
 fi
 
-windows_package="$(jq -r '.sources.windows.architectures.x64.packageMoniker // .sources.windows.packageMoniker' "$probe_manifest")"
-windows_version="$(jq -r '.sources.windows.version // empty' "$probe_manifest")"
-if [[ -z "$windows_version" || "$windows_version" == "null" ]]; then
-  windows_version="$(sed -E 's/^OpenAI\.Codex_([^_]+)_.*/\1/' <<<"$windows_package")"
+windows_package="$(jq -r '.sources.windows.architectures.x64.packageMoniker // .sources.windows.packageMoniker // empty' "$probe_manifest")"
+windows_package_version="$(jq -r '.sources.windows.version // empty' "$probe_manifest")"
+if [[ -z "$windows_package_version" || "$windows_package_version" == "null" ]]; then
+  windows_package_version="$(sed -E 's/^OpenAI\.Codex_([^_]+)_.*/\1/' <<<"$windows_package")"
 fi
+windows_x64_last_modified="$(jq -r '.sources.windows.architectures.x64.lastModified // .sources.windows.lastModified // empty' "$probe_manifest")"
+windows_x64_content_length="$(jq -r '.sources.windows.architectures.x64.contentLength // .sources.windows.contentLength // 0' "$probe_manifest")"
+windows_x64_etag="$(jq -r '.sources.windows.architectures.x64.etag // .sources.windows.etag // empty' "$probe_manifest")"
 windows_arm64_package="$(jq -r '.sources.windows.architectures.arm64.packageMoniker // empty' "$probe_manifest")"
-windows_arm64_version="$(jq -r '.sources.windows.architectures.arm64.version // empty' "$probe_manifest")"
+windows_arm64_package_version="$(jq -r '.sources.windows.architectures.arm64.version // empty' "$probe_manifest")"
 windows_arm64_status="$(jq -r '.sources.windows.architectures.arm64.status // empty' "$probe_manifest")"
-windows_arm64_downloadable="$(jq -r '.sources.windows.architectures.arm64.downloadable // false' "$probe_manifest")"
+windows_arm64_probe_downloadable="$(jq -r '.sources.windows.architectures.arm64.downloadable // false' "$probe_manifest")"
+windows_arm64_last_modified="$(jq -r '.sources.windows.architectures.arm64.lastModified // empty' "$probe_manifest")"
 
 mac_arm_version="$(jq -r '.macos.arm64.bundleShortVersion' "$macos_metadata")"
 mac_arm_build="$(jq -r '.macos.arm64.bundleVersion' "$macos_metadata")"
@@ -77,10 +129,12 @@ mac_common_version="$(jq -r '.commonShortVersion // empty' "$macos_metadata")"
 mac_common_build="$(jq -r '.commonBundleVersion // empty' "$macos_metadata")"
 mac_arm_appcast_version="$(jq -r '.sources.macos.arm64.appcast.shortVersionString // empty' "$probe_manifest")"
 mac_arm_appcast_build="$(jq -r '.sources.macos.arm64.appcast.version // empty' "$probe_manifest")"
+mac_arm_pub_date="$(jq -r '.sources.macos.arm64.appcast.pubDate // .sources.macos.arm64.lastModified // empty' "$probe_manifest")"
 mac_x64_appcast_version="$(jq -r '.sources.macos.x64.appcast.shortVersionString // empty' "$probe_manifest")"
 mac_x64_appcast_build="$(jq -r '.sources.macos.x64.appcast.version // empty' "$probe_manifest")"
+mac_x64_pub_date="$(jq -r '.sources.macos.x64.appcast.pubDate // .sources.macos.x64.lastModified // empty' "$probe_manifest")"
 
-if [[ -z "$windows_version" || -z "$mac_arm_version" || -z "$mac_arm_build" || -z "$mac_x64_version" || -z "$mac_x64_build" ]]; then
+if [[ -z "$windows_package_version" || -z "$windows_package" || -z "$mac_arm_version" || -z "$mac_arm_build" || -z "$mac_x64_version" || -z "$mac_x64_build" ]]; then
   echo "Missing version metadata." >&2
   exit 1
 fi
@@ -103,41 +157,116 @@ if [[ -n "$mac_x64_appcast_build" && "$mac_x64_appcast_build" != "$mac_x64_build
   echo "macOS Intel DMG build differs from appcast; keeping both: appcast=$mac_x64_appcast_build dmg=$mac_x64_build" >&2
 fi
 
+if [[ "$mac_arm_version" != "$mac_x64_version" ]]; then
+  echo "macOS arm64 and Intel resolve to different Codex versions; one canonical release cannot safely contain both yet: arm64=$mac_arm_version x64=$mac_x64_version" >&2
+  exit 1
+fi
+
+windows_artifacts_dir="$artifacts_dir/codex-windows"
+windows_x64_msix="$(find_windows_x64_msix "$windows_artifacts_dir")"
+windows_arm64_msix="$(find_windows_arm64_msix "$windows_artifacts_dir")"
+windows_arm64_downloadable=false
+windows_arm64_missing_reason="${windows_arm64_status:-catalog-only}"
+if [[ "$windows_arm64_probe_downloadable" == "true" && -n "$windows_arm64_package" ]]; then
+  if [[ -n "$windows_arm64_msix" ]]; then
+    windows_arm64_downloadable=true
+    windows_arm64_status="${windows_arm64_status:-downloadable}"
+  else
+    windows_arm64_status="skipped-rollout-drift"
+    windows_arm64_missing_reason="$windows_arm64_status"
+  fi
+fi
+windows_app_version="${WINDOWS_APP_VERSION:-}"
+if [[ -z "$windows_app_version" ]]; then
+  windows_app_version="$(jq -r '.sources.windows.appVersion // .sources.windows.architectures.x64.appVersion // empty' "$probe_manifest")"
+fi
+if [[ -z "$windows_app_version" || "$windows_app_version" == "null" ]]; then
+  if [[ -z "$windows_x64_msix" ]]; then
+    echo "Cannot determine Windows Codex app version: no x64 MSIX was found in $windows_artifacts_dir." >&2
+    exit 1
+  fi
+  windows_app_version="$(python3 "$script_dir/read-windows-msix-version.py" "$windows_x64_msix")"
+fi
+
+if [[ -z "$windows_app_version" || "$windows_app_version" == "null" ]]; then
+  echo "Missing Windows Codex app version." >&2
+  exit 1
+fi
+
+mac_codex_version="${mac_common_version:-$mac_arm_version}"
+codex_version="$(max_codex_version "$windows_app_version" "$mac_codex_version")"
+if [[ "$windows_app_version" == "$codex_version" ]]; then
+  include_windows=true
+else
+  include_windows=false
+fi
+if [[ "$mac_codex_version" == "$codex_version" ]]; then
+  include_macos=true
+else
+  include_macos=false
+fi
+
+if [[ "$include_windows" != "true" && "$include_macos" != "true" ]]; then
+  echo "No platform package matches selected Codex version $codex_version." >&2
+  exit 1
+fi
+
+if [[ "$include_windows" == "true" && "$include_macos" == "true" ]]; then
+  prerelease=false
+  publish_latest=true
+  platform_completeness="complete"
+else
+  prerelease=true
+  publish_latest=false
+  platform_completeness="partial"
+fi
+
+canonical_tag="codex-app-$(sanitize_tag_part "$codex_version")"
 if [[ -n "$release_tag_override" ]]; then
+  validate_release_tag "$release_tag_override"
+  if [[ "$release_tag_override" != "$canonical_tag" ]]; then
+    echo "Release tag override '$release_tag_override' does not match canonical tag '$canonical_tag' for Codex $codex_version." >&2
+    exit 1
+  fi
   tag="$release_tag_override"
 else
-  windows_tag="$(sanitize_tag_part "$windows_version")"
-  mac_arm_tag_version="${mac_arm_appcast_version:-$mac_arm_version}"
-  mac_arm_tag_build="${mac_arm_appcast_build:-$mac_arm_build}"
-  mac_x64_tag_version="${mac_x64_appcast_version:-$mac_x64_version}"
-  mac_x64_tag_build="${mac_x64_appcast_build:-$mac_x64_build}"
-  if [[ "$mac_arm_tag_version" == "$mac_x64_tag_version" && "$mac_arm_tag_build" == "$mac_x64_tag_build" ]]; then
-    mac_tag="mac-$(sanitize_tag_part "$mac_arm_tag_version")-b$(sanitize_tag_part "$mac_arm_tag_build")"
-  else
-    mac_tag="mac-arm64-$(sanitize_tag_part "$mac_arm_tag_version")-b$(sanitize_tag_part "$mac_arm_tag_build")-x64-$(sanitize_tag_part "$mac_x64_tag_version")-b$(sanitize_tag_part "$mac_x64_tag_build")"
-  fi
-  tag="codex-app-win-${windows_tag}-${mac_tag}"
+  tag="$canonical_tag"
 fi
-
 validate_release_tag "$tag"
 
-windows_major_minor="$(major_minor "$windows_version")"
-mac_major_minor="$(major_minor "${mac_common_version:-$mac_arm_version}")"
-if [[ -n "$windows_major_minor" && "$windows_major_minor" == "$mac_major_minor" ]]; then
-  title="Codex App Mirror $windows_major_minor"
-else
-  title="Codex App Mirror Windows $windows_major_minor macOS $mac_major_minor"
-fi
+title="Codex App Mirror $codex_version"
+published_at="$(date -u +'%Y-%m-%dT%H:%M:%SZ')"
+published_at_label="$(date -u +'%Y-%m-%d %H:%M UTC')"
 
 jq \
   --slurpfile mac "$macos_metadata" \
-  --arg windowsVersion "$windows_version" \
+  --arg codexVersion "$codex_version" \
+  --arg publishedAt "$published_at" \
+  --arg windowsPackageVersion "$windows_package_version" \
+  --arg windowsAppVersion "$windows_app_version" \
+  --argjson includeWindows "$include_windows" \
+  --argjson includeMacos "$include_macos" \
+  --argjson prerelease "$prerelease" \
+  --argjson publishLatest "$publish_latest" \
+  --argjson windowsArm64Downloadable "$windows_arm64_downloadable" \
+  --arg windowsArm64Status "$windows_arm64_status" \
+  --arg platformCompleteness "$platform_completeness" \
   '
-  .schemaVersion = 2
-  | .sources.windows.version = $windowsVersion
-  | .sources.windows.architectures.x64.version = $windowsVersion
+  .schemaVersion = 3
+  | .codexVersion = $codexVersion
+  | .publishedAt = $publishedAt
+  | .sources.windows.version = $windowsPackageVersion
+  | .sources.windows.appVersion = $windowsAppVersion
+  | .sources.windows.architectures.x64.version = $windowsPackageVersion
+  | .sources.windows.architectures.x64.appVersion = $windowsAppVersion
   | .sources.windows.architectures.x64.downloadable = true
   | .sources.windows.architectures.x64.status = (.sources.windows.architectures.x64.status // "downloadable")
+  | if .sources.windows.architectures.arm64? != null then
+      .sources.windows.architectures.arm64.downloadable = $windowsArm64Downloadable
+      | .sources.windows.architectures.arm64.status = $windowsArm64Status
+    else
+      .
+    end
   | .sources.macos.arm64.bundleShortVersion = $mac[0].macos.arm64.bundleShortVersion
   | .sources.macos.arm64.bundleVersion = $mac[0].macos.arm64.bundleVersion
   | .sources.macos.arm64.bundleIdentifier = $mac[0].macos.arm64.bundleIdentifier
@@ -149,36 +278,35 @@ jq \
   | .sources.macos.x64.minimumSystemVersion = $mac[0].macos.x64.minimumSystemVersion
   | .sources.macos.x64.sha256 = $mac[0].macos.x64.sha256
   | .derived = {
-      windowsVersion: $windowsVersion,
+      codexVersion: $codexVersion,
+      platformCompleteness: $platformCompleteness,
+      includeWindows: $includeWindows,
+      includeMacos: $includeMacos,
+      prerelease: $prerelease,
+      publishLatest: $publishLatest,
+      windowsPackageVersion: $windowsPackageVersion,
+      windowsAppVersion: $windowsAppVersion,
       macosCommonShortVersion: $mac[0].commonShortVersion,
       macosCommonBundleVersion: $mac[0].commonBundleVersion,
-      macosVersionsMatch: $mac[0].versionsMatch
+      macosVersionsMatch: $mac[0].versionsMatch,
+      missingPlatforms: ([if $includeWindows then empty else "windows" end, if $includeMacos then empty else "macos" end])
     }
   ' "$probe_manifest" > "$tmp_manifest"
 mv "$tmp_manifest" release-manifest.json
 
-write_checksum() {
-  local file="$1"
-  local name="${2:-$(basename "$file")}"
-  local hash
-
-  hash="$(sha256sum "$file" | awk '{print $1}')"
-  printf '%s  %s\n' "$hash" "$name"
-}
-
 {
-  while IFS= read -r -d '' file; do
-    write_checksum "$file"
-  done < <(find "$artifacts_dir" -type f ! -name macos-metadata.json -print0 | sort -z)
+  if [[ "$include_macos" == "true" ]]; then
+    while IFS= read -r -d '' file; do
+      write_checksum "$file"
+    done < <(find "$artifacts_dir/codex-macos" -type f ! -name macos-metadata.json -print0 | sort -z)
+  fi
+  if [[ "$include_windows" == "true" ]]; then
+    while IFS= read -r -d '' file; do
+      write_checksum "$file"
+    done < <(find "$artifacts_dir/codex-windows" -type f -print0 | sort -z)
+  fi
   write_checksum release-manifest.json release-manifest.json
 } > SHA256SUMS.txt
-
-windows_content_length="$(jq -r '.sources.windows.contentLength' release-manifest.json)"
-windows_etag="$(jq -r '.sources.windows.etag // empty' release-manifest.json)"
-mac_arm_content_length="$(jq -r '.sources.macos.arm64.contentLength' release-manifest.json)"
-mac_arm_etag="$(jq -r '.sources.macos.arm64.etag // empty' release-manifest.json)"
-mac_x64_content_length="$(jq -r '.sources.macos.x64.contentLength' release-manifest.json)"
-mac_x64_etag="$(jq -r '.sources.macos.x64.etag // empty' release-manifest.json)"
 
 {
   echo "<!-- release-banner:start -->"
@@ -187,51 +315,79 @@ mac_x64_etag="$(jq -r '.sources.macos.x64.etag // empty' release-manifest.json)"
   echo
   echo "# Codex App 安装包镜像更新"
   echo
-  echo "本次 Release 同步了官方 Codex 桌面端安装包，方便在 GitHub Releases 中下载当前版本对应的安装包。"
+  if [[ "$platform_completeness" == "complete" ]]; then
+    echo "本次 Release 同步了 Codex \`${codex_version}\` 的官方桌面端安装包，方便在 GitHub Releases 中下载当前版本对应的安装包。"
+  else
+    echo "本次 Release 先同步 Codex \`${codex_version}\` 已发布平台的官方安装包；缺失平台发布后会补齐同一个 Release。"
+  fi
   echo
   echo "## 下载"
   echo
-  echo "- Windows x64: \`${windows_package}.Msix\`"
-  if [[ "$windows_arm64_downloadable" == "true" && -n "$windows_arm64_package" ]]; then
-    echo "- Windows ARM64: \`${windows_arm64_package}.Msix\`"
+  if [[ "$include_windows" == "true" ]]; then
+    echo "- Windows x64: \`${windows_package}.Msix\`"
+    if [[ "$windows_arm64_downloadable" == "true" && -n "$windows_arm64_package" ]]; then
+      echo "- Windows ARM64: \`${windows_arm64_package}.Msix\`"
+    fi
+  else
+    echo "- Windows: 待官方发布 Codex \`${codex_version}\` 对应 MSIX"
   fi
-  echo "- macOS Apple Silicon: \`Codex-mac-arm64.dmg\`"
-  echo "- macOS Intel: \`Codex-mac-x64.dmg\`"
+  if [[ "$include_macos" == "true" ]]; then
+    echo "- macOS Apple Silicon: \`Codex-mac-arm64.dmg\`"
+    echo "- macOS Intel: \`Codex-mac-x64.dmg\`"
+  else
+    echo "- macOS: 待官方发布 Codex \`${codex_version}\` 对应 DMG"
+  fi
   echo
-  echo "## 版本信息"
+  echo "## 版本与发布时间"
   echo
-  echo "- Windows x64 MSIX: \`${windows_version}\`"
-  if [[ -n "$windows_arm64_package" ]]; then
-    if [[ "$windows_arm64_downloadable" == "true" ]]; then
-      echo "- Windows ARM64 MSIX: \`${windows_arm64_version:-$windows_version}\`"
-    else
-      echo "- Windows ARM64 MSIX: \`${windows_arm64_version:-unknown}\`（Microsoft Store 目录已出现，下载 URL 暂未解析，状态：\`${windows_arm64_status:-catalog-only}\`）"
+  echo "| 平台 | Codex 版本 | 平台包 / build | 官方发布时间 | 镜像发布时间 | 状态 |"
+  echo "|---|---:|---:|---|---|---|"
+  if [[ "$include_windows" == "true" ]]; then
+    echo "| Windows x64 | \`${windows_app_version}\` | \`${windows_package_version}\` | $(table_cell "$windows_x64_last_modified") | ${published_at_label} | 已发布 |"
+    if [[ -n "$windows_arm64_package" ]]; then
+      if [[ "$windows_arm64_downloadable" == "true" ]]; then
+        echo "| Windows ARM64 | \`${windows_app_version}\` | \`${windows_arm64_package_version:-$windows_package_version}\` | $(table_cell "$windows_arm64_last_modified") | ${published_at_label} | 已发布 |"
+      elif [[ "$windows_arm64_missing_reason" == "skipped-rollout-drift" ]]; then
+        echo "| Windows ARM64 | \`${windows_app_version}\` | \`${windows_arm64_package_version:-$windows_package_version}\` |  |  | 下载阶段上游版本漂移，待下次探测补齐（\`${windows_arm64_status}\`） |"
+      else
+        echo "| Windows ARM64 | \`${windows_app_version}\` | \`${windows_arm64_package_version:-$windows_package_version}\` |  |  | Microsoft Store 目录已出现，下载 URL 待解析（\`${windows_arm64_status:-catalog-only}\`） |"
+      fi
+    fi
+  else
+    echo "| Windows x64 |  |  |  |  | 待官方发布对应版本 |"
+    if [[ -n "$windows_arm64_package" ]]; then
+      echo "| Windows ARM64 |  |  |  |  | 待官方发布对应版本 |"
     fi
   fi
-  echo "- macOS Apple Silicon: \`${mac_arm_version}\` build \`${mac_arm_build}\`"
-  echo "- macOS Intel: \`${mac_x64_version}\` build \`${mac_x64_build}\`"
-  if [[ -n "$mac_arm_appcast_version" || -n "$mac_x64_appcast_version" ]]; then
-    echo "- macOS Apple Silicon Sparkle: \`${mac_arm_appcast_version:-$mac_arm_version}\` build \`${mac_arm_appcast_build:-$mac_arm_build}\`"
-    echo "- macOS Intel Sparkle: \`${mac_x64_appcast_version:-$mac_x64_version}\` build \`${mac_x64_appcast_build:-$mac_x64_build}\`"
+  if [[ "$include_macos" == "true" ]]; then
+    echo "| macOS Apple Silicon | \`${mac_arm_version}\` | build \`${mac_arm_build}\` | $(table_cell "$mac_arm_pub_date") | ${published_at_label} | 已发布 |"
+    echo "| macOS Intel | \`${mac_x64_version}\` | build \`${mac_x64_build}\` | $(table_cell "$mac_x64_pub_date") | ${published_at_label} | 已发布 |"
+  else
+    echo "| macOS Apple Silicon |  |  |  |  | 待官方发布对应版本 |"
+    echo "| macOS Intel |  |  |  |  | 待官方发布对应版本 |"
   fi
   echo
-  echo "Windows、macOS DMG 和 macOS Sparkle 更新来自不同官方上游，版本号或 build 可能不完全一致；这是正常情况。"
+  echo "本仓库以 Codex 内部版本聚合平台安装包；Windows MSIX 的四段包版本会单独列在“平台包 / build”列。"
   echo
-  echo "<!-- latest-links-cn:start -->"
-  echo "## 最新版快速下载"
-  echo
-  echo "- Windows: ${r2_public_base_url}/latest/win"
-  echo "- Windows x64: ${r2_public_base_url}/latest/win-x64"
-  if [[ "$windows_arm64_downloadable" == "true" && -n "$windows_arm64_package" ]]; then
-    echo "- Windows ARM64: ${r2_public_base_url}/latest/win-arm64"
+  if [[ "$publish_latest" == "true" ]]; then
+    echo "<!-- latest-links-cn:start -->"
+    echo "## 最新版快速下载"
+    echo
+    echo "- Windows: ${r2_public_base_url}/latest/win"
+    echo "- Windows x64: ${r2_public_base_url}/latest/win-x64"
+    if [[ "$windows_arm64_downloadable" == "true" && -n "$windows_arm64_package" ]]; then
+      echo "- Windows ARM64: ${r2_public_base_url}/latest/win-arm64"
+    fi
+    echo "- Apple Silicon Mac: ${r2_public_base_url}/latest/mac-arm64"
+    echo "- Intel Mac: ${r2_public_base_url}/latest/mac-intel"
+    echo "- 校验和: ${r2_public_base_url}/latest/checksums"
+    echo "- Manifest: ${r2_public_base_url}/latest/manifest"
+    echo
+    echo "这些链接始终指向当前最新完整镜像版本。如果你正在查看历史 Release，请优先使用该 Release 页面中的附件。"
+    echo "<!-- latest-links-cn:end -->"
+  else
+    echo "此 Release 是平台补齐前的预发布，不会更新 latest 短链；缺失平台发布后将补齐同一个版本并转为正式 Release。"
   fi
-  echo "- Apple Silicon Mac: ${r2_public_base_url}/latest/mac-arm64"
-  echo "- Intel Mac: ${r2_public_base_url}/latest/mac-intel"
-  echo "- 校验和: ${r2_public_base_url}/latest/checksums"
-  echo "- Manifest: ${r2_public_base_url}/latest/manifest"
-  echo
-  echo "这些链接始终指向当前最新镜像版本。如果你正在查看历史 Release，请优先使用该 Release 页面中的附件。"
-  echo "<!-- latest-links-cn:end -->"
   echo
   echo "## 校验"
   echo
@@ -249,51 +405,79 @@ mac_x64_etag="$(jq -r '.sources.macos.x64.etag // empty' release-manifest.json)"
   echo
   echo "# Codex App installer mirror update"
   echo
-  echo "This release mirrors the latest official Codex desktop app installers and makes the matching packages available as assets on this GitHub Release."
+  if [[ "$platform_completeness" == "complete" ]]; then
+    echo "This release mirrors the official desktop installers for Codex \`${codex_version}\` and makes the matching packages available as assets on this GitHub Release."
+  else
+    echo "This release mirrors the official installers currently available for Codex \`${codex_version}\`; missing platforms will be added to this same Release after upstream publishes them."
+  fi
   echo
   echo "## Downloads"
   echo
-  echo "- Windows x64: \`${windows_package}.Msix\`"
-  if [[ "$windows_arm64_downloadable" == "true" && -n "$windows_arm64_package" ]]; then
-    echo "- Windows ARM64: \`${windows_arm64_package}.Msix\`"
+  if [[ "$include_windows" == "true" ]]; then
+    echo "- Windows x64: \`${windows_package}.Msix\`"
+    if [[ "$windows_arm64_downloadable" == "true" && -n "$windows_arm64_package" ]]; then
+      echo "- Windows ARM64: \`${windows_arm64_package}.Msix\`"
+    fi
+  else
+    echo "- Windows: waiting for the official MSIX for Codex \`${codex_version}\`"
   fi
-  echo "- macOS Apple Silicon: \`Codex-mac-arm64.dmg\`"
-  echo "- macOS Intel: \`Codex-mac-x64.dmg\`"
+  if [[ "$include_macos" == "true" ]]; then
+    echo "- macOS Apple Silicon: \`Codex-mac-arm64.dmg\`"
+    echo "- macOS Intel: \`Codex-mac-x64.dmg\`"
+  else
+    echo "- macOS: waiting for the official DMG for Codex \`${codex_version}\`"
+  fi
   echo
-  echo "## Version details"
+  echo "## Versions and publish times"
   echo
-  echo "- Windows x64 MSIX: \`${windows_version}\`"
-  if [[ -n "$windows_arm64_package" ]]; then
-    if [[ "$windows_arm64_downloadable" == "true" ]]; then
-      echo "- Windows ARM64 MSIX: \`${windows_arm64_version:-$windows_version}\`"
-    else
-      echo "- Windows ARM64 MSIX: \`${windows_arm64_version:-unknown}\` (present in Microsoft Store catalog, download URL unresolved, status: \`${windows_arm64_status:-catalog-only}\`)"
+  echo "| Platform | Codex version | Platform package / build | Official publish time | Mirror publish time | Status |"
+  echo "|---|---:|---:|---|---|---|"
+  if [[ "$include_windows" == "true" ]]; then
+    echo "| Windows x64 | \`${windows_app_version}\` | \`${windows_package_version}\` | $(table_cell "$windows_x64_last_modified") | ${published_at_label} | Published |"
+    if [[ -n "$windows_arm64_package" ]]; then
+      if [[ "$windows_arm64_downloadable" == "true" ]]; then
+        echo "| Windows ARM64 | \`${windows_app_version}\` | \`${windows_arm64_package_version:-$windows_package_version}\` | $(table_cell "$windows_arm64_last_modified") | ${published_at_label} | Published |"
+      elif [[ "$windows_arm64_missing_reason" == "skipped-rollout-drift" ]]; then
+        echo "| Windows ARM64 | \`${windows_app_version}\` | \`${windows_arm64_package_version:-$windows_package_version}\` |  |  | Upstream version drifted during download; will be completed on the next probe (\`${windows_arm64_status}\`) |"
+      else
+        echo "| Windows ARM64 | \`${windows_app_version}\` | \`${windows_arm64_package_version:-$windows_package_version}\` |  |  | Present in Microsoft Store catalog, download URL unresolved (\`${windows_arm64_status:-catalog-only}\`) |"
+      fi
+    fi
+  else
+    echo "| Windows x64 |  |  |  |  | Waiting for matching upstream package |"
+    if [[ -n "$windows_arm64_package" ]]; then
+      echo "| Windows ARM64 |  |  |  |  | Waiting for matching upstream package |"
     fi
   fi
-  echo "- macOS Apple Silicon: \`${mac_arm_version}\` build \`${mac_arm_build}\`"
-  echo "- macOS Intel: \`${mac_x64_version}\` build \`${mac_x64_build}\`"
-  if [[ -n "$mac_arm_appcast_version" || -n "$mac_x64_appcast_version" ]]; then
-    echo "- macOS Apple Silicon Sparkle: \`${mac_arm_appcast_version:-$mac_arm_version}\` build \`${mac_arm_appcast_build:-$mac_arm_build}\`"
-    echo "- macOS Intel Sparkle: \`${mac_x64_appcast_version:-$mac_x64_version}\` build \`${mac_x64_appcast_build:-$mac_x64_build}\`"
+  if [[ "$include_macos" == "true" ]]; then
+    echo "| macOS Apple Silicon | \`${mac_arm_version}\` | build \`${mac_arm_build}\` | $(table_cell "$mac_arm_pub_date") | ${published_at_label} | Published |"
+    echo "| macOS Intel | \`${mac_x64_version}\` | build \`${mac_x64_build}\` | $(table_cell "$mac_x64_pub_date") | ${published_at_label} | Published |"
+  else
+    echo "| macOS Apple Silicon |  |  |  |  | Waiting for matching upstream package |"
+    echo "| macOS Intel |  |  |  |  | Waiting for matching upstream package |"
   fi
   echo
-  echo "Windows, macOS DMGs, and macOS Sparkle updates are resolved from different official upstream packages, so their version numbers or builds may not always match exactly."
+  echo "This mirror groups platform installers by the Codex app's internal version; the four-part Windows MSIX package version is listed separately in the platform package / build column."
   echo
-  echo "<!-- latest-links-en:start -->"
-  echo "## Latest quick downloads"
-  echo
-  echo "- Windows: ${r2_public_base_url}/latest/win"
-  echo "- Windows x64: ${r2_public_base_url}/latest/win-x64"
-  if [[ "$windows_arm64_downloadable" == "true" && -n "$windows_arm64_package" ]]; then
-    echo "- Windows ARM64: ${r2_public_base_url}/latest/win-arm64"
+  if [[ "$publish_latest" == "true" ]]; then
+    echo "<!-- latest-links-en:start -->"
+    echo "## Latest quick downloads"
+    echo
+    echo "- Windows: ${r2_public_base_url}/latest/win"
+    echo "- Windows x64: ${r2_public_base_url}/latest/win-x64"
+    if [[ "$windows_arm64_downloadable" == "true" && -n "$windows_arm64_package" ]]; then
+      echo "- Windows ARM64: ${r2_public_base_url}/latest/win-arm64"
+    fi
+    echo "- Apple Silicon Mac: ${r2_public_base_url}/latest/mac-arm64"
+    echo "- Intel Mac: ${r2_public_base_url}/latest/mac-intel"
+    echo "- Checksums: ${r2_public_base_url}/latest/checksums"
+    echo "- Manifest: ${r2_public_base_url}/latest/manifest"
+    echo
+    echo "These links always point to the newest complete mirrored version. If you are viewing a historical Release, prefer the assets attached to that Release page."
+    echo "<!-- latest-links-en:end -->"
+  else
+    echo "This is a prerelease while platform coverage is incomplete. It does not update latest quick links; when the missing platform ships, this same version will be completed and promoted to a regular Release."
   fi
-  echo "- Apple Silicon Mac: ${r2_public_base_url}/latest/mac-arm64"
-  echo "- Intel Mac: ${r2_public_base_url}/latest/mac-intel"
-  echo "- Checksums: ${r2_public_base_url}/latest/checksums"
-  echo "- Manifest: ${r2_public_base_url}/latest/manifest"
-  echo
-  echo "These links always point to the newest mirrored version. If you are viewing a historical Release, prefer the assets attached to that Release page."
-  echo "<!-- latest-links-en:end -->"
   echo
   echo "## Verification"
   echo
@@ -312,8 +496,20 @@ if [[ -n "${GITHUB_OUTPUT:-}" ]]; then
   {
     github_output_value "tag" "$tag"
     github_output_value "title" "$title"
+    github_output_value "codex_version" "$codex_version"
+    github_output_value "include_windows" "$include_windows"
+    github_output_value "include_macos" "$include_macos"
+    github_output_value "prerelease" "$prerelease"
+    github_output_value "publish_latest" "$publish_latest"
+    github_output_value "platform_completeness" "$platform_completeness"
   } >> "$GITHUB_OUTPUT"
 fi
 
 echo "tag=$tag"
 echo "title=$title"
+echo "codex_version=$codex_version"
+echo "include_windows=$include_windows"
+echo "include_macos=$include_macos"
+echo "prerelease=$prerelease"
+echo "publish_latest=$publish_latest"
+echo "platform_completeness=$platform_completeness"

--- a/scripts/probe-release.sh
+++ b/scripts/probe-release.sh
@@ -340,29 +340,6 @@ download_release_asset() {
   gh api -H "Accept: application/octet-stream" "$asset_api_url" > "$dest_dir/$asset_name"
 }
 
-release_exists() {
-  local status
-
-  if github_api_json_allow_404 "repos/{owner}/{repo}/releases/tags/$1" >/dev/null; then
-    return 0
-  else
-    # `$?` after the closing `fi` is the if-statement's status (0 on a false
-    # condition with no else), not the helper's — capture it in the else branch
-    # so a 404 (status 1) is treated as "absent" instead of falling through to
-    # `exit "$status"` and silently terminating the whole probe.
-    status=$?
-  fi
-  if [[ "$status" -eq 1 ]]; then
-    return 1
-  fi
-
-  exit "$status"
-}
-
-sanitize_tag_part() {
-  tr -cs 'A-Za-z0-9._-' '-' <<<"$1" | sed -E 's/^-+//; s/-+$//'
-}
-
 validate_release_tag() {
   local tag="$1"
 
@@ -370,25 +347,6 @@ validate_release_tag() {
     echo "Invalid release tag '$tag'. Use 1-128 ASCII letters, numbers, dots, underscores, or hyphens; the first character must be alphanumeric." >&2
     exit 1
   fi
-}
-
-predicted_release_tag() {
-  local windows_version="$1"
-  local arm_version="$2"
-  local arm_build="$3"
-  local x64_version="$4"
-  local x64_build="$5"
-  local windows_tag
-  local mac_tag
-
-  windows_tag="$(sanitize_tag_part "$windows_version")"
-  if [[ "$arm_version" == "$x64_version" && "$arm_build" == "$x64_build" ]]; then
-    mac_tag="mac-$(sanitize_tag_part "$arm_version")-b$(sanitize_tag_part "$arm_build")"
-  else
-    mac_tag="mac-arm64-$(sanitize_tag_part "$arm_version")-b$(sanitize_tag_part "$arm_build")-x64-$(sanitize_tag_part "$x64_version")-b$(sanitize_tag_part "$x64_build")"
-  fi
-
-  printf 'codex-app-win-%s-%s\n' "$windows_tag" "$mac_tag"
 }
 
 windows_update_wait_notice() {
@@ -979,28 +937,18 @@ else
   fi
 fi
 
-if [[ "$should_release" == "true" && "$force_release" != "true" && -z "$release_tag_input" && -z "$release_tag_fallback" ]]; then
-  predicted_tag="$(predicted_release_tag "$windows_version" "$arm_appcast_version" "$arm_appcast_build" "$x64_appcast_version" "$x64_appcast_build")"
-  if release_exists "$predicted_tag"; then
-    if public_mirror_latest_matches "$manifest_path" "$predicted_tag"; then
-      should_release="false"
-      update_notice="$(windows_update_wait_notice "$manifest_path")"
-      if [[ -n "$update_notice" ]]; then
-        skip_reason="$update_notice Release tag $predicted_tag already exists."
-      else
-        skip_reason="release tag $predicted_tag already exists"
-      fi
-    else
-      release_tag_fallback="$predicted_tag"
-      skip_reason="release tag $predicted_tag already exists, but public mirror aliases or appcasts are stale; republishing"
-    fi
-  fi
-fi
+# The canonical tag now depends on the Windows Codex app's internal version,
+# which is stored inside the downloaded MSIX (app.asar/package.json) rather than
+# in Microsoft Store's four-part package moniker. Leave release_tag empty here so
+# prepare-release-metadata.sh can derive the exact codex-app-<version> tag after
+# the Windows artifact has been downloaded. The latest-tag fallback above is
+# still used when this run is only repairing stale latest aliases for the already
+# published latest release.
 
 if [[ -n "$release_tag_input" ]]; then
   release_tag="$release_tag_input"
 elif [[ "$force_release" == "true" ]]; then
-  release_tag="codex-app-force-$(date -u +'%Y%m%d-%H%M%S')"
+  release_tag=""
 elif [[ -n "$release_tag_fallback" ]]; then
   release_tag="$release_tag_fallback"
 else

--- a/scripts/read-windows-msix-version.py
+++ b/scripts/read-windows-msix-version.py
@@ -1,0 +1,160 @@
+#!/usr/bin/env python3
+import json
+import struct
+import sys
+import zipfile
+
+
+def die(message):
+    print(message, file=sys.stderr)
+    raise SystemExit(1)
+
+
+def read_exact(handle, size):
+    data = handle.read(size)
+    if len(data) != size:
+        die(f"Unexpected end of file while reading {size} bytes.")
+    return data
+
+
+def parse_asar_header(handle):
+    prefix = read_exact(handle, 16)
+    fields = struct.unpack("<IIII", prefix)
+
+    candidates = []
+    # Electron ASAR archives commonly begin with:
+    #   uint32 4, uint32 header_size, uint32 pickle_payload_size, uint32 json_size
+    # followed by the JSON header at offset 16. The payload starts at
+    # 8 + header_size.
+    if fields[0] == 4 and fields[1] >= 8 and fields[3] > 0:
+        candidates.append((16, fields[3], 8 + fields[1]))
+
+    # Older/custom writers sometimes expose the JSON size directly after the
+    # first uint32. Keep this fallback small and structural so corrupt files do
+    # not accidentally parse as a huge header.
+    if fields[0] > 0 and fields[1] > 0:
+        candidates.append((8, fields[1], 8 + fields[0]))
+
+    max_needed = max((offset + size for offset, size, _ in candidates), default=0)
+    if max_needed > len(prefix):
+        prefix += read_exact(handle, max_needed - len(prefix))
+
+    for json_offset, json_size, data_offset in candidates:
+        raw = prefix[json_offset : json_offset + json_size]
+        if not raw.startswith(b"{"):
+            continue
+        try:
+            header = json.loads(raw.decode("utf-8"))
+        except json.JSONDecodeError:
+            continue
+        if isinstance(header, dict) and isinstance(header.get("files"), dict):
+            return header, data_offset
+
+    die("Could not parse app.asar header.")
+
+
+def find_file_entry(node, path_parts):
+    current = node.get("files", {})
+    for part in path_parts:
+        entry = current.get(part)
+        if not isinstance(entry, dict):
+            return None
+        if part == path_parts[-1]:
+            return entry
+        current = entry.get("files", {})
+    return None
+
+
+def find_file_by_basename(node, basename):
+    files = node.get("files", {})
+    for name, entry in files.items():
+        if name == basename and isinstance(entry, dict) and "offset" in entry and "size" in entry:
+            return entry
+        if isinstance(entry, dict):
+            found = find_file_by_basename(entry, basename)
+            if found:
+                return found
+    return None
+
+
+def read_asar_file_from_zip(zip_file, asar_name, offset, size):
+    with zip_file.open(asar_name) as handle:
+        remaining = offset
+        while remaining:
+            chunk = handle.read(min(1024 * 1024, remaining))
+            if not chunk:
+                die("Unexpected end of app.asar while seeking to package.json.")
+            remaining -= len(chunk)
+        return read_exact(handle, size)
+
+
+def app_asar_names(zip_file):
+    names = [
+        info.filename
+        for info in zip_file.infolist()
+        if info.filename.replace("\\", "/").lower().endswith("app.asar")
+    ]
+    names.sort(key=lambda name: ("/resources/app.asar" not in name.replace("\\", "/").lower(), len(name)))
+    return names
+
+
+def direct_package_json_names(zip_file):
+    names = [
+        info.filename
+        for info in zip_file.infolist()
+        if info.filename.replace("\\", "/").lower().endswith("/package.json")
+    ]
+    names.sort(key=lambda name: ("resources/app" not in name.replace("\\", "/").lower(), len(name)))
+    return names
+
+
+def package_version_from_asar(zip_file, asar_name):
+    with zip_file.open(asar_name) as handle:
+        header, data_offset = parse_asar_header(handle)
+
+    entry = find_file_entry(header, ["package.json"]) or find_file_by_basename(header, "package.json")
+    if not entry:
+        return ""
+
+    try:
+        offset = data_offset + int(str(entry["offset"]))
+        size = int(entry["size"])
+    except (KeyError, TypeError, ValueError):
+        return ""
+
+    package_json = json.loads(read_asar_file_from_zip(zip_file, asar_name, offset, size).decode("utf-8"))
+    return str(package_json.get("version") or "")
+
+
+def package_version_direct(zip_file, name):
+    try:
+        with zip_file.open(name) as handle:
+            package_json = json.loads(handle.read().decode("utf-8"))
+        return str(package_json.get("version") or "")
+    except (KeyError, json.JSONDecodeError, UnicodeDecodeError):
+        return ""
+
+
+def main(argv):
+    if len(argv) != 2:
+        die("Usage: read-windows-msix-version.py <OpenAI.Codex_...Msix>")
+
+    msix_path = argv[1]
+    with zipfile.ZipFile(msix_path) as zip_file:
+        for name in app_asar_names(zip_file):
+            version = package_version_from_asar(zip_file, name)
+            if version:
+                print(version)
+                return
+
+        for name in direct_package_json_names(zip_file):
+            version = package_version_direct(zip_file, name)
+            if version:
+                print(version)
+                return
+
+    die("Could not find Codex package.json version in MSIX.")
+
+
+if __name__ == "__main__":
+    main(sys.argv)

--- a/scripts/test-download-windows-retry.sh
+++ b/scripts/test-download-windows-retry.sh
@@ -19,7 +19,10 @@ printf '0' > "$counter_path"
 
 expected_package="OpenAI.Codex_26.616.4196.0_x64__2p2nqsd0c76g0"
 old_package="OpenAI.Codex_26.616.3767.0_x64__2p2nqsd0c76g0"
+expected_arm64_package="OpenAI.Codex_26.616.4196.0_arm64__2p2nqsd0c76g0"
+changed_arm64_package="OpenAI.Codex_26.616.5000.0_arm64__2p2nqsd0c76g0"
 printf 'win' > "$tmp_dir/server/$expected_package.Msix"
+printf 'arm64-new' > "$tmp_dir/server/$changed_arm64_package.Msix"
 
 cat > "$tmp_dir/bin/dotnet" <<'DOTNET'
 #!/usr/bin/env bash
@@ -30,6 +33,14 @@ case "${1:-}" in
     printf 'fake dotnet info\n'
     ;;
   run)
+    if [[ "$*" == *" arm64" ]]; then
+      printf '%s\thttp://127.0.0.1:%s/%s.Msix\n' \
+        "${TEST_CHANGED_ARM64_PACKAGE:?TEST_CHANGED_ARM64_PACKAGE must be set}" \
+        "${TEST_HTTP_PORT:?TEST_HTTP_PORT must be set}" \
+        "$TEST_CHANGED_ARM64_PACKAGE"
+      exit 0
+    fi
+
     count="$(cat "${TEST_STORE_LINK_COUNTER:?TEST_STORE_LINK_COUNTER must be set}")"
     count=$((count + 1))
     printf '%s' "$count" > "$TEST_STORE_LINK_COUNTER"
@@ -101,9 +112,9 @@ cat > "$tmp_dir/probe-manifest.json" <<JSON
         },
         "arm64": {
           "architecture": "arm64",
-          "status": "catalog-only",
-          "downloadable": false,
-          "packageMoniker": "OpenAI.Codex_26.616.4196.0_arm64__2p2nqsd0c76g0",
+          "status": "downloadable",
+          "downloadable": true,
+          "packageMoniker": "$expected_arm64_package",
           "contentLength": 4
         }
       }
@@ -118,6 +129,7 @@ JSON
   TEST_STORE_LINK_COUNTER="$counter_path" \
   TEST_OLD_PACKAGE="$old_package" \
   TEST_EXPECTED_PACKAGE="$expected_package" \
+  TEST_CHANGED_ARM64_PACKAGE="$changed_arm64_package" \
   TEST_HTTP_PORT="$port" \
     pwsh -NoLogo -NoProfile -File scripts/download-windows.ps1 \
       -OutDir "$tmp_dir/out" \
@@ -128,7 +140,12 @@ JSON
 
 test "$(cat "$counter_path")" = "2"
 test -f "$tmp_dir/out/$expected_package.Msix"
-test ! -f "$tmp_dir/out/OpenAI.Codex_26.616.4196.0_arm64__2p2nqsd0c76g0.Msix"
+test ! -f "$tmp_dir/out/$expected_arm64_package.Msix"
+test ! -f "$tmp_dir/out/$changed_arm64_package.Msix"
 grep -F "$expected_package.Msix" "$tmp_dir/out/SHA256SUMS-windows.txt"
+if grep -F 'arm64' "$tmp_dir/out/SHA256SUMS-windows.txt"; then
+  echo "Optional ARM64 drift should not appear in SHA256SUMS-windows.txt." >&2
+  exit 1
+fi
 
 echo "download-windows retry fixture PASS"

--- a/scripts/test-prepare-release-metadata.sh
+++ b/scripts/test-prepare-release-metadata.sh
@@ -16,6 +16,26 @@ printf 'win' > "$tmp_dir/artifacts/codex-windows/OpenAI.Codex_1.2.3.4_x64__2p2nq
 printf 'macsum' > "$tmp_dir/artifacts/codex-macos/SHA256SUMS-macos.txt"
 printf 'winsum' > "$tmp_dir/artifacts/codex-windows/SHA256SUMS-windows.txt"
 
+python3 - "$tmp_dir/minimal.Msix" <<'PY'
+import json
+import struct
+import sys
+import zipfile
+
+msix_path = sys.argv[1]
+package_json = json.dumps({"version": "9.8.7"}, separators=(",", ":")).encode()
+header_json = json.dumps(
+    {"files": {"package.json": {"size": len(package_json), "offset": "0"}}},
+    separators=(",", ":"),
+).encode()
+header_size = 8 + len(header_json)
+asar = struct.pack("<IIII", 4, header_size, len(header_json) + 4, len(header_json)) + header_json + package_json
+with zipfile.ZipFile(msix_path, "w") as archive:
+    archive.writestr("app/resources/app.asar", asar)
+PY
+
+test "$(python3 "$repo_root/scripts/read-windows-msix-version.py" "$tmp_dir/minimal.Msix")" = "9.8.7"
+
 cat > "$tmp_dir/probe-manifest.json" <<'JSON'
 {
   "schemaVersion": 1,
@@ -92,28 +112,80 @@ JSON
 
 (
   cd "$tmp_dir"
-  "$repo_root/scripts/prepare-release-metadata.sh" \
+  WINDOWS_APP_VERSION=1.2.3 "$repo_root/scripts/prepare-release-metadata.sh" \
     probe-manifest.json \
     macos-metadata.json \
     artifacts \
     https://example.com > output.txt
 
-  grep -F 'tag=codex-app-win-1.2.3.4-mac-1.2.3-b6' output.txt
-  grep -F 'title=Codex App Mirror 1.2' output.txt
+  grep -F 'tag=codex-app-1.2.3' output.txt
+  grep -F 'title=Codex App Mirror 1.2.3' output.txt
+  grep -F 'codex_version=1.2.3' output.txt
+  grep -F 'include_windows=true' output.txt
+  grep -F 'include_macos=true' output.txt
+  grep -F 'prerelease=false' output.txt
+  grep -F 'publish_latest=true' output.txt
   grep -F 'Codex-mac-arm64.dmg' SHA256SUMS.txt
   grep -F 'OpenAI.Codex_1.2.3.4_x64__2p2nqsd0c76g0.Msix' SHA256SUMS.txt
   grep -F '![Codex App Mirror](https://github.com/Wangnov/codex-app-mirror/releases/latest/download/status.png)' release-notes.md
-  grep -F 'Windows ARM64 MSIX: `1.2.3.4`（Microsoft Store 目录已出现，下载 URL 暂未解析，状态：`catalog-only`）' release-notes.md
+  grep -F '| Windows x64 | `1.2.3` | `1.2.3.4` |' release-notes.md
+  grep -F '| Windows ARM64 | `1.2.3` | `1.2.3.4` |  |  | Microsoft Store 目录已出现，下载 URL 待解析（`catalog-only`） |' release-notes.md
   grep -F 'Windows x64: https://example.com/latest/win-x64' release-notes.md
-  grep -F 'macOS Apple Silicon Sparkle: `1.2.3` build `6`' release-notes.md
-  grep -F 'These links always point to the newest mirrored version.' release-notes.md
+  grep -F '| macOS Apple Silicon | `1.2.3` | build `5` |' release-notes.md
+  grep -F 'These links always point to the newest complete mirrored version.' release-notes.md
 
   if grep -F 'artifacts/' SHA256SUMS.txt; then
     echo "SHA256SUMS.txt should use basenames, not CI artifact paths." >&2
     exit 1
   fi
 
-  if "$repo_root/scripts/prepare-release-metadata.sh" \
+  jq '
+    .sources.windows.architectures.arm64.downloadable = true
+    | .sources.windows.architectures.arm64.status = "downloadable"
+  ' probe-manifest.json > probe-manifest-arm64-drift.json
+  mkdir arm64-drift
+  (
+    cd arm64-drift
+    WINDOWS_APP_VERSION=1.2.3 "$repo_root/scripts/prepare-release-metadata.sh" \
+      ../probe-manifest-arm64-drift.json \
+      ../macos-metadata.json \
+      ../artifacts \
+      https://example.com > output.txt
+
+    grep -F 'include_windows=true' output.txt
+    grep -F 'publish_latest=true' output.txt
+    grep -F '下载阶段上游版本漂移，待下次探测补齐（`skipped-rollout-drift`）' release-notes.md
+    grep -F 'Upstream version drifted during download; will be completed on the next probe (`skipped-rollout-drift`)' release-notes.md
+    test "$(jq -r '.sources.windows.architectures.arm64.downloadable' release-manifest.json)" = "false"
+    test "$(jq -r '.sources.windows.architectures.arm64.status' release-manifest.json)" = "skipped-rollout-drift"
+  )
+
+  mkdir partial
+  (
+    cd partial
+    WINDOWS_APP_VERSION=1.2.2 "$repo_root/scripts/prepare-release-metadata.sh" \
+      ../probe-manifest.json \
+      ../macos-metadata.json \
+      ../artifacts \
+      https://example.com > output.txt
+
+    grep -F 'tag=codex-app-1.2.3' output.txt
+    grep -F 'include_windows=false' output.txt
+    grep -F 'include_macos=true' output.txt
+    grep -F 'prerelease=true' output.txt
+    grep -F 'publish_latest=false' output.txt
+    grep -F '| Windows x64 |  |  |  |  | 待官方发布对应版本 |' release-notes.md
+    grep -F 'This is a prerelease while platform coverage is incomplete.' release-notes.md
+    grep -F 'Codex-mac-arm64.dmg' SHA256SUMS.txt
+    if grep -F 'OpenAI.Codex_1.2.3.4_x64__2p2nqsd0c76g0.Msix' SHA256SUMS.txt; then
+      echo "Partial macOS-only checksums should not reference Windows assets." >&2
+      exit 1
+    fi
+    test "$(jq -r '.derived.platformCompleteness' release-manifest.json)" = "partial"
+    test "$(jq -r '.derived.missingPlatforms[0]' release-manifest.json)" = "windows"
+  )
+
+  if WINDOWS_APP_VERSION=1.2.3 "$repo_root/scripts/prepare-release-metadata.sh" \
     probe-manifest.json \
     macos-metadata.json \
     artifacts \

--- a/scripts/test-probe-release-windows-rollout.sh
+++ b/scripts/test-probe-release-windows-rollout.sh
@@ -21,10 +21,10 @@ trap cleanup EXIT
 
 mkdir -p "$tmp_dir/bin"
 
-latest_tag="codex-app-win-26.608.1337.0-mac-26.608.12217-b3722"
-# win (downloadable 26.608) + mac (advanced 26.609) -> a brand-new combination
-# whose predicted tag does not exist yet, so release_exists must 404.
-predicted_tag="codex-app-win-26.608.1337.0-mac-26.609.41114-b3888"
+latest_tag="codex-app-26.608.12217"
+# win (downloadable 26.608) + mac (advanced 26.609) should still release.
+# The exact canonical tag is derived later after the Windows MSIX is downloaded
+# and its internal Codex version can be read.
 package="OpenAI.Codex_26.608.1337.0_x64__2p2nqsd0c76g0"
 gh_log="$tmp_dir/gh.log"
 : > "$gh_log"
@@ -118,12 +118,6 @@ case "$url" in
     ;;
   repos/\{owner\}/\{repo\}/releases/tags/"${TEST_LATEST_TAG}")
     printf '{"tag_name":"%s","assets":[{"name":"release-manifest.json","url":"https://api.example/assets/release-manifest"},{"name":"SHA256SUMS.txt","url":"https://api.example/assets/checksums"}]}\n' "$TEST_LATEST_TAG"
-    ;;
-  repos/\{owner\}/\{repo\}/releases/tags/"${TEST_PREDICTED_TAG}")
-    # The win608+mac609 combination has never been released; behave like GitHub's
-    # 404 so release_exists() reports "does not exist" and does not veto.
-    echo "gh: Not Found (HTTP 404)" >&2
-    exit 1
     ;;
   https://api.example/assets/release-manifest)
     cat "${TEST_LATEST_MANIFEST:?TEST_LATEST_MANIFEST must be set}"
@@ -248,7 +242,6 @@ chmod +x "$tmp_dir/bin/curl"
   PATH="$tmp_dir/bin:$PATH" \
   TEST_GH_LOG="$gh_log" \
   TEST_LATEST_TAG="$latest_tag" \
-  TEST_PREDICTED_TAG="$predicted_tag" \
   TEST_LATEST_MANIFEST="$tmp_dir/latest-release-manifest.json" \
   STORE_LINK_MAX_ATTEMPTS=1 \
   MANIFEST_PATH="$tmp_dir/probe-manifest.json" \

--- a/scripts/test-probe-release.sh
+++ b/scripts/test-probe-release.sh
@@ -16,8 +16,7 @@ trap cleanup EXIT
 
 mkdir -p "$tmp_dir/bin"
 
-latest_tag="codex-app-force-20260611-010101"
-predicted_tag="codex-app-win-1.2.3.4-mac-1.2.3-b5"
+latest_tag="codex-app-1.2.3"
 package="OpenAI.Codex_1.2.3.4_x64__2p2nqsd0c76g0"
 gh_log="$tmp_dir/gh.log"
 : > "$gh_log"
@@ -238,9 +237,6 @@ case "$url" in
   repos/\{owner\}/\{repo\}/releases/tags/"${TEST_LATEST_TAG}")
     printf '{"tag_name":"%s","assets":[{"name":"release-manifest.json","url":"https://api.example/assets/release-manifest"},{"name":"SHA256SUMS.txt","url":"https://api.example/assets/checksums"}]}\n' "$TEST_LATEST_TAG"
     ;;
-  repos/\{owner\}/\{repo\}/releases/tags/"${TEST_PREDICTED_TAG}")
-    printf '{"tag_name":"%s","assets":[]}\n' "$TEST_PREDICTED_TAG"
-    ;;
   https://api.example/assets/release-manifest)
     cat "${TEST_LATEST_MANIFEST:?TEST_LATEST_MANIFEST must be set}"
     ;;
@@ -399,7 +395,6 @@ chmod +x "$tmp_dir/bin/curl"
   PATH="$tmp_dir/bin:$PATH" \
   TEST_GH_LOG="$gh_log" \
   TEST_LATEST_TAG="$latest_tag" \
-  TEST_PREDICTED_TAG="$predicted_tag" \
   TEST_LATEST_MANIFEST="$tmp_dir/latest-release-manifest.json" \
   TEST_LATEST_CHECKSUMS="$tmp_dir/latest-SHA256SUMS.txt" \
   TEST_PUBLIC_MANIFEST="$tmp_dir/public-manifest.json" \
@@ -416,16 +411,5 @@ grep -F "latest_tag=$latest_tag" "$tmp_dir/output.txt"
 grep -F "latest release $latest_tag matches current sources, but public mirror aliases or appcasts are stale; republishing" "$tmp_dir/output.txt"
 test "$(jq -r '.sources.windows.architectures.arm64.status' "$tmp_dir/probe-manifest.json")" = "catalog-only"
 test "$(jq -r '.sources.windows.architectures.arm64.packageMoniker' "$tmp_dir/probe-manifest.json")" = "OpenAI.Codex_1.2.3.4_arm64__2p2nqsd0c76g0"
-
-if grep -F "release_tag=$predicted_tag" "$tmp_dir/output.txt"; then
-  echo "probe-release.sh overwrote the latest-tag fallback with the predicted tag." >&2
-  exit 1
-fi
-
-if grep -F "releases/tags/$predicted_tag" "$gh_log"; then
-  echo "probe-release.sh should not query the predicted tag after selecting a latest-tag fallback." >&2
-  cat "$gh_log" >&2
-  exit 1
-fi
 
 echo "probe-release fixture test PASS"


### PR DESCRIPTION
## Summary

- Use the Codex app internal version as the canonical mirror release version, tag, and title (`codex-app-<version>` / `Codex App Mirror <version>`).
- Read the Windows internal app version from the downloaded MSIX `app.asar/package.json` instead of using the Microsoft Store four-part package moniker.
- Add per-platform publish-time tables to release notes and support partial prereleases when Windows and macOS are not available for the same internal version yet.
- Treat Windows x64 as required and Windows ARM64 as optional: if ARM64 drifts between probe and download, skip it for that run, mark it in the manifest/body, and remove stale `latest/win-arm64` aliases from R2 and the secondary mirror.

## Root Cause

The failing run hit a Microsoft Store rollout race: probe resolved one ARM64 package moniker, but download-time resolution saw a newer ARM64 moniker while x64 was still on the previous package. The old workflow treated every downloadable Windows architecture as required, so the run failed instead of publishing the stable required package set.

## Validation

- `actionlint`
- `python -m py_compile scripts/read-windows-msix-version.py`
- PowerShell 7 parser check for `scripts/download-windows.ps1`
- LF temp checkout: `bash -n scripts/*.sh`
- LF temp checkout: `bash scripts/test-prepare-release-metadata.sh`
- LF temp checkout: `bash scripts/test-probe-release.sh`
- LF temp checkout: `bash scripts/test-probe-release-windows-rollout.sh`
- `npm run check` in `cloudflare/secondary-sync` (includes tests and `wrangler deploy --dry-run`)
- `git diff --check`

## Notes

`bash scripts/test-download-windows-retry.sh` cannot run directly in this local WSL bash because `pwsh` is not installed inside WSL. The test fixture itself was updated to cover optional ARM64 drift and should run in Ubuntu CI with PowerShell available.
