### PR TITLE
Verify Windows ARM64 internal version before release

### DIFF
--- a/.github/workflows/mirror.yml
+++ b/.github/workflows/mirror.yml
@@ -198,11 +198,19 @@ jobs:
           fi
 
           if [[ "$INCLUDE_WINDOWS" == "true" ]]; then
-            mapfile -d '' windows_assets < <(find artifacts/codex-windows -maxdepth 1 -type f -print0 | sort -z)
-            if [[ "${#windows_assets[@]}" -eq 0 ]]; then
-              echo "No Windows release assets found." >&2
-              exit 1
+            windows_assets=()
+            win_x64_msix="$(find artifacts/codex-windows -maxdepth 1 -type f \( -name '*_x64__*.Msix' -o -name '*_x64__*.msix' \) | sort | head -n 1)"
+            test -f "$win_x64_msix"
+            windows_assets+=("$win_x64_msix")
+
+            if [[ "$(jq -r '.sources.windows.architectures.arm64.downloadable // false' release-manifest.json)" == "true" ]]; then
+              win_arm64_msix="$(find artifacts/codex-windows -maxdepth 1 -type f \( -name '*_arm64__*.Msix' -o -name '*_arm64__*.msix' \) | sort | head -n 1)"
+              test -f "$win_arm64_msix"
+              windows_assets+=("$win_arm64_msix")
             fi
+
+            test -f artifacts/codex-windows/SHA256SUMS-windows.txt
+            windows_assets+=(artifacts/codex-windows/SHA256SUMS-windows.txt)
             release_assets+=("${windows_assets[@]}")
           fi
 
@@ -232,9 +240,14 @@ jobs:
           fi
 
           if existing_assets_json="$(gh release view "$RELEASE_TAG" --json assets --jq '.assets' 2>/dev/null)"; then
+            desired_asset_names=()
+            for asset in "${release_assets[@]}"; do
+              desired_asset_names+=("$(basename "$asset")")
+            done
             missing_assets=()
             replacement_assets=()
             mismatched_assets=()
+            stale_optional_assets=()
             for asset in "${release_assets[@]}"; do
               name="$(basename "$asset")"
               local_size="$(wc -c < "$asset" | tr -d '[:space:]')"
@@ -257,6 +270,16 @@ jobs:
                 esac
               fi
             done
+            while IFS= read -r name; do
+              [[ -z "$name" ]] && continue
+              case "$name" in
+                OpenAI.Codex_*_arm64__*.Msix|OpenAI.Codex_*_arm64__*.msix)
+                  if ! printf '%s\n' "${desired_asset_names[@]}" | grep -Fxq "$name"; then
+                    stale_optional_assets+=("$name")
+                  fi
+                  ;;
+              esac
+            done < <(jq -r '.[].name' <<<"$existing_assets_json")
 
             if [[ "${#mismatched_assets[@]}" -gt 0 ]]; then
               echo "Existing release assets differ from the newly built assets; refusing to overwrite them without operator review." >&2
@@ -265,6 +288,11 @@ jobs:
             fi
 
             gh release edit "$RELEASE_TAG" "${edit_args[@]}"
+            if [[ "${#stale_optional_assets[@]}" -gt 0 ]]; then
+              for name in "${stale_optional_assets[@]}"; do
+                gh release delete-asset "$RELEASE_TAG" "$name" --yes
+              done
+            fi
             if [[ "${#missing_assets[@]}" -gt 0 ]]; then
               gh release upload "$RELEASE_TAG" "${missing_assets[@]}"
             fi
@@ -274,7 +302,7 @@ jobs:
                 gh release upload "$RELEASE_TAG" "$asset"
               done
             fi
-            if [[ "${#missing_assets[@]}" -eq 0 && "${#replacement_assets[@]}" -eq 0 ]]; then
+            if [[ "${#missing_assets[@]}" -eq 0 && "${#replacement_assets[@]}" -eq 0 && "${#stale_optional_assets[@]}" -eq 0 ]]; then
               echo "All release assets already exist with matching SHA-256 digests."
             else
               echo "Release assets were reconciled without bulk clobbering existing downloads."
@@ -318,6 +346,7 @@ jobs:
           mac_intel="artifacts/codex-macos/Codex-mac-x64.dmg"
           win_x64_msix="$(find artifacts/codex-windows -maxdepth 1 -type f \( -name '*_x64__*.Msix' -o -name '*_x64__*.msix' \) | sort | head -n 1)"
           win_arm64_msix="$(find artifacts/codex-windows -maxdepth 1 -type f \( -name '*_arm64__*.Msix' -o -name '*_arm64__*.msix' \) | sort | head -n 1 || true)"
+          win_arm64_downloadable="$(jq -r '.sources.windows.architectures.arm64.downloadable // false' release-manifest.json)"
 
           test -f "$mac_arm64"
           test -f "$mac_intel"
@@ -364,7 +393,7 @@ jobs:
             bash scripts/sync-r2.sh --object "$R2_BUCKET_NAME" "$prefix/mac-intel" "$mac_intel" Codex-mac-intel.dmg
             bash scripts/sync-r2.sh --object "$R2_BUCKET_NAME" "$prefix/win" "$win_x64_msix" Codex-Windows-x64.msix
             bash scripts/sync-r2.sh --object "$R2_BUCKET_NAME" "$prefix/win-x64" "$win_x64_msix" Codex-Windows-x64.msix
-            if [[ -n "$win_arm64_msix" && -f "$win_arm64_msix" ]]; then
+            if [[ "$win_arm64_downloadable" == "true" && -n "$win_arm64_msix" && -f "$win_arm64_msix" ]]; then
               bash scripts/sync-r2.sh --object "$R2_BUCKET_NAME" "$prefix/win-arm64" "$win_arm64_msix" Codex-Windows-arm64.msix
             fi
             bash scripts/sync-r2.sh --object "$R2_BUCKET_NAME" "$prefix/checksums" SHA256SUMS.txt SHA256SUMS.txt
@@ -391,7 +420,7 @@ jobs:
           bash scripts/sync-r2.sh --object "$R2_BUCKET_NAME" latest/mac-intel "$mac_intel" Codex-mac-intel.dmg
           bash scripts/sync-r2.sh --object "$R2_BUCKET_NAME" latest/win "$win_x64_msix" Codex-Windows-x64.msix
           bash scripts/sync-r2.sh --object "$R2_BUCKET_NAME" latest/win-x64 "$win_x64_msix" Codex-Windows-x64.msix
-          if [[ -n "$win_arm64_msix" && -f "$win_arm64_msix" ]]; then
+          if [[ "$win_arm64_downloadable" == "true" && -n "$win_arm64_msix" && -f "$win_arm64_msix" ]]; then
             bash scripts/sync-r2.sh --object "$R2_BUCKET_NAME" latest/win-arm64 "$win_arm64_msix" Codex-Windows-arm64.msix
           else
             aws s3 rm "s3://$R2_BUCKET_NAME/latest/win-arm64" \

--- a/scripts/prepare-release-metadata.sh
+++ b/scripts/prepare-release-metadata.sh
@@ -167,15 +167,7 @@ windows_x64_msix="$(find_windows_x64_msix "$windows_artifacts_dir")"
 windows_arm64_msix="$(find_windows_arm64_msix "$windows_artifacts_dir")"
 windows_arm64_downloadable=false
 windows_arm64_missing_reason="${windows_arm64_status:-catalog-only}"
-if [[ "$windows_arm64_probe_downloadable" == "true" && -n "$windows_arm64_package" ]]; then
-  if [[ -n "$windows_arm64_msix" ]]; then
-    windows_arm64_downloadable=true
-    windows_arm64_status="${windows_arm64_status:-downloadable}"
-  else
-    windows_arm64_status="skipped-rollout-drift"
-    windows_arm64_missing_reason="$windows_arm64_status"
-  fi
-fi
+windows_arm64_app_version=""
 windows_app_version="${WINDOWS_APP_VERSION:-}"
 if [[ -z "$windows_app_version" ]]; then
   windows_app_version="$(jq -r '.sources.windows.appVersion // .sources.windows.architectures.x64.appVersion // empty' "$probe_manifest")"
@@ -191,6 +183,30 @@ fi
 if [[ -z "$windows_app_version" || "$windows_app_version" == "null" ]]; then
   echo "Missing Windows Codex app version." >&2
   exit 1
+fi
+
+if [[ -n "$windows_arm64_msix" ]]; then
+  if ! windows_arm64_app_version="$(python3 "$script_dir/read-windows-msix-version.py" "$windows_arm64_msix")"; then
+    windows_arm64_app_version=""
+    windows_arm64_status="skipped-version-unreadable"
+    windows_arm64_missing_reason="$windows_arm64_status"
+  fi
+fi
+
+if [[ "$windows_arm64_probe_downloadable" == "true" && -n "$windows_arm64_package" ]]; then
+  if [[ -z "$windows_arm64_msix" ]]; then
+    windows_arm64_status="skipped-rollout-drift"
+    windows_arm64_missing_reason="$windows_arm64_status"
+  elif [[ -z "$windows_arm64_app_version" ]]; then
+    windows_arm64_status="${windows_arm64_status:-skipped-version-unreadable}"
+    windows_arm64_missing_reason="$windows_arm64_status"
+  elif [[ "$windows_arm64_app_version" != "$windows_app_version" ]]; then
+    windows_arm64_status="skipped-version-mismatch"
+    windows_arm64_missing_reason="$windows_arm64_status"
+  else
+    windows_arm64_downloadable=true
+    windows_arm64_status="${windows_arm64_status:-downloadable}"
+  fi
 fi
 
 mac_codex_version="${mac_common_version:-$mac_arm_version}"
@@ -250,6 +266,7 @@ jq \
   --argjson publishLatest "$publish_latest" \
   --argjson windowsArm64Downloadable "$windows_arm64_downloadable" \
   --arg windowsArm64Status "$windows_arm64_status" \
+  --arg windowsArm64AppVersion "$windows_arm64_app_version" \
   --arg platformCompleteness "$platform_completeness" \
   '
   .schemaVersion = 3
@@ -264,6 +281,11 @@ jq \
   | if .sources.windows.architectures.arm64? != null then
       .sources.windows.architectures.arm64.downloadable = $windowsArm64Downloadable
       | .sources.windows.architectures.arm64.status = $windowsArm64Status
+      | if $windowsArm64AppVersion != "" then
+          .sources.windows.architectures.arm64.appVersion = $windowsArm64AppVersion
+        else
+          del(.sources.windows.architectures.arm64.appVersion)
+        end
     else
       .
     end
@@ -286,6 +308,7 @@ jq \
       publishLatest: $publishLatest,
       windowsPackageVersion: $windowsPackageVersion,
       windowsAppVersion: $windowsAppVersion,
+      windowsArm64AppVersion: $windowsArm64AppVersion,
       macosCommonShortVersion: $mac[0].commonShortVersion,
       macosCommonBundleVersion: $mac[0].commonBundleVersion,
       macosVersionsMatch: $mac[0].versionsMatch,
@@ -294,6 +317,20 @@ jq \
   ' "$probe_manifest" > "$tmp_manifest"
 mv "$tmp_manifest" release-manifest.json
 
+windows_selected_files=()
+if [[ "$include_windows" == "true" ]]; then
+  windows_selected_files+=("$windows_x64_msix")
+  if [[ "$windows_arm64_downloadable" == "true" && -n "$windows_arm64_msix" ]]; then
+    windows_selected_files+=("$windows_arm64_msix")
+  fi
+
+  {
+    for file in "${windows_selected_files[@]}"; do
+      write_checksum "$file"
+    done
+  } > "$artifacts_dir/codex-windows/SHA256SUMS-windows.txt"
+fi
+
 {
   if [[ "$include_macos" == "true" ]]; then
     while IFS= read -r -d '' file; do
@@ -301,9 +338,9 @@ mv "$tmp_manifest" release-manifest.json
     done < <(find "$artifacts_dir/codex-macos" -type f ! -name macos-metadata.json -print0 | sort -z)
   fi
   if [[ "$include_windows" == "true" ]]; then
-    while IFS= read -r -d '' file; do
+    for file in "${windows_selected_files[@]}" "$artifacts_dir/codex-windows/SHA256SUMS-windows.txt"; do
       write_checksum "$file"
-    done < <(find "$artifacts_dir/codex-windows" -type f -print0 | sort -z)
+    done
   fi
   write_checksum release-manifest.json release-manifest.json
 } > SHA256SUMS.txt
@@ -349,6 +386,10 @@ mv "$tmp_manifest" release-manifest.json
         echo "| Windows ARM64 | \`${windows_app_version}\` | \`${windows_arm64_package_version:-$windows_package_version}\` | $(table_cell "$windows_arm64_last_modified") | ${published_at_label} | 已发布 |"
       elif [[ "$windows_arm64_missing_reason" == "skipped-rollout-drift" ]]; then
         echo "| Windows ARM64 | \`${windows_app_version}\` | \`${windows_arm64_package_version:-$windows_package_version}\` |  |  | 下载阶段上游版本漂移，待下次探测补齐（\`${windows_arm64_status}\`） |"
+      elif [[ "$windows_arm64_missing_reason" == "skipped-version-mismatch" ]]; then
+        echo "| Windows ARM64 | \`${windows_arm64_app_version}\` | \`${windows_arm64_package_version:-$windows_package_version}\` |  |  | 内部版本与 Windows x64 \`${windows_app_version}\` 不一致，待下次探测补齐（\`${windows_arm64_status}\`） |"
+      elif [[ "$windows_arm64_missing_reason" == "skipped-version-unreadable" ]]; then
+        echo "| Windows ARM64 |  | \`${windows_arm64_package_version:-$windows_package_version}\` |  |  | 无法读取内部版本，待下次探测补齐（\`${windows_arm64_status}\`） |"
       else
         echo "| Windows ARM64 | \`${windows_app_version}\` | \`${windows_arm64_package_version:-$windows_package_version}\` |  |  | Microsoft Store 目录已出现，下载 URL 待解析（\`${windows_arm64_status:-catalog-only}\`） |"
       fi
@@ -439,6 +480,10 @@ mv "$tmp_manifest" release-manifest.json
         echo "| Windows ARM64 | \`${windows_app_version}\` | \`${windows_arm64_package_version:-$windows_package_version}\` | $(table_cell "$windows_arm64_last_modified") | ${published_at_label} | Published |"
       elif [[ "$windows_arm64_missing_reason" == "skipped-rollout-drift" ]]; then
         echo "| Windows ARM64 | \`${windows_app_version}\` | \`${windows_arm64_package_version:-$windows_package_version}\` |  |  | Upstream version drifted during download; will be completed on the next probe (\`${windows_arm64_status}\`) |"
+      elif [[ "$windows_arm64_missing_reason" == "skipped-version-mismatch" ]]; then
+        echo "| Windows ARM64 | \`${windows_arm64_app_version}\` | \`${windows_arm64_package_version:-$windows_package_version}\` |  |  | Internal version differs from Windows x64 \`${windows_app_version}\`; will be completed on the next probe (\`${windows_arm64_status}\`) |"
+      elif [[ "$windows_arm64_missing_reason" == "skipped-version-unreadable" ]]; then
+        echo "| Windows ARM64 |  | \`${windows_arm64_package_version:-$windows_package_version}\` |  |  | Could not read internal version; will be completed on the next probe (\`${windows_arm64_status}\`) |"
       else
         echo "| Windows ARM64 | \`${windows_app_version}\` | \`${windows_arm64_package_version:-$windows_package_version}\` |  |  | Present in Microsoft Store catalog, download URL unresolved (\`${windows_arm64_status:-catalog-only}\`) |"
       fi

--- a/scripts/test-prepare-release-metadata.sh
+++ b/scripts/test-prepare-release-metadata.sh
@@ -160,6 +160,29 @@ JSON
     test "$(jq -r '.sources.windows.architectures.arm64.status' release-manifest.json)" = "skipped-rollout-drift"
   )
 
+  cp -R artifacts artifacts-arm64-mismatch
+  cp minimal.Msix artifacts-arm64-mismatch/codex-windows/OpenAI.Codex_1.2.3.4_arm64__2p2nqsd0c76g0.Msix
+  mkdir arm64-mismatch
+  (
+    cd arm64-mismatch
+    WINDOWS_APP_VERSION=1.2.3 "$repo_root/scripts/prepare-release-metadata.sh" \
+      ../probe-manifest-arm64-drift.json \
+      ../macos-metadata.json \
+      ../artifacts-arm64-mismatch \
+      https://example.com > output.txt
+
+    grep -F 'include_windows=true' output.txt
+    grep -F '内部版本与 Windows x64 `1.2.3` 不一致，待下次探测补齐（`skipped-version-mismatch`）' release-notes.md
+    grep -F 'Internal version differs from Windows x64 `1.2.3`; will be completed on the next probe (`skipped-version-mismatch`)' release-notes.md
+    test "$(jq -r '.sources.windows.architectures.arm64.downloadable' release-manifest.json)" = "false"
+    test "$(jq -r '.sources.windows.architectures.arm64.status' release-manifest.json)" = "skipped-version-mismatch"
+    test "$(jq -r '.sources.windows.architectures.arm64.appVersion' release-manifest.json)" = "9.8.7"
+    if grep -E 'OpenAI\.Codex_.*_arm64__' SHA256SUMS.txt ../artifacts-arm64-mismatch/codex-windows/SHA256SUMS-windows.txt; then
+      echo "Skipped ARM64 package should not appear in checksum files." >&2
+      exit 1
+    fi
+  )
+
   mkdir partial
   (
     cd partial


### PR DESCRIPTION
## Summary

- Read the downloaded Windows ARM64 MSIX internal Codex version before including it in a canonical release.
- Skip ARM64 when its internal version differs from Windows x64, and record `skipped-version-mismatch` in the manifest/body.
- Filter skipped ARM64 files out of `SHA256SUMS-windows.txt`, global `SHA256SUMS.txt`, GitHub Release assets, R2 latest aliases, and staging aliases.
- Delete stale optional ARM64 MSIX release assets when reconciling an existing release.

## Why

After the canonical release workflow shipped, the live Store state produced x64 `26.623.5546.0` and ARM64 `26.623.5175.0` in the same run. The release grouped by x64's internal Codex version, but ARM64's internal version was not independently verified. This patch makes ARM64 inclusion conditional on matching the x64 internal Codex version.

## Validation

- `actionlint`
- LF temp checkout: `bash -n scripts/*.sh`
- LF temp checkout: `bash scripts/test-prepare-release-metadata.sh`
- LF temp checkout: `bash scripts/test-probe-release.sh`
- LF temp checkout: `bash scripts/test-probe-release-windows-rollout.sh`
- `npm run check` in `cloudflare/secondary-sync`
- `python -m py_compile scripts/read-windows-msix-version.py`
- PowerShell 7 parser check for `scripts/download-windows.ps1`
- `git diff --check`
