### PR TITLE
fix: publish partial releases per architecture

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,6 +55,10 @@ jobs:
         shell: bash
         run: scripts/test-probe-release.sh
 
+      - name: Test release probe preserved ARM64 fixture
+        shell: bash
+        run: scripts/test-probe-release-preserved-arm64.sh
+
       - name: Test release probe Windows-rollout fixture
         shell: bash
         run: scripts/test-probe-release-windows-rollout.sh

--- a/.github/workflows/mirror.yml
+++ b/.github/workflows/mirror.yml
@@ -141,7 +141,7 @@ jobs:
             "$RELEASE_TAG"
 
       - name: Build macOS Sparkle appcasts
-        if: steps.meta.outputs.include_macos == 'true'
+        if: steps.meta.outputs.sync_latest == 'true'
         shell: bash
         run: |
           set -euo pipefail
@@ -156,6 +156,10 @@ jobs:
           RELEASE_TITLE: ${{ steps.meta.outputs.title }}
           INCLUDE_WINDOWS: ${{ steps.meta.outputs.include_windows }}
           INCLUDE_MACOS: ${{ steps.meta.outputs.include_macos }}
+          INCLUDE_WINDOWS_X64: ${{ steps.meta.outputs.include_windows_x64 }}
+          INCLUDE_WINDOWS_ARM64: ${{ steps.meta.outputs.include_windows_arm64 }}
+          INCLUDE_MACOS_ARM64: ${{ steps.meta.outputs.include_macos_arm64 }}
+          INCLUDE_MACOS_X64: ${{ steps.meta.outputs.include_macos_x64 }}
           PRERELEASE: ${{ steps.meta.outputs.prerelease }}
           PUBLISH_LATEST: ${{ steps.meta.outputs.publish_latest }}
         shell: bash
@@ -167,43 +171,46 @@ jobs:
             SHA256SUMS.txt
           )
 
-          if [[ "$INCLUDE_MACOS" == "true" ]]; then
-            # The Sparkle .zip archives are checksummed in SHA256SUMS.txt, so
-            # attach them to the Release too. This keeps every listed checksum
-            # downloadable and gives the archives a canonical immutable home.
-            arm_short_version="$(jq -r '.sources.macos.arm64.appcast.shortVersionString' release-manifest.json)"
-            x64_short_version="$(jq -r '.sources.macos.x64.appcast.shortVersionString' release-manifest.json)"
-            mac_arm64_zip="artifacts/codex-macos/Codex-darwin-arm64-${arm_short_version}.zip"
-            mac_intel_zip="artifacts/codex-macos/Codex-darwin-x64-${x64_short_version}.zip"
-            test -f "$mac_arm64_zip"
-            test -f "$mac_intel_zip"
+          add_macos_arch_assets() {
+            local arch_key="$1"
+            local dmg="$2"
+            local zip_prefix="$3"
+            local short_version
+            local zip
+            local bn
 
-            release_assets+=(
-              artifacts/codex-macos/Codex-mac-arm64.dmg
-              artifacts/codex-macos/Codex-mac-x64.dmg
-              "$mac_arm64_zip"
-              "$mac_intel_zip"
-              artifacts/codex-macos/SHA256SUMS-macos.txt
-            )
-
+            short_version="$(jq -r --arg a "$arch_key" '.sources.macos[$a].appcast.shortVersionString' release-manifest.json)"
+            zip="artifacts/codex-macos/${zip_prefix}-${short_version}.zip"
+            test -f "$dmg"
+            test -f "$zip"
+            release_assets+=("$dmg" "$zip")
             while IFS= read -r bn; do
               [[ -z "$bn" ]] && continue
               release_assets+=("artifacts/codex-macos/$bn")
             done < <(
-              jq -r '
-                .sources.macos.arm64.appcast.deltas[]?.basename // empty,
-                .sources.macos.x64.appcast.deltas[]?.basename // empty
-              ' release-manifest.json
+              jq -r --arg a "$arch_key" '.sources.macos[$a].appcast.deltas[]?.basename // empty' release-manifest.json
             )
+          }
+
+          if [[ "$INCLUDE_MACOS_ARM64" == "true" ]]; then
+            add_macos_arch_assets arm64 artifacts/codex-macos/Codex-mac-arm64.dmg Codex-darwin-arm64
+          fi
+          if [[ "$INCLUDE_MACOS_X64" == "true" ]]; then
+            add_macos_arch_assets x64 artifacts/codex-macos/Codex-mac-x64.dmg Codex-darwin-x64
+          fi
+          if [[ "$INCLUDE_MACOS" == "true" ]]; then
+            test -f artifacts/codex-macos/SHA256SUMS-macos.txt
+            release_assets+=(artifacts/codex-macos/SHA256SUMS-macos.txt)
           fi
 
           if [[ "$INCLUDE_WINDOWS" == "true" ]]; then
             windows_assets=()
-            win_x64_msix="$(find artifacts/codex-windows -maxdepth 1 -type f \( -name '*_x64__*.Msix' -o -name '*_x64__*.msix' \) | sort | head -n 1)"
-            test -f "$win_x64_msix"
-            windows_assets+=("$win_x64_msix")
-
-            if [[ "$(jq -r '.sources.windows.architectures.arm64.downloadable // false' release-manifest.json)" == "true" ]]; then
+            if [[ "$INCLUDE_WINDOWS_X64" == "true" ]]; then
+              win_x64_msix="$(find artifacts/codex-windows -maxdepth 1 -type f \( -name '*_x64__*.Msix' -o -name '*_x64__*.msix' \) | sort | head -n 1)"
+              test -f "$win_x64_msix"
+              windows_assets+=("$win_x64_msix")
+            fi
+            if [[ "$INCLUDE_WINDOWS_ARM64" == "true" ]]; then
               win_arm64_msix="$(find artifacts/codex-windows -maxdepth 1 -type f \( -name '*_arm64__*.Msix' -o -name '*_arm64__*.msix' \) | sort | head -n 1)"
               test -f "$win_arm64_msix"
               windows_assets+=("$win_arm64_msix")
@@ -322,7 +329,7 @@ jobs:
         run: bash scripts/remove-latest-links-from-release-notes.sh "$LATEST_TAG"
 
       - name: Ensure AWS CLI
-        if: steps.meta.outputs.publish_latest == 'true'
+        if: steps.meta.outputs.sync_latest == 'true'
         shell: bash
         run: |
           set -euo pipefail
@@ -332,7 +339,7 @@ jobs:
           fi
 
       - name: Sync GitHub Release assets to Cloudflare R2
-        if: steps.meta.outputs.publish_latest == 'true'
+        if: steps.meta.outputs.sync_latest == 'true'
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
@@ -396,7 +403,7 @@ jobs:
             if [[ "$win_arm64_downloadable" == "true" && -n "$win_arm64_msix" && -f "$win_arm64_msix" ]]; then
               bash scripts/sync-r2.sh --object "$R2_BUCKET_NAME" "$prefix/win-arm64" "$win_arm64_msix" Codex-Windows-arm64.msix
             fi
-            bash scripts/sync-r2.sh --object "$R2_BUCKET_NAME" "$prefix/checksums" SHA256SUMS.txt SHA256SUMS.txt
+            bash scripts/sync-r2.sh --object "$R2_BUCKET_NAME" "$prefix/checksums" latest-SHA256SUMS.txt SHA256SUMS.txt
             bash scripts/sync-r2.sh --object "$R2_BUCKET_NAME" "$prefix/manifest" release-manifest.json release-manifest.json
           }
 
@@ -422,13 +429,8 @@ jobs:
           bash scripts/sync-r2.sh --object "$R2_BUCKET_NAME" latest/win-x64 "$win_x64_msix" Codex-Windows-x64.msix
           if [[ "$win_arm64_downloadable" == "true" && -n "$win_arm64_msix" && -f "$win_arm64_msix" ]]; then
             bash scripts/sync-r2.sh --object "$R2_BUCKET_NAME" latest/win-arm64 "$win_arm64_msix" Codex-Windows-arm64.msix
-          else
-            aws s3 rm "s3://$R2_BUCKET_NAME/latest/win-arm64" \
-              --endpoint-url "$R2_S3_ENDPOINT" \
-              --region "${AWS_DEFAULT_REGION:-auto}" \
-              --only-show-errors
           fi
-          bash scripts/sync-r2.sh --object "$R2_BUCKET_NAME" latest/checksums SHA256SUMS.txt SHA256SUMS.txt
+          bash scripts/sync-r2.sh --object "$R2_BUCKET_NAME" latest/checksums latest-SHA256SUMS.txt SHA256SUMS.txt
           bash scripts/sync-r2.sh --object "$R2_BUCKET_NAME" latest/manifest release-manifest.json release-manifest.json
 
           # Sparkle archives first, then the appcasts that reference them, so the
@@ -492,7 +494,7 @@ jobs:
             appcast-x64.xml
 
       - name: Trigger Cloudflare secondary S3 sync
-        if: steps.meta.outputs.publish_latest == 'true'
+        if: steps.meta.outputs.sync_latest == 'true'
         env:
           CF_SECONDARY_SYNC_URL: ${{ secrets.CF_SECONDARY_SYNC_URL }}
           CF_SECONDARY_SYNC_TOKEN: ${{ secrets.CF_SECONDARY_SYNC_TOKEN }}

--- a/.github/workflows/mirror.yml
+++ b/.github/workflows/mirror.yml
@@ -126,6 +126,7 @@ jobs:
         id: meta
         env:
           RELEASE_TAG: ${{ needs.probe.outputs.release_tag }}
+          INHERIT_LATEST_FROM_MIRROR: "true"
         shell: bash
         run: |
           set -euo pipefail
@@ -170,6 +171,9 @@ jobs:
             release-manifest.json
             SHA256SUMS.txt
           )
+          desired_existing_asset_names=()
+          required_existing_asset_names=()
+          declare -A required_existing_asset_sha256=()
 
           add_macos_arch_assets() {
             local arch_key="$1"
@@ -211,9 +215,25 @@ jobs:
               windows_assets+=("$win_x64_msix")
             fi
             if [[ "$INCLUDE_WINDOWS_ARM64" == "true" ]]; then
-              win_arm64_msix="$(find artifacts/codex-windows -maxdepth 1 -type f \( -name '*_arm64__*.Msix' -o -name '*_arm64__*.msix' \) | sort | head -n 1)"
-              test -f "$win_arm64_msix"
-              windows_assets+=("$win_arm64_msix")
+              win_arm64_current_local="$(jq -r '.sources.windows.architectures.arm64.currentLocalArtifact // .sources.windows.architectures.arm64.currentForCodexVersion // false' release-manifest.json)"
+              win_arm64_package="$(jq -r '.sources.windows.architectures.arm64.packageMoniker // empty' release-manifest.json)"
+              if [[ "$win_arm64_current_local" == "true" ]]; then
+                win_arm64_msix="$(find artifacts/codex-windows -maxdepth 1 -type f \( -name '*_arm64__*.Msix' -o -name '*_arm64__*.msix' \) | sort | head -n 1)"
+                test -f "$win_arm64_msix"
+                windows_assets+=("$win_arm64_msix")
+              elif [[ -n "$win_arm64_package" ]]; then
+                win_arm64_expected_sha="$(jq -r --arg name "${win_arm64_package}.Msix" '.derived.latestChecksums[$name] // empty' release-manifest.json)"
+                if [[ -z "$win_arm64_expected_sha" ]]; then
+                  echo "Windows ARM64 is preserved but release-manifest.json has no latest checksum for ${win_arm64_package}.Msix." >&2
+                  exit 1
+                fi
+                desired_existing_asset_names+=("${win_arm64_package}.Msix")
+                required_existing_asset_names+=("${win_arm64_package}.Msix")
+                required_existing_asset_sha256["${win_arm64_package}.Msix"]="$win_arm64_expected_sha"
+              else
+                echo "Windows ARM64 is included but release-manifest.json has no packageMoniker." >&2
+                exit 1
+              fi
             fi
 
             test -f artifacts/codex-windows/SHA256SUMS-windows.txt
@@ -251,6 +271,7 @@ jobs:
             for asset in "${release_assets[@]}"; do
               desired_asset_names+=("$(basename "$asset")")
             done
+            desired_asset_names+=("${desired_existing_asset_names[@]}")
             missing_assets=()
             replacement_assets=()
             mismatched_assets=()
@@ -275,6 +296,22 @@ jobs:
                     mismatched_assets+=("$name (release=$existing_size/$existing_sha local=$local_size/$local_sha)")
                     ;;
                 esac
+              fi
+            done
+            for name in "${required_existing_asset_names[@]}"; do
+              if ! jq -e --arg name "$name" 'any(.[]?; .name == $name)' <<<"$existing_assets_json" >/dev/null; then
+                mismatched_assets+=("$name (preserved release asset is missing)")
+                continue
+              fi
+              expected_sha="${required_existing_asset_sha256[$name]:-}"
+              if [[ -n "$expected_sha" ]]; then
+                existing_digest="$(jq -r --arg name "$name" '.[] | select(.name == $name) | .digest // ""' <<<"$existing_assets_json" | head -n 1)"
+                existing_sha="${existing_digest#sha256:}"
+                if [[ "$existing_sha" == "$existing_digest" || -z "$existing_sha" ]]; then
+                  mismatched_assets+=("$name (preserved release asset has no sha256 digest)")
+                elif [[ "${existing_sha,,}" != "${expected_sha,,}" ]]; then
+                  mismatched_assets+=("$name (preserved release asset sha256 ${existing_sha,,} != manifest ${expected_sha,,})")
+                fi
               fi
             done
             while IFS= read -r name; do
@@ -315,11 +352,16 @@ jobs:
               echo "Release assets were reconciled without bulk clobbering existing downloads."
             fi
           else
+            if [[ "${#required_existing_asset_names[@]}" -gt 0 ]]; then
+              echo "Release $RELEASE_TAG does not exist, but release-manifest.json depends on preserved assets that can only be reused from an existing Release:" >&2
+              printf '  %s\n' "${required_existing_asset_names[@]}" >&2
+              exit 1
+            fi
             gh release create "$RELEASE_TAG" "${create_args[@]}" "${release_assets[@]}"
           fi
 
       - name: Remove latest links from previous release notes
-        if: steps.meta.outputs.publish_latest == 'true' && needs.probe.outputs.latest_tag != '' && needs.probe.outputs.latest_tag != steps.meta.outputs.tag
+        if: steps.meta.outputs.sync_latest == 'true' && needs.probe.outputs.latest_tag != '' && needs.probe.outputs.latest_tag != steps.meta.outputs.tag
         continue-on-error: true
         env:
           GH_TOKEN: ${{ github.token }}
@@ -345,7 +387,10 @@ jobs:
           AWS_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
           AWS_DEFAULT_REGION: auto
           R2_S3_ENDPOINT: https://${{ secrets.CLOUDFLARE_ACCOUNT_ID }}.r2.cloudflarestorage.com
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
           RELEASE_TAG: ${{ steps.meta.outputs.tag }}
+          LATEST_TAG: ${{ needs.probe.outputs.latest_tag }}
         shell: bash
         run: |
           set -euo pipefail
@@ -353,11 +398,70 @@ jobs:
           mac_intel="artifacts/codex-macos/Codex-mac-x64.dmg"
           win_x64_msix="$(find artifacts/codex-windows -maxdepth 1 -type f \( -name '*_x64__*.Msix' -o -name '*_x64__*.msix' \) | sort | head -n 1)"
           win_arm64_msix="$(find artifacts/codex-windows -maxdepth 1 -type f \( -name '*_arm64__*.Msix' -o -name '*_arm64__*.msix' \) | sort | head -n 1 || true)"
+          win_arm64_current_local="$(jq -r '.sources.windows.architectures.arm64.currentLocalArtifact // .sources.windows.architectures.arm64.currentForCodexVersion // false' release-manifest.json)"
           win_arm64_downloadable="$(jq -r '.sources.windows.architectures.arm64.downloadable // false' release-manifest.json)"
+          win_arm64_package="$(jq -r '.sources.windows.architectures.arm64.packageMoniker // empty' release-manifest.json)"
+          win_arm64_app_version="$(jq -r '.sources.windows.architectures.arm64.appVersion // empty' release-manifest.json)"
+          win_arm64_expected_sha=""
+          if [[ -n "$win_arm64_package" ]]; then
+            win_arm64_expected_sha="$(jq -r --arg name "${win_arm64_package}.Msix" '.derived.latestChecksums[$name] // empty' release-manifest.json)"
+          fi
+          win_arm64_alias_source="$win_arm64_current_local"
 
           test -f "$mac_arm64"
           test -f "$mac_intel"
           test -f "$win_x64_msix"
+
+          if [[ "$win_arm64_alias_source" != "true" && "$win_arm64_downloadable" == "true" && -n "$win_arm64_package" ]]; then
+            if [[ -z "$win_arm64_expected_sha" ]]; then
+              echo "Windows ARM64 is advertised by release-manifest.json but ${win_arm64_package}.Msix is missing from derived.latestChecksums." >&2
+              exit 1
+            fi
+            restored_arm64_dir="artifacts/restored-windows-arm64"
+            restored_arm64_asset="$restored_arm64_dir/${win_arm64_package}.Msix"
+            restored_arm64=false
+            mkdir -p "$restored_arm64_dir"
+
+            if aws s3 cp "s3://$R2_BUCKET_NAME/latest/win-arm64" "$restored_arm64_asset" \
+              --endpoint-url "$R2_S3_ENDPOINT" \
+              --region "${AWS_DEFAULT_REGION:-auto}" \
+              --no-progress; then
+              restored_arm64_sha="$(sha256sum "$restored_arm64_asset" | awk '{print tolower($1)}')"
+              if [[ "$restored_arm64_sha" == "${win_arm64_expected_sha,,}" ]]; then
+                echo "Preserving checksum-matching R2 latest/win-arm64 for ${win_arm64_package}.Msix."
+                restored_arm64=true
+              else
+                echo "Existing R2 latest/win-arm64 sha256 $restored_arm64_sha != manifest ${win_arm64_expected_sha,,}; trying GitHub Release assets." >&2
+                rm -f "$restored_arm64_asset"
+              fi
+            fi
+
+            if [[ "$restored_arm64" != "true" ]]; then
+              for source_tag in "$RELEASE_TAG" "${LATEST_TAG:-}" "codex-app-${win_arm64_app_version}"; do
+                [[ -n "$source_tag" && "$source_tag" != "codex-app-" ]] || continue
+                rm -f "$restored_arm64_asset"
+                if gh release download "$source_tag" \
+                  --pattern "${win_arm64_package}.Msix" \
+                  --dir "$restored_arm64_dir" \
+                  --clobber; then
+                  if [[ -f "$restored_arm64_asset" ]]; then
+                    restored_arm64_sha="$(sha256sum "$restored_arm64_asset" | awk '{print tolower($1)}')"
+                    if [[ "$restored_arm64_sha" == "${win_arm64_expected_sha,,}" ]]; then
+                      restored_arm64=true
+                      break
+                    fi
+                    echo "Downloaded ${win_arm64_package}.Msix from $source_tag, but sha256 $restored_arm64_sha != manifest ${win_arm64_expected_sha,,}; trying another source." >&2
+                  fi
+                fi
+              done
+              if [[ "$restored_arm64" != "true" ]]; then
+                echo "Windows ARM64 is advertised by release-manifest.json but no local, R2, or checksum-matching GitHub Release asset was found for ${win_arm64_package}.Msix." >&2
+                exit 1
+              fi
+            fi
+            win_arm64_msix="$restored_arm64_asset"
+            win_arm64_alias_source=true
+          fi
 
           # Sparkle update archives the generated appcasts point at. Their object
           # keys (latest/mac/{arm64,intel}/...) must match the enclosure URLs that
@@ -400,7 +504,7 @@ jobs:
             bash scripts/sync-r2.sh --object "$R2_BUCKET_NAME" "$prefix/mac-intel" "$mac_intel" Codex-mac-intel.dmg
             bash scripts/sync-r2.sh --object "$R2_BUCKET_NAME" "$prefix/win" "$win_x64_msix" Codex-Windows-x64.msix
             bash scripts/sync-r2.sh --object "$R2_BUCKET_NAME" "$prefix/win-x64" "$win_x64_msix" Codex-Windows-x64.msix
-            if [[ "$win_arm64_downloadable" == "true" && -n "$win_arm64_msix" && -f "$win_arm64_msix" ]]; then
+            if [[ "$win_arm64_alias_source" == "true" && -n "$win_arm64_msix" && -f "$win_arm64_msix" ]]; then
               bash scripts/sync-r2.sh --object "$R2_BUCKET_NAME" "$prefix/win-arm64" "$win_arm64_msix" Codex-Windows-arm64.msix
             fi
             bash scripts/sync-r2.sh --object "$R2_BUCKET_NAME" "$prefix/checksums" latest-SHA256SUMS.txt SHA256SUMS.txt
@@ -427,8 +531,13 @@ jobs:
           bash scripts/sync-r2.sh --object "$R2_BUCKET_NAME" latest/mac-intel "$mac_intel" Codex-mac-intel.dmg
           bash scripts/sync-r2.sh --object "$R2_BUCKET_NAME" latest/win "$win_x64_msix" Codex-Windows-x64.msix
           bash scripts/sync-r2.sh --object "$R2_BUCKET_NAME" latest/win-x64 "$win_x64_msix" Codex-Windows-x64.msix
-          if [[ "$win_arm64_downloadable" == "true" && -n "$win_arm64_msix" && -f "$win_arm64_msix" ]]; then
+          if [[ "$win_arm64_alias_source" == "true" && -n "$win_arm64_msix" && -f "$win_arm64_msix" ]]; then
             bash scripts/sync-r2.sh --object "$R2_BUCKET_NAME" latest/win-arm64 "$win_arm64_msix" Codex-Windows-arm64.msix
+          else
+            echo "Removing stale R2 latest/win-arm64 because this manifest does not advertise a checksum-matching ARM64 package."
+            aws s3 rm "s3://$R2_BUCKET_NAME/latest/win-arm64" \
+              --endpoint-url "$R2_S3_ENDPOINT" \
+              --region "${AWS_DEFAULT_REGION:-auto}"
           fi
           bash scripts/sync-r2.sh --object "$R2_BUCKET_NAME" latest/checksums latest-SHA256SUMS.txt SHA256SUMS.txt
           bash scripts/sync-r2.sh --object "$R2_BUCKET_NAME" latest/manifest release-manifest.json release-manifest.json

--- a/README.md
+++ b/README.md
@@ -149,9 +149,9 @@ codex-app-26.623.41415
 Codex App Mirror 26.623.41415
 ```
 
-当某个平台尚未发布同一内部版本时，会先创建该内部版本的 prerelease，并在 body 的“版本与发布时间”表格中把缺失平台标记为待官方发布。平台补齐后，同一个 Release 会被补全并提升为正式 latest。
+当某个平台尚未发布同一内部版本时，会先创建该内部版本的 prerelease，并在 body 的“版本与发布时间”表格中把缺失平台标记为待官方发布。已发布的架构会立即推进 R2/S3 `latest/*` 短链；尚未发布该版本的架构会继续指向它自己的当前 latest。四个架构补齐后，同一个 Release 会被补全并提升为正式 latest。
 
-Windows x64 是 Windows 平台的必需包；Windows ARM64 是可选架构。如果 Microsoft Store 在探测和下载之间发生 ARM64 rollout 漂移，本轮会跳过 ARM64、清理 `latest/win-arm64` 短链，并在后续探测到稳定包时补上。
+Windows x64 是 Windows 平台的必需包；Windows ARM64 是可选架构。如果 Microsoft Store 在探测和下载之间发生 ARM64 rollout 漂移，本轮会跳过本地 ARM64 上传，并保留上一份校验匹配的 `latest/win-arm64`；后续探测到稳定包时再补上。
 
 当前 Windows 包名形如：
 
@@ -311,9 +311,9 @@ codex-app-26.623.41415
 Codex App Mirror 26.623.41415
 ```
 
-If one platform has not yet published the same internal version, the mirror creates a prerelease for that internal version and marks the missing platform as waiting in the "Versions and publish times" table. Once the missing platform arrives, the same Release is completed and promoted to latest.
+If one platform has not yet published the same internal version, the mirror creates a prerelease for that internal version and marks the missing platform as waiting in the "Versions and publish times" table. Architectures that have shipped immediately advance the R2/S3 `latest/*` short links; architectures that have not shipped that version keep pointing at their own current latest package. Once all four architectures arrive, the same Release is completed and promoted to latest.
 
-Windows x64 is the required Windows package; Windows ARM64 is an optional architecture. If the Microsoft Store ARM64 rollout drifts between probe and download, that run skips ARM64, removes the `latest/win-arm64` short link, and fills it back in once a stable ARM64 package is detected.
+Windows x64 is the required Windows package; Windows ARM64 is an optional architecture. If the Microsoft Store ARM64 rollout drifts between probe and download, that run skips the local ARM64 upload and preserves the previous checksum-matching `latest/win-arm64`; it is replaced once a stable ARM64 package is detected.
 
 ## Windows "blocked by your system administrator"
 

--- a/scripts/prepare-release-metadata.sh
+++ b/scripts/prepare-release-metadata.sh
@@ -110,8 +110,10 @@ require python3
 require sha256sum
 
 tmp_manifest="$(mktemp)"
+tmp_previous_manifest="$(mktemp)"
+tmp_previous_checksums="$(mktemp)"
 cleanup() {
-  rm -f "$tmp_manifest"
+  rm -f "$tmp_manifest" "$tmp_previous_manifest" "$tmp_previous_checksums"
 }
 trap cleanup EXIT
 
@@ -179,6 +181,7 @@ windows_artifacts_dir="$artifacts_dir/codex-windows"
 windows_x64_msix="$(find_windows_x64_msix "$windows_artifacts_dir")"
 windows_arm64_msix="$(find_windows_arm64_msix "$windows_artifacts_dir")"
 windows_arm64_downloadable=false
+windows_arm64_local_latest=false
 windows_arm64_missing_reason="${windows_arm64_status:-catalog-only}"
 windows_arm64_app_version=""
 windows_app_version="${WINDOWS_APP_VERSION:-}"
@@ -215,12 +218,63 @@ if [[ "$windows_arm64_probe_downloadable" == "true" && -n "$windows_arm64_packag
     windows_arm64_missing_reason="$windows_arm64_status"
   else
     windows_arm64_downloadable=true
+    windows_arm64_local_latest=true
     windows_arm64_status="${windows_arm64_status:-downloadable}"
     windows_arm64_missing_reason=""
   fi
 fi
+windows_arm64_release_app_version="$windows_arm64_app_version"
 
-codex_version="$(max_nonempty_codex_versions "$windows_app_version" "$windows_arm64_app_version" "$mac_arm_version" "$mac_x64_version")"
+previous_latest_available=false
+previous_windows_arm64_json="null"
+preserved_windows_arm64_checksum_line=""
+preserved_windows_arm64=false
+if [[ "${INHERIT_LATEST_FROM_MIRROR:-false}" == "true" && "$windows_arm64_downloadable" != "true" ]]; then
+  if ! command -v curl >/dev/null 2>&1; then
+    echo "curl is required when INHERIT_LATEST_FROM_MIRROR=true." >&2
+    exit 1
+  fi
+
+  if curl -fsSL --retry 3 --retry-delay 2 --retry-all-errors --connect-timeout 20 --max-time 120 \
+      "$r2_public_base_url/latest/manifest?prepare=$$" > "$tmp_previous_manifest" &&
+     curl -fsSL --retry 3 --retry-delay 2 --retry-all-errors --connect-timeout 20 --max-time 120 \
+      "$r2_public_base_url/latest/checksums?prepare=$$" > "$tmp_previous_checksums"; then
+    previous_latest_available=true
+  else
+    : > "$tmp_previous_manifest"
+    : > "$tmp_previous_checksums"
+  fi
+fi
+
+if [[ "$previous_latest_available" == "true" &&
+      "$windows_arm64_downloadable" != "true" &&
+      "$(jq -r '.sources.windows.architectures.arm64.downloadable // false' "$tmp_previous_manifest")" == "true" ]]; then
+  previous_windows_arm64_package="$(jq -r '.sources.windows.architectures.arm64.packageMoniker // empty' "$tmp_previous_manifest")"
+  if [[ -n "$previous_windows_arm64_package" ]]; then
+    preserved_windows_arm64_checksum_line="$(
+      awk -v name="${previous_windows_arm64_package}.Msix" '
+        $1 ~ /^[0-9a-fA-F]{64}$/ && $2 == name {
+          print tolower($1) "  " $2
+          exit
+        }
+      ' "$tmp_previous_checksums"
+    )"
+  fi
+
+  if [[ -n "$preserved_windows_arm64_checksum_line" ]]; then
+    previous_windows_arm64_json="$(jq -c '.sources.windows.architectures.arm64' "$tmp_previous_manifest")"
+    windows_arm64_downloadable=true
+    windows_arm64_package="$previous_windows_arm64_package"
+    windows_arm64_package_version="$(jq -r '.sources.windows.architectures.arm64.version // empty' "$tmp_previous_manifest")"
+    windows_arm64_status="$(jq -r '.sources.windows.architectures.arm64.status // "downloadable"' "$tmp_previous_manifest")"
+    windows_arm64_app_version="$(jq -r '.sources.windows.architectures.arm64.appVersion // empty' "$tmp_previous_manifest")"
+    windows_arm64_last_modified="$(jq -r '.sources.windows.architectures.arm64.lastModified // empty' "$tmp_previous_manifest")"
+    windows_arm64_missing_reason=""
+    preserved_windows_arm64=true
+  fi
+fi
+
+codex_version="$(max_nonempty_codex_versions "$windows_app_version" "$windows_arm64_release_app_version" "$mac_arm_version" "$mac_x64_version")"
 if [[ -z "$codex_version" ]]; then
   echo "No downloadable package versions were found." >&2
   exit 1
@@ -231,7 +285,9 @@ if [[ "$windows_app_version" == "$codex_version" ]]; then
 else
   include_windows_x64=false
 fi
-if [[ "$windows_arm64_downloadable" == "true" && "$windows_arm64_app_version" == "$codex_version" ]]; then
+if [[ "$windows_arm64_downloadable" == "true" &&
+      ( "$windows_arm64_release_app_version" == "$codex_version" ||
+        ( "$preserved_windows_arm64" == "true" && "$windows_arm64_app_version" == "$codex_version" ) ) ]]; then
   include_windows_arm64=true
 else
   include_windows_arm64=false
@@ -310,6 +366,8 @@ jq \
   --argjson publishLatest "$publish_latest" \
   --argjson syncLatest "$sync_latest" \
   --argjson windowsArm64Downloadable "$windows_arm64_downloadable" \
+  --argjson windowsArm64LocalLatest "$windows_arm64_local_latest" \
+  --argjson previousWindowsArm64 "$previous_windows_arm64_json" \
   --arg windowsArm64Status "$windows_arm64_status" \
   --arg windowsArm64AppVersion "$windows_arm64_app_version" \
   --arg platformCompleteness "$platform_completeness" \
@@ -324,10 +382,18 @@ jq \
   | .sources.windows.architectures.x64.downloadable = true
   | .sources.windows.architectures.x64.status = (.sources.windows.architectures.x64.status // "downloadable")
   | .sources.windows.architectures.x64.currentForCodexVersion = $includeWindowsX64
-  | if .sources.windows.architectures.arm64? != null then
+  | if $previousWindowsArm64 != null then
+      .sources.windows.architectures.arm64 = ($previousWindowsArm64 + {
+        currentForCodexVersion: $includeWindowsArm64,
+        currentLocalArtifact: false,
+        preservedFromLatest: true
+      })
+    elif .sources.windows.architectures.arm64? != null then
       .sources.windows.architectures.arm64.downloadable = $windowsArm64Downloadable
       | .sources.windows.architectures.arm64.status = $windowsArm64Status
       | .sources.windows.architectures.arm64.currentForCodexVersion = $includeWindowsArm64
+      | .sources.windows.architectures.arm64.currentLocalArtifact = $windowsArm64LocalLatest
+      | .sources.windows.architectures.arm64.preservedFromLatest = false
       | if $windowsArm64AppVersion != "" then
           .sources.windows.architectures.arm64.appVersion = $windowsArm64AppVersion
         else
@@ -414,7 +480,9 @@ if [[ "$include_windows_x64" == "true" ]]; then
   windows_selected_files+=("$windows_x64_msix")
 fi
 if [[ "$include_windows_arm64" == "true" ]]; then
-  windows_selected_files+=("$windows_arm64_msix")
+  if [[ "$preserved_windows_arm64" != "true" ]]; then
+    windows_selected_files+=("$windows_arm64_msix")
+  fi
 fi
 
 if [[ "$include_windows" == "true" ]]; then
@@ -426,6 +494,9 @@ if [[ "$include_windows" == "true" ]]; then
     for file in "${windows_selected_files[@]}"; do
       write_checksum "$file"
     done
+    if [[ "$include_windows_arm64" == "true" && "$preserved_windows_arm64" == "true" && -n "$preserved_windows_arm64_checksum_line" ]]; then
+      printf '%s\n' "$preserved_windows_arm64_checksum_line"
+    fi
   } > "$artifacts_dir/codex-windows/SHA256SUMS-windows.txt"
 fi
 
@@ -453,20 +524,6 @@ if [[ "$include_macos" == "true" ]]; then
   } > "$artifacts_dir/codex-macos/SHA256SUMS-macos.txt"
 fi
 
-{
-  if [[ "$include_macos" == "true" ]]; then
-    for file in "${macos_selected_files[@]}" "$artifacts_dir/codex-macos/SHA256SUMS-macos.txt"; do
-      write_checksum "$file"
-    done
-  fi
-  if [[ "$include_windows" == "true" ]]; then
-    for file in "${windows_selected_files[@]}" "$artifacts_dir/codex-windows/SHA256SUMS-windows.txt"; do
-      write_checksum "$file"
-    done
-  fi
-  write_checksum release-manifest.json release-manifest.json
-} > SHA256SUMS.txt
-
 latest_checksum_files=()
 while IFS= read -r file; do
   [[ -n "$file" && -f "$file" ]] || continue
@@ -479,14 +536,72 @@ done < <(macos_arch_files x64 "$artifacts_dir/codex-macos/Codex-mac-x64.dmg" Cod
 if [[ -n "$windows_x64_msix" && -f "$windows_x64_msix" ]]; then
   latest_checksum_files+=("$windows_x64_msix")
 fi
-if [[ "$windows_arm64_downloadable" == "true" && -n "$windows_arm64_msix" && -f "$windows_arm64_msix" ]]; then
+if [[ "$windows_arm64_local_latest" == "true" && -n "$windows_arm64_msix" && -f "$windows_arm64_msix" ]]; then
   latest_checksum_files+=("$windows_arm64_msix")
 fi
+
+tmp_latest_artifact_checksums="$(mktemp)"
+{
+  for file in "${latest_checksum_files[@]}"; do
+    write_checksum "$file"
+  done
+  if [[ -n "$preserved_windows_arm64_checksum_line" ]]; then
+    printf '%s\n' "$preserved_windows_arm64_checksum_line"
+  fi
+} > "$tmp_latest_artifact_checksums"
+
+latest_checksums_json="$(
+  python3 - "$tmp_latest_artifact_checksums" <<'PY'
+import json
+import re
+import sys
+
+checksums = {}
+for line in open(sys.argv[1], encoding="utf-8"):
+    line = line.strip()
+    if not line:
+        continue
+    parts = line.split(None, 1)
+    if len(parts) != 2:
+        continue
+    digest, name = parts
+    if re.fullmatch(r"[0-9a-fA-F]{64}", digest):
+        checksums[name] = digest.lower()
+print(json.dumps(checksums, sort_keys=True, separators=(",", ":")))
+PY
+)"
+rm -f "$tmp_latest_artifact_checksums"
+
+jq --argjson latestChecksums "$latest_checksums_json" \
+  '.derived.latestChecksums = $latestChecksums' \
+  release-manifest.json > "$tmp_manifest"
+mv "$tmp_manifest" release-manifest.json
+
+{
+  if [[ "$include_macos" == "true" ]]; then
+    for file in "${macos_selected_files[@]}" "$artifacts_dir/codex-macos/SHA256SUMS-macos.txt"; do
+      write_checksum "$file"
+    done
+  fi
+  if [[ "$include_windows" == "true" ]]; then
+    for file in "${windows_selected_files[@]}"; do
+      write_checksum "$file"
+    done
+    if [[ "$include_windows_arm64" == "true" && "$preserved_windows_arm64" == "true" && -n "$preserved_windows_arm64_checksum_line" ]]; then
+      printf '%s\n' "$preserved_windows_arm64_checksum_line"
+    fi
+    write_checksum "$artifacts_dir/codex-windows/SHA256SUMS-windows.txt"
+  fi
+  write_checksum release-manifest.json release-manifest.json
+} > SHA256SUMS.txt
 
 {
   for file in "${latest_checksum_files[@]}"; do
     write_checksum "$file"
   done
+  if [[ -n "$preserved_windows_arm64_checksum_line" ]]; then
+    printf '%s\n' "$preserved_windows_arm64_checksum_line"
+  fi
   write_checksum release-manifest.json release-manifest.json
 } > latest-SHA256SUMS.txt
 

--- a/scripts/prepare-release-metadata.sh
+++ b/scripts/prepare-release-metadata.sh
@@ -56,6 +56,24 @@ print(max([left, right], key=key))
 PY
 }
 
+max_nonempty_codex_versions() {
+  local selected=""
+  local version
+
+  for version in "$@"; do
+    if [[ -z "$version" || "$version" == "null" ]]; then
+      continue
+    fi
+    if [[ -z "$selected" ]]; then
+      selected="$version"
+    else
+      selected="$(max_codex_version "$selected" "$version")"
+    fi
+  done
+
+  printf '%s' "$selected"
+}
+
 find_windows_x64_msix() {
   local dir="$1"
 
@@ -157,11 +175,6 @@ if [[ -n "$mac_x64_appcast_build" && "$mac_x64_appcast_build" != "$mac_x64_build
   echo "macOS Intel DMG build differs from appcast; keeping both: appcast=$mac_x64_appcast_build dmg=$mac_x64_build" >&2
 fi
 
-if [[ "$mac_arm_version" != "$mac_x64_version" ]]; then
-  echo "macOS arm64 and Intel resolve to different Codex versions; one canonical release cannot safely contain both yet: arm64=$mac_arm_version x64=$mac_x64_version" >&2
-  exit 1
-fi
-
 windows_artifacts_dir="$artifacts_dir/codex-windows"
 windows_x64_msix="$(find_windows_x64_msix "$windows_artifacts_dir")"
 windows_arm64_msix="$(find_windows_arm64_msix "$windows_artifacts_dir")"
@@ -200,23 +213,46 @@ if [[ "$windows_arm64_probe_downloadable" == "true" && -n "$windows_arm64_packag
   elif [[ -z "$windows_arm64_app_version" ]]; then
     windows_arm64_status="${windows_arm64_status:-skipped-version-unreadable}"
     windows_arm64_missing_reason="$windows_arm64_status"
-  elif [[ "$windows_arm64_app_version" != "$windows_app_version" ]]; then
-    windows_arm64_status="skipped-version-mismatch"
-    windows_arm64_missing_reason="$windows_arm64_status"
   else
     windows_arm64_downloadable=true
     windows_arm64_status="${windows_arm64_status:-downloadable}"
+    windows_arm64_missing_reason=""
   fi
 fi
 
-mac_codex_version="${mac_common_version:-$mac_arm_version}"
-codex_version="$(max_codex_version "$windows_app_version" "$mac_codex_version")"
+codex_version="$(max_nonempty_codex_versions "$windows_app_version" "$windows_arm64_app_version" "$mac_arm_version" "$mac_x64_version")"
+if [[ -z "$codex_version" ]]; then
+  echo "No downloadable package versions were found." >&2
+  exit 1
+fi
+
 if [[ "$windows_app_version" == "$codex_version" ]]; then
+  include_windows_x64=true
+else
+  include_windows_x64=false
+fi
+if [[ "$windows_arm64_downloadable" == "true" && "$windows_arm64_app_version" == "$codex_version" ]]; then
+  include_windows_arm64=true
+else
+  include_windows_arm64=false
+fi
+if [[ "$mac_arm_version" == "$codex_version" ]]; then
+  include_macos_arm64=true
+else
+  include_macos_arm64=false
+fi
+if [[ "$mac_x64_version" == "$codex_version" ]]; then
+  include_macos_x64=true
+else
+  include_macos_x64=false
+fi
+
+if [[ "$include_windows_x64" == "true" || "$include_windows_arm64" == "true" ]]; then
   include_windows=true
 else
   include_windows=false
 fi
-if [[ "$mac_codex_version" == "$codex_version" ]]; then
+if [[ "$include_macos_arm64" == "true" || "$include_macos_x64" == "true" ]]; then
   include_macos=true
 else
   include_macos=false
@@ -227,7 +263,10 @@ if [[ "$include_windows" != "true" && "$include_macos" != "true" ]]; then
   exit 1
 fi
 
-if [[ "$include_windows" == "true" && "$include_macos" == "true" ]]; then
+if [[ "$include_windows_x64" == "true" &&
+      "$include_windows_arm64" == "true" &&
+      "$include_macos_arm64" == "true" &&
+      "$include_macos_x64" == "true" ]]; then
   prerelease=false
   publish_latest=true
   platform_completeness="complete"
@@ -236,6 +275,7 @@ else
   publish_latest=false
   platform_completeness="partial"
 fi
+sync_latest=true
 
 canonical_tag="codex-app-$(sanitize_tag_part "$codex_version")"
 if [[ -n "$release_tag_override" ]]; then
@@ -262,14 +302,19 @@ jq \
   --arg windowsAppVersion "$windows_app_version" \
   --argjson includeWindows "$include_windows" \
   --argjson includeMacos "$include_macos" \
+  --argjson includeWindowsX64 "$include_windows_x64" \
+  --argjson includeWindowsArm64 "$include_windows_arm64" \
+  --argjson includeMacosArm64 "$include_macos_arm64" \
+  --argjson includeMacosX64 "$include_macos_x64" \
   --argjson prerelease "$prerelease" \
   --argjson publishLatest "$publish_latest" \
+  --argjson syncLatest "$sync_latest" \
   --argjson windowsArm64Downloadable "$windows_arm64_downloadable" \
   --arg windowsArm64Status "$windows_arm64_status" \
   --arg windowsArm64AppVersion "$windows_arm64_app_version" \
   --arg platformCompleteness "$platform_completeness" \
   '
-  .schemaVersion = 3
+  .schemaVersion = 4
   | .codexVersion = $codexVersion
   | .publishedAt = $publishedAt
   | .sources.windows.version = $windowsPackageVersion
@@ -278,9 +323,11 @@ jq \
   | .sources.windows.architectures.x64.appVersion = $windowsAppVersion
   | .sources.windows.architectures.x64.downloadable = true
   | .sources.windows.architectures.x64.status = (.sources.windows.architectures.x64.status // "downloadable")
+  | .sources.windows.architectures.x64.currentForCodexVersion = $includeWindowsX64
   | if .sources.windows.architectures.arm64? != null then
       .sources.windows.architectures.arm64.downloadable = $windowsArm64Downloadable
       | .sources.windows.architectures.arm64.status = $windowsArm64Status
+      | .sources.windows.architectures.arm64.currentForCodexVersion = $includeWindowsArm64
       | if $windowsArm64AppVersion != "" then
           .sources.windows.architectures.arm64.appVersion = $windowsArm64AppVersion
         else
@@ -294,35 +341,86 @@ jq \
   | .sources.macos.arm64.bundleIdentifier = $mac[0].macos.arm64.bundleIdentifier
   | .sources.macos.arm64.minimumSystemVersion = $mac[0].macos.arm64.minimumSystemVersion
   | .sources.macos.arm64.sha256 = $mac[0].macos.arm64.sha256
+  | .sources.macos.arm64.downloadable = true
+  | .sources.macos.arm64.status = "downloadable"
+  | .sources.macos.arm64.currentForCodexVersion = $includeMacosArm64
   | .sources.macos.x64.bundleShortVersion = $mac[0].macos.x64.bundleShortVersion
   | .sources.macos.x64.bundleVersion = $mac[0].macos.x64.bundleVersion
   | .sources.macos.x64.bundleIdentifier = $mac[0].macos.x64.bundleIdentifier
   | .sources.macos.x64.minimumSystemVersion = $mac[0].macos.x64.minimumSystemVersion
   | .sources.macos.x64.sha256 = $mac[0].macos.x64.sha256
+  | .sources.macos.x64.downloadable = true
+  | .sources.macos.x64.status = "downloadable"
+  | .sources.macos.x64.currentForCodexVersion = $includeMacosX64
   | .derived = {
       codexVersion: $codexVersion,
       platformCompleteness: $platformCompleteness,
       includeWindows: $includeWindows,
       includeMacos: $includeMacos,
+      includeWindowsX64: $includeWindowsX64,
+      includeWindowsArm64: $includeWindowsArm64,
+      includeMacosArm64: $includeMacosArm64,
+      includeMacosX64: $includeMacosX64,
       prerelease: $prerelease,
       publishLatest: $publishLatest,
+      syncLatest: $syncLatest,
       windowsPackageVersion: $windowsPackageVersion,
       windowsAppVersion: $windowsAppVersion,
       windowsArm64AppVersion: $windowsArm64AppVersion,
       macosCommonShortVersion: $mac[0].commonShortVersion,
       macosCommonBundleVersion: $mac[0].commonBundleVersion,
       macosVersionsMatch: $mac[0].versionsMatch,
-      missingPlatforms: ([if $includeWindows then empty else "windows" end, if $includeMacos then empty else "macos" end])
+      missingPlatforms: ([if $includeWindows then empty else "windows" end, if $includeMacos then empty else "macos" end]),
+      missingArchitectures: ([
+        if $includeWindowsX64 then empty else "windows-x64" end,
+        if $includeWindowsArm64 then empty else "windows-arm64" end,
+        if $includeMacosArm64 then empty else "macos-arm64" end,
+        if $includeMacosX64 then empty else "macos-x64" end
+      ])
     }
   ' "$probe_manifest" > "$tmp_manifest"
 mv "$tmp_manifest" release-manifest.json
 
-windows_selected_files=()
-if [[ "$include_windows" == "true" ]]; then
-  windows_selected_files+=("$windows_x64_msix")
-  if [[ "$windows_arm64_downloadable" == "true" && -n "$windows_arm64_msix" ]]; then
-    windows_selected_files+=("$windows_arm64_msix")
+macos_arch_files() {
+  local arch_key="$1"
+  local dmg_path="$2"
+  local zip_prefix="$3"
+  local short_version
+  local basename
+
+  printf '%s\n' "$dmg_path"
+
+  short_version="$(jq -r --arg a "$arch_key" '.sources.macos[$a].appcast.shortVersionString // empty' release-manifest.json)"
+  if [[ -n "$short_version" && "$short_version" != "null" ]]; then
+    printf '%s\n' "$artifacts_dir/codex-macos/${zip_prefix}-${short_version}.zip"
   fi
+
+  while IFS= read -r basename; do
+    [[ -n "$basename" ]] || continue
+    printf '%s\n' "$artifacts_dir/codex-macos/$basename"
+  done < <(jq -r --arg a "$arch_key" '.sources.macos[$a].appcast.deltas[]?.basename // empty' release-manifest.json)
+}
+
+require_selected_file() {
+  local file="$1"
+  if [[ ! -f "$file" ]]; then
+    echo "Selected release file does not exist: $file" >&2
+    exit 1
+  fi
+}
+
+windows_selected_files=()
+if [[ "$include_windows_x64" == "true" ]]; then
+  windows_selected_files+=("$windows_x64_msix")
+fi
+if [[ "$include_windows_arm64" == "true" ]]; then
+  windows_selected_files+=("$windows_arm64_msix")
+fi
+
+if [[ "$include_windows" == "true" ]]; then
+  for file in "${windows_selected_files[@]}"; do
+    require_selected_file "$file"
+  done
 
   {
     for file in "${windows_selected_files[@]}"; do
@@ -331,11 +429,35 @@ if [[ "$include_windows" == "true" ]]; then
   } > "$artifacts_dir/codex-windows/SHA256SUMS-windows.txt"
 fi
 
+macos_selected_files=()
+if [[ "$include_macos_arm64" == "true" ]]; then
+  while IFS= read -r file; do
+    [[ -n "$file" ]] || continue
+    require_selected_file "$file"
+    macos_selected_files+=("$file")
+  done < <(macos_arch_files arm64 "$artifacts_dir/codex-macos/Codex-mac-arm64.dmg" Codex-darwin-arm64)
+fi
+if [[ "$include_macos_x64" == "true" ]]; then
+  while IFS= read -r file; do
+    [[ -n "$file" ]] || continue
+    require_selected_file "$file"
+    macos_selected_files+=("$file")
+  done < <(macos_arch_files x64 "$artifacts_dir/codex-macos/Codex-mac-x64.dmg" Codex-darwin-x64)
+fi
+
+if [[ "$include_macos" == "true" ]]; then
+  {
+    for file in "${macos_selected_files[@]}"; do
+      write_checksum "$file"
+    done
+  } > "$artifacts_dir/codex-macos/SHA256SUMS-macos.txt"
+fi
+
 {
   if [[ "$include_macos" == "true" ]]; then
-    while IFS= read -r -d '' file; do
+    for file in "${macos_selected_files[@]}" "$artifacts_dir/codex-macos/SHA256SUMS-macos.txt"; do
       write_checksum "$file"
-    done < <(find "$artifacts_dir/codex-macos" -type f ! -name macos-metadata.json -print0 | sort -z)
+    done
   fi
   if [[ "$include_windows" == "true" ]]; then
     for file in "${windows_selected_files[@]}" "$artifacts_dir/codex-windows/SHA256SUMS-windows.txt"; do
@@ -344,6 +466,29 @@ fi
   fi
   write_checksum release-manifest.json release-manifest.json
 } > SHA256SUMS.txt
+
+latest_checksum_files=()
+while IFS= read -r file; do
+  [[ -n "$file" && -f "$file" ]] || continue
+  latest_checksum_files+=("$file")
+done < <(macos_arch_files arm64 "$artifacts_dir/codex-macos/Codex-mac-arm64.dmg" Codex-darwin-arm64)
+while IFS= read -r file; do
+  [[ -n "$file" && -f "$file" ]] || continue
+  latest_checksum_files+=("$file")
+done < <(macos_arch_files x64 "$artifacts_dir/codex-macos/Codex-mac-x64.dmg" Codex-darwin-x64)
+if [[ -n "$windows_x64_msix" && -f "$windows_x64_msix" ]]; then
+  latest_checksum_files+=("$windows_x64_msix")
+fi
+if [[ "$windows_arm64_downloadable" == "true" && -n "$windows_arm64_msix" && -f "$windows_arm64_msix" ]]; then
+  latest_checksum_files+=("$windows_arm64_msix")
+fi
+
+{
+  for file in "${latest_checksum_files[@]}"; do
+    write_checksum "$file"
+  done
+  write_checksum release-manifest.json release-manifest.json
+} > latest-SHA256SUMS.txt
 
 {
   echo "<!-- release-banner:start -->"
@@ -360,57 +505,71 @@ fi
   echo
   echo "## 下载"
   echo
-  if [[ "$include_windows" == "true" ]]; then
+  if [[ "$include_windows_x64" == "true" ]]; then
     echo "- Windows x64: \`${windows_package}.Msix\`"
-    if [[ "$windows_arm64_downloadable" == "true" && -n "$windows_arm64_package" ]]; then
-      echo "- Windows ARM64: \`${windows_arm64_package}.Msix\`"
+  else
+    echo "- Windows x64: 待官方发布 Codex \`${codex_version}\` 对应 MSIX（当前 latest 保持 \`${windows_app_version}\`）"
+  fi
+  if [[ "$include_windows_arm64" == "true" && -n "$windows_arm64_package" ]]; then
+    echo "- Windows ARM64: \`${windows_arm64_package}.Msix\`"
+  elif [[ -n "$windows_arm64_package" ]]; then
+    if [[ "$windows_arm64_downloadable" == "true" && -n "$windows_arm64_app_version" ]]; then
+      echo "- Windows ARM64: 待官方发布 Codex \`${codex_version}\` 对应 MSIX（当前 latest 保持 \`${windows_arm64_app_version}\`）"
+    else
+      echo "- Windows ARM64: 待官方发布 Codex \`${codex_version}\` 对应可下载 MSIX（\`${windows_arm64_status:-catalog-only}\`）"
     fi
   else
-    echo "- Windows: 待官方发布 Codex \`${codex_version}\` 对应 MSIX"
+    echo "- Windows ARM64: 待官方发布 Codex \`${codex_version}\` 对应 MSIX"
   fi
-  if [[ "$include_macos" == "true" ]]; then
+  if [[ "$include_macos_arm64" == "true" ]]; then
     echo "- macOS Apple Silicon: \`Codex-mac-arm64.dmg\`"
+  else
+    echo "- macOS Apple Silicon: 待官方发布 Codex \`${codex_version}\` 对应 DMG（当前 latest 保持 \`${mac_arm_version}\`）"
+  fi
+  if [[ "$include_macos_x64" == "true" ]]; then
     echo "- macOS Intel: \`Codex-mac-x64.dmg\`"
   else
-    echo "- macOS: 待官方发布 Codex \`${codex_version}\` 对应 DMG"
+    echo "- macOS Intel: 待官方发布 Codex \`${codex_version}\` 对应 DMG（当前 latest 保持 \`${mac_x64_version}\`）"
   fi
   echo
   echo "## 版本与发布时间"
   echo
   echo "| 平台 | Codex 版本 | 平台包 / build | 官方发布时间 | 镜像发布时间 | 状态 |"
   echo "|---|---:|---:|---|---|---|"
-  if [[ "$include_windows" == "true" ]]; then
+  if [[ "$include_windows_x64" == "true" ]]; then
     echo "| Windows x64 | \`${windows_app_version}\` | \`${windows_package_version}\` | $(table_cell "$windows_x64_last_modified") | ${published_at_label} | 已发布 |"
-    if [[ -n "$windows_arm64_package" ]]; then
-      if [[ "$windows_arm64_downloadable" == "true" ]]; then
-        echo "| Windows ARM64 | \`${windows_app_version}\` | \`${windows_arm64_package_version:-$windows_package_version}\` | $(table_cell "$windows_arm64_last_modified") | ${published_at_label} | 已发布 |"
-      elif [[ "$windows_arm64_missing_reason" == "skipped-rollout-drift" ]]; then
-        echo "| Windows ARM64 | \`${windows_app_version}\` | \`${windows_arm64_package_version:-$windows_package_version}\` |  |  | 下载阶段上游版本漂移，待下次探测补齐（\`${windows_arm64_status}\`） |"
-      elif [[ "$windows_arm64_missing_reason" == "skipped-version-mismatch" ]]; then
-        echo "| Windows ARM64 | \`${windows_arm64_app_version}\` | \`${windows_arm64_package_version:-$windows_package_version}\` |  |  | 内部版本与 Windows x64 \`${windows_app_version}\` 不一致，待下次探测补齐（\`${windows_arm64_status}\`） |"
-      elif [[ "$windows_arm64_missing_reason" == "skipped-version-unreadable" ]]; then
-        echo "| Windows ARM64 |  | \`${windows_arm64_package_version:-$windows_package_version}\` |  |  | 无法读取内部版本，待下次探测补齐（\`${windows_arm64_status}\`） |"
-      else
-        echo "| Windows ARM64 | \`${windows_app_version}\` | \`${windows_arm64_package_version:-$windows_package_version}\` |  |  | Microsoft Store 目录已出现，下载 URL 待解析（\`${windows_arm64_status:-catalog-only}\`） |"
-      fi
+  else
+    echo "| Windows x64 | \`${windows_app_version}\` | \`${windows_package_version}\` | $(table_cell "$windows_x64_last_modified") |  | 当前 latest，待目标版本 |"
+  fi
+  if [[ "$include_windows_arm64" == "true" ]]; then
+    echo "| Windows ARM64 | \`${windows_arm64_app_version}\` | \`${windows_arm64_package_version:-$windows_package_version}\` | $(table_cell "$windows_arm64_last_modified") | ${published_at_label} | 已发布 |"
+  elif [[ -n "$windows_arm64_package" ]]; then
+    if [[ "$windows_arm64_downloadable" == "true" ]]; then
+      echo "| Windows ARM64 | \`${windows_arm64_app_version}\` | \`${windows_arm64_package_version:-$windows_package_version}\` | $(table_cell "$windows_arm64_last_modified") |  | 当前 latest，待目标版本 |"
+    elif [[ "$windows_arm64_missing_reason" == "skipped-rollout-drift" ]]; then
+      echo "| Windows ARM64 |  | \`${windows_arm64_package_version:-$windows_package_version}\` |  |  | 下载阶段上游版本漂移，待下次探测补齐（\`${windows_arm64_status}\`） |"
+    elif [[ "$windows_arm64_missing_reason" == "skipped-version-unreadable" ]]; then
+      echo "| Windows ARM64 |  | \`${windows_arm64_package_version:-$windows_package_version}\` |  |  | 无法读取内部版本，待下次探测补齐（\`${windows_arm64_status}\`） |"
+    else
+      echo "| Windows ARM64 |  | \`${windows_arm64_package_version:-$windows_package_version}\` |  |  | Microsoft Store 目录已出现，下载 URL 待解析（\`${windows_arm64_status:-catalog-only}\`） |"
     fi
   else
-    echo "| Windows x64 |  |  |  |  | 待官方发布对应版本 |"
-    if [[ -n "$windows_arm64_package" ]]; then
-      echo "| Windows ARM64 |  |  |  |  | 待官方发布对应版本 |"
-    fi
+    echo "| Windows ARM64 |  |  |  |  | 待官方发布对应版本 |"
   fi
-  if [[ "$include_macos" == "true" ]]; then
+  if [[ "$include_macos_arm64" == "true" ]]; then
     echo "| macOS Apple Silicon | \`${mac_arm_version}\` | build \`${mac_arm_build}\` | $(table_cell "$mac_arm_pub_date") | ${published_at_label} | 已发布 |"
+  else
+    echo "| macOS Apple Silicon | \`${mac_arm_version}\` | build \`${mac_arm_build}\` | $(table_cell "$mac_arm_pub_date") |  | 当前 latest，待目标版本 |"
+  fi
+  if [[ "$include_macos_x64" == "true" ]]; then
     echo "| macOS Intel | \`${mac_x64_version}\` | build \`${mac_x64_build}\` | $(table_cell "$mac_x64_pub_date") | ${published_at_label} | 已发布 |"
   else
-    echo "| macOS Apple Silicon |  |  |  |  | 待官方发布对应版本 |"
-    echo "| macOS Intel |  |  |  |  | 待官方发布对应版本 |"
+    echo "| macOS Intel | \`${mac_x64_version}\` | build \`${mac_x64_build}\` | $(table_cell "$mac_x64_pub_date") |  | 当前 latest，待目标版本 |"
   fi
   echo
   echo "本仓库以 Codex 内部版本聚合平台安装包；Windows MSIX 的四段包版本会单独列在“平台包 / build”列。"
   echo
-  if [[ "$publish_latest" == "true" ]]; then
+  if [[ "$sync_latest" == "true" ]]; then
     echo "<!-- latest-links-cn:start -->"
     echo "## 最新版快速下载"
     echo
@@ -424,10 +583,8 @@ fi
     echo "- 校验和: ${r2_public_base_url}/latest/checksums"
     echo "- Manifest: ${r2_public_base_url}/latest/manifest"
     echo
-    echo "这些链接始终指向当前最新完整镜像版本。如果你正在查看历史 Release，请优先使用该 Release 页面中的附件。"
+    echo "这些 latest 链接按架构滚动：某个架构一旦同步到新版本，该架构用户就能收到；尚未发布该版本的架构会继续指向它自己的当前版本。"
     echo "<!-- latest-links-cn:end -->"
-  else
-    echo "此 Release 是平台补齐前的预发布，不会更新 latest 短链；缺失平台发布后将补齐同一个版本并转为正式 Release。"
   fi
   echo
   echo "## 校验"
@@ -454,57 +611,71 @@ fi
   echo
   echo "## Downloads"
   echo
-  if [[ "$include_windows" == "true" ]]; then
+  if [[ "$include_windows_x64" == "true" ]]; then
     echo "- Windows x64: \`${windows_package}.Msix\`"
-    if [[ "$windows_arm64_downloadable" == "true" && -n "$windows_arm64_package" ]]; then
-      echo "- Windows ARM64: \`${windows_arm64_package}.Msix\`"
+  else
+    echo "- Windows x64: waiting for the official MSIX for Codex \`${codex_version}\` (current latest stays on \`${windows_app_version}\`)"
+  fi
+  if [[ "$include_windows_arm64" == "true" && -n "$windows_arm64_package" ]]; then
+    echo "- Windows ARM64: \`${windows_arm64_package}.Msix\`"
+  elif [[ -n "$windows_arm64_package" ]]; then
+    if [[ "$windows_arm64_downloadable" == "true" && -n "$windows_arm64_app_version" ]]; then
+      echo "- Windows ARM64: waiting for the official MSIX for Codex \`${codex_version}\` (current latest stays on \`${windows_arm64_app_version}\`)"
+    else
+      echo "- Windows ARM64: waiting for a downloadable official MSIX for Codex \`${codex_version}\` (\`${windows_arm64_status:-catalog-only}\`)"
     fi
   else
-    echo "- Windows: waiting for the official MSIX for Codex \`${codex_version}\`"
+    echo "- Windows ARM64: waiting for the official MSIX for Codex \`${codex_version}\`"
   fi
-  if [[ "$include_macos" == "true" ]]; then
+  if [[ "$include_macos_arm64" == "true" ]]; then
     echo "- macOS Apple Silicon: \`Codex-mac-arm64.dmg\`"
+  else
+    echo "- macOS Apple Silicon: waiting for the official DMG for Codex \`${codex_version}\` (current latest stays on \`${mac_arm_version}\`)"
+  fi
+  if [[ "$include_macos_x64" == "true" ]]; then
     echo "- macOS Intel: \`Codex-mac-x64.dmg\`"
   else
-    echo "- macOS: waiting for the official DMG for Codex \`${codex_version}\`"
+    echo "- macOS Intel: waiting for the official DMG for Codex \`${codex_version}\` (current latest stays on \`${mac_x64_version}\`)"
   fi
   echo
   echo "## Versions and publish times"
   echo
   echo "| Platform | Codex version | Platform package / build | Official publish time | Mirror publish time | Status |"
   echo "|---|---:|---:|---|---|---|"
-  if [[ "$include_windows" == "true" ]]; then
+  if [[ "$include_windows_x64" == "true" ]]; then
     echo "| Windows x64 | \`${windows_app_version}\` | \`${windows_package_version}\` | $(table_cell "$windows_x64_last_modified") | ${published_at_label} | Published |"
-    if [[ -n "$windows_arm64_package" ]]; then
-      if [[ "$windows_arm64_downloadable" == "true" ]]; then
-        echo "| Windows ARM64 | \`${windows_app_version}\` | \`${windows_arm64_package_version:-$windows_package_version}\` | $(table_cell "$windows_arm64_last_modified") | ${published_at_label} | Published |"
-      elif [[ "$windows_arm64_missing_reason" == "skipped-rollout-drift" ]]; then
-        echo "| Windows ARM64 | \`${windows_app_version}\` | \`${windows_arm64_package_version:-$windows_package_version}\` |  |  | Upstream version drifted during download; will be completed on the next probe (\`${windows_arm64_status}\`) |"
-      elif [[ "$windows_arm64_missing_reason" == "skipped-version-mismatch" ]]; then
-        echo "| Windows ARM64 | \`${windows_arm64_app_version}\` | \`${windows_arm64_package_version:-$windows_package_version}\` |  |  | Internal version differs from Windows x64 \`${windows_app_version}\`; will be completed on the next probe (\`${windows_arm64_status}\`) |"
-      elif [[ "$windows_arm64_missing_reason" == "skipped-version-unreadable" ]]; then
-        echo "| Windows ARM64 |  | \`${windows_arm64_package_version:-$windows_package_version}\` |  |  | Could not read internal version; will be completed on the next probe (\`${windows_arm64_status}\`) |"
-      else
-        echo "| Windows ARM64 | \`${windows_app_version}\` | \`${windows_arm64_package_version:-$windows_package_version}\` |  |  | Present in Microsoft Store catalog, download URL unresolved (\`${windows_arm64_status:-catalog-only}\`) |"
-      fi
+  else
+    echo "| Windows x64 | \`${windows_app_version}\` | \`${windows_package_version}\` | $(table_cell "$windows_x64_last_modified") |  | Current latest, waiting for target version |"
+  fi
+  if [[ "$include_windows_arm64" == "true" ]]; then
+    echo "| Windows ARM64 | \`${windows_arm64_app_version}\` | \`${windows_arm64_package_version:-$windows_package_version}\` | $(table_cell "$windows_arm64_last_modified") | ${published_at_label} | Published |"
+  elif [[ -n "$windows_arm64_package" ]]; then
+    if [[ "$windows_arm64_downloadable" == "true" ]]; then
+      echo "| Windows ARM64 | \`${windows_arm64_app_version}\` | \`${windows_arm64_package_version:-$windows_package_version}\` | $(table_cell "$windows_arm64_last_modified") |  | Current latest, waiting for target version |"
+    elif [[ "$windows_arm64_missing_reason" == "skipped-rollout-drift" ]]; then
+      echo "| Windows ARM64 |  | \`${windows_arm64_package_version:-$windows_package_version}\` |  |  | Upstream version drifted during download; will be retried on the next probe (\`${windows_arm64_status}\`) |"
+    elif [[ "$windows_arm64_missing_reason" == "skipped-version-unreadable" ]]; then
+      echo "| Windows ARM64 |  | \`${windows_arm64_package_version:-$windows_package_version}\` |  |  | Could not read internal version; will be retried on the next probe (\`${windows_arm64_status}\`) |"
+    else
+      echo "| Windows ARM64 |  | \`${windows_arm64_package_version:-$windows_package_version}\` |  |  | Present in Microsoft Store catalog, download URL unresolved (\`${windows_arm64_status:-catalog-only}\`) |"
     fi
   else
-    echo "| Windows x64 |  |  |  |  | Waiting for matching upstream package |"
-    if [[ -n "$windows_arm64_package" ]]; then
-      echo "| Windows ARM64 |  |  |  |  | Waiting for matching upstream package |"
-    fi
+    echo "| Windows ARM64 |  |  |  |  | Waiting for matching upstream package |"
   fi
-  if [[ "$include_macos" == "true" ]]; then
+  if [[ "$include_macos_arm64" == "true" ]]; then
     echo "| macOS Apple Silicon | \`${mac_arm_version}\` | build \`${mac_arm_build}\` | $(table_cell "$mac_arm_pub_date") | ${published_at_label} | Published |"
+  else
+    echo "| macOS Apple Silicon | \`${mac_arm_version}\` | build \`${mac_arm_build}\` | $(table_cell "$mac_arm_pub_date") |  | Current latest, waiting for target version |"
+  fi
+  if [[ "$include_macos_x64" == "true" ]]; then
     echo "| macOS Intel | \`${mac_x64_version}\` | build \`${mac_x64_build}\` | $(table_cell "$mac_x64_pub_date") | ${published_at_label} | Published |"
   else
-    echo "| macOS Apple Silicon |  |  |  |  | Waiting for matching upstream package |"
-    echo "| macOS Intel |  |  |  |  | Waiting for matching upstream package |"
+    echo "| macOS Intel | \`${mac_x64_version}\` | build \`${mac_x64_build}\` | $(table_cell "$mac_x64_pub_date") |  | Current latest, waiting for target version |"
   fi
   echo
   echo "This mirror groups platform installers by the Codex app's internal version; the four-part Windows MSIX package version is listed separately in the platform package / build column."
   echo
-  if [[ "$publish_latest" == "true" ]]; then
+  if [[ "$sync_latest" == "true" ]]; then
     echo "<!-- latest-links-en:start -->"
     echo "## Latest quick downloads"
     echo
@@ -518,10 +689,8 @@ fi
     echo "- Checksums: ${r2_public_base_url}/latest/checksums"
     echo "- Manifest: ${r2_public_base_url}/latest/manifest"
     echo
-    echo "These links always point to the newest complete mirrored version. If you are viewing a historical Release, prefer the assets attached to that Release page."
+    echo "These latest links roll forward per architecture: once an architecture is mirrored, users on that architecture can receive it immediately; architectures not yet published for this Codex version continue to point at their own current latest package."
     echo "<!-- latest-links-en:end -->"
-  else
-    echo "This is a prerelease while platform coverage is incomplete. It does not update latest quick links; when the missing platform ships, this same version will be completed and promoted to a regular Release."
   fi
   echo
   echo "## Verification"
@@ -544,8 +713,13 @@ if [[ -n "${GITHUB_OUTPUT:-}" ]]; then
     github_output_value "codex_version" "$codex_version"
     github_output_value "include_windows" "$include_windows"
     github_output_value "include_macos" "$include_macos"
+    github_output_value "include_windows_x64" "$include_windows_x64"
+    github_output_value "include_windows_arm64" "$include_windows_arm64"
+    github_output_value "include_macos_arm64" "$include_macos_arm64"
+    github_output_value "include_macos_x64" "$include_macos_x64"
     github_output_value "prerelease" "$prerelease"
     github_output_value "publish_latest" "$publish_latest"
+    github_output_value "sync_latest" "$sync_latest"
     github_output_value "platform_completeness" "$platform_completeness"
   } >> "$GITHUB_OUTPUT"
 fi
@@ -555,6 +729,11 @@ echo "title=$title"
 echo "codex_version=$codex_version"
 echo "include_windows=$include_windows"
 echo "include_macos=$include_macos"
+echo "include_windows_x64=$include_windows_x64"
+echo "include_windows_arm64=$include_windows_arm64"
+echo "include_macos_arm64=$include_macos_arm64"
+echo "include_macos_x64=$include_macos_x64"
 echo "prerelease=$prerelease"
 echo "publish_latest=$publish_latest"
+echo "sync_latest=$sync_latest"
 echo "platform_completeness=$platform_completeness"

--- a/scripts/probe-release.sh
+++ b/scripts/probe-release.sh
@@ -414,24 +414,53 @@ manifest_key() {
   }' "$1"
 }
 
+public_mirror_current_latest_view() {
+  local manifest="$1"
+  local live_manifest="$2"
+  local output="$3"
+
+  jq '
+    . as $current
+    | input as $live
+    | if
+        (($live.sources.windows.architectures.arm64.preservedFromLatest // false) == true)
+        and (($current.sources.windows.architectures.arm64.downloadable // false) != true)
+      then
+        $current
+        | .sources.windows.architectures.arm64 = $live.sources.windows.architectures.arm64
+      else
+        $current
+      end
+  ' "$manifest" "$live_manifest" > "$output"
+}
+
 public_mirror_manifest_key_matches() {
   local manifest="$1"
+  local dir
   local live_manifest
+  local current_view
   local current_key
   local live_key
 
-  live_manifest="$(mktemp)"
+  dir="$(mktemp -d)"
+  live_manifest="$dir/live-manifest.json"
+  current_view="$dir/current-latest-view.json"
   if ! curl_get "public mirror manifest" "$r2_public_base_url/latest/manifest?probe=$$" > "$live_manifest"; then
-    rm -f "$live_manifest"
+    rm -rf "$dir"
     return 1
   fi
 
-  if ! current_key="$(manifest_key "$manifest")" || ! live_key="$(manifest_key "$live_manifest")"; then
-    rm -f "$live_manifest"
+  if ! public_mirror_current_latest_view "$manifest" "$live_manifest" "$current_view"; then
+    rm -rf "$dir"
     return 1
   fi
 
-  rm -f "$live_manifest"
+  if ! current_key="$(manifest_key "$current_view")" || ! live_key="$(manifest_key "$live_manifest")"; then
+    rm -rf "$dir"
+    return 1
+  fi
+
+  rm -rf "$dir"
   [[ "$current_key" == "$live_key" ]]
 }
 
@@ -500,39 +529,139 @@ public_mirror_object_size_matches() {
 public_mirror_checksums_match() {
   local manifest="$1"
   local dir
-  local expected_name
+  local live_manifest
 
   dir="$(mktemp -d)"
+  live_manifest="$dir/live-manifest.json"
+  if ! curl_get "public mirror manifest" "$r2_public_base_url/latest/manifest?probe=$$" > "$live_manifest"; then
+    rm -rf "$dir"
+    return 1
+  fi
   if ! curl_get "public mirror checksums" "$r2_public_base_url/latest/checksums?probe=$$" > "$dir/live-SHA256SUMS.txt"; then
     rm -rf "$dir"
     return 1
   fi
 
-  while IFS= read -r expected_name; do
-    [[ -n "$expected_name" ]] || continue
-    if ! grep -F "  $expected_name" "$dir/live-SHA256SUMS.txt" >/dev/null; then
-      rm -rf "$dir"
-      return 1
-    fi
-  done < <(
-    jq -r '
-      "release-manifest.json",
-      ((.sources.windows.architectures.x64.packageMoniker // .sources.windows.packageMoniker // empty) + ".Msix"),
-      (if .sources.windows.architectures.arm64.downloadable == true
-        then ((.sources.windows.architectures.arm64.packageMoniker // empty) + ".Msix")
-        else empty
-      end),
-      "Codex-mac-arm64.dmg",
-      "Codex-mac-x64.dmg",
-      ("Codex-darwin-arm64-" + (.sources.macos.arm64.appcast.shortVersionString // empty) + ".zip"),
-      ("Codex-darwin-x64-" + (.sources.macos.x64.appcast.shortVersionString // empty) + ".zip"),
-      (.sources.macos.arm64.appcast.deltas[]?.basename // empty),
-      (.sources.macos.x64.appcast.deltas[]?.basename // empty)
-    ' "$manifest"
-  )
+  if ! jq -e '.derived.latestChecksums | type == "object" and length > 0' "$live_manifest" >/dev/null; then
+    rm -rf "$dir"
+    return 1
+  fi
+
+  if ! jq -r '
+    .derived.latestChecksums
+    | to_entries[]
+    | ((.value | ascii_downcase) + "  " + .key)
+  ' "$live_manifest" | LC_ALL=C sort > "$dir/expected-SHA256SUMS.txt"; then
+    rm -rf "$dir"
+    return 1
+  fi
+  live_manifest_sha="$(sha256sum "$live_manifest" | awk '{print tolower($1)}')"
+  if ! grep -F -q "  release-manifest.json" "$dir/expected-SHA256SUMS.txt"; then
+    printf '%s  release-manifest.json\n' "$live_manifest_sha" >> "$dir/expected-SHA256SUMS.txt"
+  elif ! awk -v expected="$live_manifest_sha" '
+    $2 == "release-manifest.json" && tolower($1) != expected { exit 1 }
+  ' "$dir/expected-SHA256SUMS.txt"; then
+    rm -rf "$dir"
+    return 1
+  fi
+  LC_ALL=C sort -o "$dir/expected-SHA256SUMS.txt" "$dir/expected-SHA256SUMS.txt"
+
+  if ! awk '
+    NF == 0 { next }
+    {
+      digest = $1
+      name = $0
+      sub(/^[^[:space:]]+[[:space:]]+/, "", name)
+      if (digest !~ /^[0-9A-Fa-f]{64}$/ || name == "") {
+        exit 1
+      }
+      print tolower(digest) "  " name
+    }
+  ' "$dir/live-SHA256SUMS.txt" | LC_ALL=C sort > "$dir/actual-SHA256SUMS.txt"; then
+    rm -rf "$dir"
+    return 1
+  fi
+
+  if ! cmp -s "$dir/expected-SHA256SUMS.txt" "$dir/actual-SHA256SUMS.txt"; then
+    rm -rf "$dir"
+    return 1
+  fi
 
   rm -rf "$dir"
   return 0
+}
+
+public_mirror_objects_match() {
+  local manifest="$1"
+  local dir
+  local live_manifest
+  local current_view
+  local arm_short_version
+  local x64_short_version
+
+  dir="$(mktemp -d)"
+  live_manifest="$dir/live-manifest.json"
+  current_view="$dir/current-latest-view.json"
+  if ! curl_get "public mirror manifest" "$r2_public_base_url/latest/manifest?probe=$$" > "$live_manifest"; then
+    rm -rf "$dir"
+    return 1
+  fi
+  if ! public_mirror_current_latest_view "$manifest" "$live_manifest" "$current_view"; then
+    rm -rf "$dir"
+    return 1
+  fi
+
+  manifest="$current_view"
+  arm_short_version="$(jq -r '.sources.macos.arm64.appcast.shortVersionString // ""' "$manifest")"
+  x64_short_version="$(jq -r '.sources.macos.x64.appcast.shortVersionString // ""' "$manifest")"
+
+  if [[ -z "$arm_short_version" || -z "$x64_short_version" ]]; then
+    rm -rf "$dir"
+    return 1
+  fi
+
+  if public_mirror_object_size_matches \
+      "public mirror Windows alias" \
+      "latest/win" \
+      "$(jq -r '.sources.windows.contentLength // 0' "$manifest")" &&
+    public_mirror_object_size_matches \
+      "public mirror Windows x64 alias" \
+      "latest/win-x64" \
+      "$(jq -r '.sources.windows.architectures.x64.contentLength // .sources.windows.contentLength // 0' "$manifest")" &&
+    {
+      if jq -e '.sources.windows.architectures.arm64.downloadable == true' "$manifest" >/dev/null; then
+        public_mirror_object_size_matches \
+          "public mirror Windows arm64 alias" \
+          "latest/win-arm64" \
+          "$(jq -r '.sources.windows.architectures.arm64.contentLength // 0' "$manifest")"
+      else
+        true
+      fi
+    } &&
+    public_mirror_object_size_matches \
+      "public mirror macOS arm64 DMG alias" \
+      "latest/mac-arm64" \
+      "$(jq -r '.sources.macos.arm64.contentLength // 0' "$manifest")" &&
+    public_mirror_object_size_matches \
+      "public mirror macOS x64 DMG alias" \
+      "latest/mac-intel" \
+      "$(jq -r '.sources.macos.x64.contentLength // 0' "$manifest")" &&
+    public_mirror_object_size_matches \
+      "public mirror macOS arm64 Sparkle archive" \
+      "latest/mac/arm64/Codex-darwin-arm64-${arm_short_version}.zip" \
+      "$(jq -r '.sources.macos.arm64.appcast.enclosureLength // 0' "$manifest")" &&
+    public_mirror_object_size_matches \
+      "public mirror macOS x64 Sparkle archive" \
+      "latest/mac/intel/Codex-darwin-x64-${x64_short_version}.zip" \
+      "$(jq -r '.sources.macos.x64.appcast.enclosureLength // 0' "$manifest")" &&
+    public_mirror_delta_objects_match "$manifest" arm64 arm64 &&
+    public_mirror_delta_objects_match "$manifest" x64 intel; then
+    rm -rf "$dir"
+    return 0
+  fi
+
+  rm -rf "$dir"
+  return 1
 }
 
 public_mirror_delta_objects_match() {
@@ -555,52 +684,6 @@ public_mirror_delta_objects_match() {
       | @tsv
     ' "$manifest"
   )
-}
-
-public_mirror_objects_match() {
-  local manifest="$1"
-  local arm_short_version
-  local x64_short_version
-
-  arm_short_version="$(jq -r '.sources.macos.arm64.appcast.shortVersionString // ""' "$manifest")"
-  x64_short_version="$(jq -r '.sources.macos.x64.appcast.shortVersionString // ""' "$manifest")"
-
-  [[ -n "$arm_short_version" && -n "$x64_short_version" ]] || return 1
-
-  public_mirror_object_size_matches \
-    "public mirror Windows alias" \
-    "latest/win" \
-    "$(jq -r '.sources.windows.contentLength // 0' "$manifest")" &&
-  public_mirror_object_size_matches \
-    "public mirror Windows x64 alias" \
-    "latest/win-x64" \
-    "$(jq -r '.sources.windows.architectures.x64.contentLength // .sources.windows.contentLength // 0' "$manifest")" &&
-  if jq -e '.sources.windows.architectures.arm64.downloadable == true' "$manifest" >/dev/null; then
-    public_mirror_object_size_matches \
-      "public mirror Windows arm64 alias" \
-      "latest/win-arm64" \
-      "$(jq -r '.sources.windows.architectures.arm64.contentLength // 0' "$manifest")"
-  else
-    true
-  fi &&
-  public_mirror_object_size_matches \
-    "public mirror macOS arm64 DMG alias" \
-    "latest/mac-arm64" \
-    "$(jq -r '.sources.macos.arm64.contentLength // 0' "$manifest")" &&
-  public_mirror_object_size_matches \
-    "public mirror macOS x64 DMG alias" \
-    "latest/mac-intel" \
-    "$(jq -r '.sources.macos.x64.contentLength // 0' "$manifest")" &&
-  public_mirror_object_size_matches \
-    "public mirror macOS arm64 Sparkle archive" \
-    "latest/mac/arm64/Codex-darwin-arm64-${arm_short_version}.zip" \
-    "$(jq -r '.sources.macos.arm64.appcast.enclosureLength // 0' "$manifest")" &&
-  public_mirror_object_size_matches \
-    "public mirror macOS x64 Sparkle archive" \
-    "latest/mac/intel/Codex-darwin-x64-${x64_short_version}.zip" \
-    "$(jq -r '.sources.macos.x64.appcast.enclosureLength // 0' "$manifest")" &&
-  public_mirror_delta_objects_match "$manifest" arm64 arm64 &&
-  public_mirror_delta_objects_match "$manifest" x64 intel
 }
 
 public_mirror_latest_matches() {

--- a/scripts/probe-release.sh
+++ b/scripts/probe-release.sh
@@ -498,29 +498,41 @@ public_mirror_object_size_matches() {
 }
 
 public_mirror_checksums_match() {
-  local tag="$1"
+  local manifest="$1"
   local dir
-
-  [[ -n "$tag" ]] || return 1
+  local expected_name
 
   dir="$(mktemp -d)"
-  if ! download_release_asset "$tag" SHA256SUMS.txt "$dir" >/dev/null 2>&1; then
-    rm -rf "$dir"
-    return 1
-  fi
-
   if ! curl_get "public mirror checksums" "$r2_public_base_url/latest/checksums?probe=$$" > "$dir/live-SHA256SUMS.txt"; then
     rm -rf "$dir"
     return 1
   fi
 
-  if cmp -s "$dir/SHA256SUMS.txt" "$dir/live-SHA256SUMS.txt"; then
-    rm -rf "$dir"
-    return 0
-  fi
+  while IFS= read -r expected_name; do
+    [[ -n "$expected_name" ]] || continue
+    if ! grep -F "  $expected_name" "$dir/live-SHA256SUMS.txt" >/dev/null; then
+      rm -rf "$dir"
+      return 1
+    fi
+  done < <(
+    jq -r '
+      "release-manifest.json",
+      ((.sources.windows.architectures.x64.packageMoniker // .sources.windows.packageMoniker // empty) + ".Msix"),
+      (if .sources.windows.architectures.arm64.downloadable == true
+        then ((.sources.windows.architectures.arm64.packageMoniker // empty) + ".Msix")
+        else empty
+      end),
+      "Codex-mac-arm64.dmg",
+      "Codex-mac-x64.dmg",
+      ("Codex-darwin-arm64-" + (.sources.macos.arm64.appcast.shortVersionString // empty) + ".zip"),
+      ("Codex-darwin-x64-" + (.sources.macos.x64.appcast.shortVersionString // empty) + ".zip"),
+      (.sources.macos.arm64.appcast.deltas[]?.basename // empty),
+      (.sources.macos.x64.appcast.deltas[]?.basename // empty)
+    ' "$manifest"
+  )
 
   rm -rf "$dir"
-  return 1
+  return 0
 }
 
 public_mirror_delta_objects_match() {
@@ -597,7 +609,7 @@ public_mirror_latest_matches() {
 
   public_mirror_manifest_key_matches "$manifest" &&
     public_mirror_appcasts_match "$manifest" &&
-    public_mirror_checksums_match "$tag" &&
+    public_mirror_checksums_match "$manifest" &&
     public_mirror_objects_match "$manifest"
 }
 
@@ -911,6 +923,9 @@ else
           release_tag_fallback="$latest_tag"
           skip_reason="latest release $latest_tag matches current sources, but public mirror aliases or appcasts are stale; republishing"
         fi
+      elif public_mirror_latest_matches "$manifest_path" "$latest_tag"; then
+        should_release="false"
+        skip_reason="public mirror latest already matches current sources; GitHub latest remains $latest_tag until all architectures are complete"
       fi
     else
       assets_json="$(release_assets_json "$latest_tag")"

--- a/scripts/sync-secondary-s3.sh
+++ b/scripts/sync-secondary-s3.sh
@@ -107,6 +107,42 @@ mac_intel_zip="$7"
 appcast_arm64="$8"
 appcast_x64="$9"
 win_arm64_msix="${10:-}"
+win_arm64_mode="$(
+  python3 - "$manifest" "${win_arm64_msix:+has-arg}" <<'PY'
+import json
+import sys
+
+with open(sys.argv[1], encoding="utf-8") as handle:
+    manifest = json.load(handle)
+has_arg = len(sys.argv) > 2
+
+arm64 = (
+    manifest.get("sources", {})
+    .get("windows", {})
+    .get("architectures", {})
+    .get("arm64", {})
+)
+
+if arm64.get("currentLocalArtifact") is True:
+    mode = "upload"
+elif arm64.get("downloadable") is True:
+    # A preserved ARM64 latest alias is already present on the secondary
+    # bucket. Do not overwrite it with a stale local artifact, and do not
+    # delete it while the manifest still advertises it as downloadable.
+    mode = "keep"
+elif any(key in arm64 for key in ("downloadable", "currentLocalArtifact", "currentForCodexVersion")):
+    mode = "delete"
+else:
+    # Older manifests predate per-architecture current markers; preserve the
+    # legacy positional-argument behavior for those callers.
+    mode = "upload" if has_arg else "keep"
+print(mode)
+PY
+)"
+if [[ "$win_arm64_mode" == "upload" && -z "$win_arm64_msix" ]]; then
+  echo "Manifest marks Windows ARM64 as current, but no ARM64 MSIX was provided." >&2
+  exit 2
+fi
 
 mac_arm64_zip_name="$(basename "$mac_arm64_zip")"
 mac_intel_zip_name="$(basename "$mac_intel_zip")"
@@ -208,12 +244,23 @@ secondary_verify_object_size() {
   echo "Secondary S3 verified $object_path ($actual_size bytes)."
 }
 
+secondary_remove_object() {
+  local object_path="$1"
+
+  echo "Secondary S3 remove: $object_path"
+  aws s3 rm "s3://$SECONDARY_S3_BUCKET/$object_path" \
+    --endpoint-url "$SECONDARY_S3_ENDPOINT" \
+    --region "$region"
+}
+
 secondary_upload_object "$prefix/mac-arm64" "$mac_arm64" Codex-mac-arm64.dmg
 secondary_upload_object "$prefix/mac-intel" "$mac_intel" Codex-mac-intel.dmg
 secondary_upload_object "$prefix/win" "$win_msix" Codex-Windows-x64.msix
 secondary_upload_object "$prefix/win-x64" "$win_msix" Codex-Windows-x64.msix
-if [[ -n "$win_arm64_msix" ]]; then
+if [[ "$win_arm64_mode" == "upload" ]]; then
   secondary_upload_object "$prefix/win-arm64" "$win_arm64_msix" Codex-Windows-arm64.msix
+elif [[ "$win_arm64_mode" == "delete" ]]; then
+  secondary_remove_object "$prefix/win-arm64"
 fi
 
 # Sparkle update archives, keyed to match the appcast enclosure URLs. Upload the

--- a/scripts/test-prepare-release-metadata.sh
+++ b/scripts/test-prepare-release-metadata.sh
@@ -33,6 +33,7 @@ PY
 }
 
 mkdir -p "$tmp_dir/artifacts/codex-macos" "$tmp_dir/artifacts/codex-windows"
+mkdir -p "$tmp_dir/bin"
 
 printf 'arm' > "$tmp_dir/artifacts/codex-macos/Codex-mac-arm64.dmg"
 printf 'x64' > "$tmp_dir/artifacts/codex-macos/Codex-mac-x64.dmg"
@@ -154,6 +155,9 @@ JSON
   test "$(jq -r '.schemaVersion' release-manifest.json)" = "4"
   test "$(jq -r '.derived.missingArchitectures | length' release-manifest.json)" = "0"
   test "$(jq -r '.sources.windows.architectures.arm64.currentForCodexVersion' release-manifest.json)" = "true"
+  test "$(jq -r '.sources.windows.architectures.arm64.currentLocalArtifact' release-manifest.json)" = "true"
+  test "$(jq -r '.derived.latestChecksums["Codex-mac-arm64.dmg"] | test("^[0-9a-f]{64}$")' release-manifest.json)" = "true"
+  test "$(jq -r '.derived.latestChecksums["OpenAI.Codex_1.2.3.4_arm64__2p2nqsd0c76g0.Msix"] | test("^[0-9a-f]{64}$")' release-manifest.json)" = "true"
 
   if grep -F 'artifacts/' SHA256SUMS.txt; then
     echo "SHA256SUMS.txt should use basenames, not CI artifact paths." >&2
@@ -185,6 +189,194 @@ JSON
     fi
   )
 
+  cat > previous-release-manifest.json <<'JSON'
+{
+  "schemaVersion": 4,
+  "sources": {
+    "windows": {
+      "architectures": {
+        "arm64": {
+          "architecture": "arm64",
+          "status": "downloadable",
+          "downloadable": true,
+          "version": "1.2.2.4",
+          "appVersion": "1.2.2",
+          "packageMoniker": "OpenAI.Codex_1.2.2.4_arm64__2p2nqsd0c76g0",
+          "contentLength": 12,
+          "lastModified": "Wed, 10 Jun 2026 00:00:00 GMT"
+        }
+      }
+    }
+  }
+}
+JSON
+  cat > previous-SHA256SUMS.txt <<'SUMS'
+aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa  OpenAI.Codex_1.2.2.4_arm64__2p2nqsd0c76g0.Msix
+SUMS
+  cat > bin/curl <<'CURL'
+#!/usr/bin/env bash
+set -euo pipefail
+
+url="${*: -1}"
+case "$url" in
+  *latest/manifest*)
+    cat ../previous-release-manifest.json
+    ;;
+  *latest/checksums*)
+    cat ../previous-SHA256SUMS.txt
+    ;;
+  *)
+    echo "unexpected curl URL: $url" >&2
+    exit 1
+    ;;
+esac
+CURL
+  chmod +x bin/curl
+  mkdir arm64-drift-preserve
+  (
+    cd arm64-drift-preserve
+    PATH="../bin:$PATH" \
+    INHERIT_LATEST_FROM_MIRROR=true \
+    WINDOWS_APP_VERSION=1.2.3 "$repo_root/scripts/prepare-release-metadata.sh" \
+      ../probe-manifest.json \
+      ../macos-metadata.json \
+      ../artifacts-arm64-drift \
+      https://example.com > output.txt
+
+    grep -F 'include_windows_arm64=false' output.txt
+    grep -F 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa  OpenAI.Codex_1.2.2.4_arm64__2p2nqsd0c76g0.Msix' latest-SHA256SUMS.txt
+    if grep -F 'OpenAI.Codex_1.2.2.4_arm64__2p2nqsd0c76g0.Msix' SHA256SUMS.txt; then
+      echo "Preserved ARM64 package should not appear in this release checksum." >&2
+      exit 1
+    fi
+    test "$(jq -r '.sources.windows.architectures.arm64.downloadable' release-manifest.json)" = "true"
+    test "$(jq -r '.sources.windows.architectures.arm64.appVersion' release-manifest.json)" = "1.2.2"
+    test "$(jq -r '.sources.windows.architectures.arm64.currentForCodexVersion' release-manifest.json)" = "false"
+    test "$(jq -r '.sources.windows.architectures.arm64.currentLocalArtifact' release-manifest.json)" = "false"
+    test "$(jq -r '.sources.windows.architectures.arm64.preservedFromLatest' release-manifest.json)" = "true"
+    test "$(jq -r '.derived.latestChecksums["OpenAI.Codex_1.2.2.4_arm64__2p2nqsd0c76g0.Msix"]' release-manifest.json)" = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+  )
+
+  cp -R artifacts artifacts-arm64-unreadable
+  printf 'not a zip' > artifacts-arm64-unreadable/codex-windows/OpenAI.Codex_1.2.3.4_arm64__2p2nqsd0c76g0.Msix
+  mkdir arm64-unreadable-preserve
+  (
+    cd arm64-unreadable-preserve
+    PATH="../bin:$PATH" \
+    INHERIT_LATEST_FROM_MIRROR=true \
+    WINDOWS_APP_VERSION=1.2.3 "$repo_root/scripts/prepare-release-metadata.sh" \
+      ../probe-manifest.json \
+      ../macos-metadata.json \
+      ../artifacts-arm64-unreadable \
+      https://example.com > output.txt
+
+    grep -F 'tag=codex-app-1.2.3' output.txt
+    grep -F 'include_windows_arm64=false' output.txt
+    grep -F 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa  OpenAI.Codex_1.2.2.4_arm64__2p2nqsd0c76g0.Msix' latest-SHA256SUMS.txt
+    if grep -F 'OpenAI.Codex_1.2.3.4_arm64__2p2nqsd0c76g0.Msix' latest-SHA256SUMS.txt; then
+      echo "Unreadable local ARM64 package should not overwrite preserved latest checksum." >&2
+      exit 1
+    fi
+    test "$(jq -r '.sources.windows.architectures.arm64.appVersion' release-manifest.json)" = "1.2.2"
+    test "$(jq -r '.sources.windows.architectures.arm64.currentForCodexVersion' release-manifest.json)" = "false"
+    test "$(jq -r '.sources.windows.architectures.arm64.currentLocalArtifact' release-manifest.json)" = "false"
+  )
+
+  cat > previous-release-manifest.json <<'JSON'
+{
+  "schemaVersion": 4,
+  "sources": {
+    "windows": {
+      "architectures": {
+        "arm64": {
+          "architecture": "arm64",
+          "status": "downloadable",
+          "downloadable": true,
+          "version": "1.2.3.4",
+          "appVersion": "1.2.3",
+          "packageMoniker": "OpenAI.Codex_1.2.3.4_arm64__2p2nqsd0c76g0",
+          "contentLength": 12,
+          "lastModified": "Wed, 10 Jun 2026 00:00:00 GMT"
+        }
+      }
+    }
+  }
+}
+JSON
+  cat > previous-SHA256SUMS.txt <<'SUMS'
+cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc  OpenAI.Codex_1.2.3.4_arm64__2p2nqsd0c76g0.Msix
+SUMS
+  mkdir arm64-drift-preserve-same-version
+  (
+    cd arm64-drift-preserve-same-version
+    PATH="../bin:$PATH" \
+    INHERIT_LATEST_FROM_MIRROR=true \
+    WINDOWS_APP_VERSION=1.2.3 "$repo_root/scripts/prepare-release-metadata.sh" \
+      ../probe-manifest.json \
+      ../macos-metadata.json \
+      ../artifacts-arm64-drift \
+      https://example.com > output.txt
+
+    grep -F 'include_windows_arm64=true' output.txt
+    grep -F 'publish_latest=true' output.txt
+    grep -F 'cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc  OpenAI.Codex_1.2.3.4_arm64__2p2nqsd0c76g0.Msix' latest-SHA256SUMS.txt
+    grep -F 'cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc  OpenAI.Codex_1.2.3.4_arm64__2p2nqsd0c76g0.Msix' SHA256SUMS.txt
+    grep -F 'cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc  OpenAI.Codex_1.2.3.4_arm64__2p2nqsd0c76g0.Msix' ../artifacts-arm64-drift/codex-windows/SHA256SUMS-windows.txt
+    test "$(jq -r '.derived.platformCompleteness' release-manifest.json)" = "complete"
+    test "$(jq -r '.sources.windows.architectures.arm64.appVersion' release-manifest.json)" = "1.2.3"
+    test "$(jq -r '.sources.windows.architectures.arm64.currentForCodexVersion' release-manifest.json)" = "true"
+    test "$(jq -r '.sources.windows.architectures.arm64.currentLocalArtifact' release-manifest.json)" = "false"
+    test "$(jq -r '.sources.windows.architectures.arm64.preservedFromLatest' release-manifest.json)" = "true"
+    test "$(jq -r '.derived.latestChecksums["OpenAI.Codex_1.2.3.4_arm64__2p2nqsd0c76g0.Msix"]' release-manifest.json)" = "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+  )
+
+  cat > previous-release-manifest.json <<'JSON'
+{
+  "schemaVersion": 4,
+  "sources": {
+    "windows": {
+      "architectures": {
+        "arm64": {
+          "architecture": "arm64",
+          "status": "downloadable",
+          "downloadable": true,
+          "version": "1.2.4.4",
+          "appVersion": "1.2.4",
+          "packageMoniker": "OpenAI.Codex_1.2.4.4_arm64__2p2nqsd0c76g0",
+          "contentLength": 12,
+          "lastModified": "Wed, 10 Jun 2026 00:00:00 GMT"
+        }
+      }
+    }
+  }
+}
+JSON
+  cat > previous-SHA256SUMS.txt <<'SUMS'
+bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb  OpenAI.Codex_1.2.4.4_arm64__2p2nqsd0c76g0.Msix
+SUMS
+  mkdir arm64-preserved-newer-than-target
+  (
+    cd arm64-preserved-newer-than-target
+    PATH="../bin:$PATH" \
+    INHERIT_LATEST_FROM_MIRROR=true \
+    WINDOWS_APP_VERSION=1.2.3 "$repo_root/scripts/prepare-release-metadata.sh" \
+      ../probe-manifest.json \
+      ../macos-metadata.json \
+      ../artifacts-arm64-drift \
+      https://example.com > output.txt
+
+    grep -F 'tag=codex-app-1.2.3' output.txt
+    grep -F 'codex_version=1.2.3' output.txt
+    grep -F 'include_windows_x64=true' output.txt
+    grep -F 'include_windows_arm64=false' output.txt
+    grep -F 'include_macos=true' output.txt
+    grep -F 'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb  OpenAI.Codex_1.2.4.4_arm64__2p2nqsd0c76g0.Msix' latest-SHA256SUMS.txt
+    test "$(jq -r '.sources.windows.architectures.arm64.appVersion' release-manifest.json)" = "1.2.4"
+    test "$(jq -r '.sources.windows.architectures.arm64.currentForCodexVersion' release-manifest.json)" = "false"
+    test "$(jq -r '.sources.windows.architectures.arm64.currentLocalArtifact' release-manifest.json)" = "false"
+    test "$(jq -r '.derived.latestChecksums["OpenAI.Codex_1.2.4.4_arm64__2p2nqsd0c76g0.Msix"]' release-manifest.json)" = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+  )
+
   cp -R artifacts artifacts-arm64-new
   cp minimal-9.8.7.Msix artifacts-arm64-new/codex-windows/OpenAI.Codex_1.2.3.4_arm64__2p2nqsd0c76g0.Msix
   mkdir arm64-newer
@@ -212,6 +404,7 @@ JSON
     test "$(jq -r '.sources.windows.architectures.arm64.status' release-manifest.json)" = "downloadable"
     test "$(jq -r '.sources.windows.architectures.arm64.appVersion' release-manifest.json)" = "9.8.7"
     test "$(jq -r '.sources.windows.architectures.arm64.currentForCodexVersion' release-manifest.json)" = "true"
+    test "$(jq -r '.sources.windows.architectures.arm64.currentLocalArtifact' release-manifest.json)" = "true"
     test "$(jq -r '.sources.windows.architectures.x64.currentForCodexVersion' release-manifest.json)" = "false"
   )
 
@@ -243,6 +436,7 @@ JSON
     grep -F 'Codex-darwin-arm64-1.2.4.zip' SHA256SUMS.txt
     grep -F 'Codex-mac-x64.dmg' latest-SHA256SUMS.txt
     grep -F 'OpenAI.Codex_1.2.3.4_x64__2p2nqsd0c76g0.Msix' latest-SHA256SUMS.txt
+    grep -F 'OpenAI.Codex_1.2.3.4_arm64__2p2nqsd0c76g0.Msix' latest-SHA256SUMS.txt
     if grep -F 'Codex-mac-x64.dmg' SHA256SUMS.txt; then
       echo "macOS x64 should stay out of the target release checksum when only arm64 advanced." >&2
       exit 1
@@ -255,6 +449,8 @@ JSON
     test "$(jq -r '.derived.missingArchitectures | index("macos-x64") != null' release-manifest.json)" = "true"
     test "$(jq -r '.sources.macos.arm64.currentForCodexVersion' release-manifest.json)" = "true"
     test "$(jq -r '.sources.macos.x64.currentForCodexVersion' release-manifest.json)" = "false"
+    test "$(jq -r '.sources.windows.architectures.arm64.currentForCodexVersion' release-manifest.json)" = "false"
+    test "$(jq -r '.sources.windows.architectures.arm64.currentLocalArtifact' release-manifest.json)" = "true"
     grep -F '这些 latest 链接按架构滚动' release-notes.md
   )
 

--- a/scripts/test-prepare-release-metadata.sh
+++ b/scripts/test-prepare-release-metadata.sh
@@ -8,22 +8,19 @@ cleanup() {
 }
 trap cleanup EXIT
 
-mkdir -p "$tmp_dir/artifacts/codex-macos" "$tmp_dir/artifacts/codex-windows"
+write_minimal_msix() {
+  local path="$1"
+  local version="$2"
 
-printf 'arm' > "$tmp_dir/artifacts/codex-macos/Codex-mac-arm64.dmg"
-printf 'x64' > "$tmp_dir/artifacts/codex-macos/Codex-mac-x64.dmg"
-printf 'win' > "$tmp_dir/artifacts/codex-windows/OpenAI.Codex_1.2.3.4_x64__2p2nqsd0c76g0.Msix"
-printf 'macsum' > "$tmp_dir/artifacts/codex-macos/SHA256SUMS-macos.txt"
-printf 'winsum' > "$tmp_dir/artifacts/codex-windows/SHA256SUMS-windows.txt"
-
-python3 - "$tmp_dir/minimal.Msix" <<'PY'
+  python3 - "$path" "$version" <<'PY'
 import json
 import struct
 import sys
 import zipfile
 
 msix_path = sys.argv[1]
-package_json = json.dumps({"version": "9.8.7"}, separators=(",", ":")).encode()
+version = sys.argv[2]
+package_json = json.dumps({"version": version}, separators=(",", ":")).encode()
 header_json = json.dumps(
     {"files": {"package.json": {"size": len(package_json), "offset": "0"}}},
     separators=(",", ":"),
@@ -33,8 +30,21 @@ asar = struct.pack("<IIII", 4, header_size, len(header_json) + 4, len(header_jso
 with zipfile.ZipFile(msix_path, "w") as archive:
     archive.writestr("app/resources/app.asar", asar)
 PY
+}
 
-test "$(python3 "$repo_root/scripts/read-windows-msix-version.py" "$tmp_dir/minimal.Msix")" = "9.8.7"
+mkdir -p "$tmp_dir/artifacts/codex-macos" "$tmp_dir/artifacts/codex-windows"
+
+printf 'arm' > "$tmp_dir/artifacts/codex-macos/Codex-mac-arm64.dmg"
+printf 'x64' > "$tmp_dir/artifacts/codex-macos/Codex-mac-x64.dmg"
+printf 'armzip123' > "$tmp_dir/artifacts/codex-macos/Codex-darwin-arm64-1.2.3.zip"
+printf 'armzip124' > "$tmp_dir/artifacts/codex-macos/Codex-darwin-arm64-1.2.4.zip"
+printf 'x64zip123' > "$tmp_dir/artifacts/codex-macos/Codex-darwin-x64-1.2.3.zip"
+printf 'win' > "$tmp_dir/artifacts/codex-windows/OpenAI.Codex_1.2.3.4_x64__2p2nqsd0c76g0.Msix"
+write_minimal_msix "$tmp_dir/artifacts/codex-windows/OpenAI.Codex_1.2.3.4_arm64__2p2nqsd0c76g0.Msix" 1.2.3
+write_minimal_msix "$tmp_dir/minimal-9.8.7.Msix" 9.8.7
+
+test "$(python3 "$repo_root/scripts/read-windows-msix-version.py" "$tmp_dir/artifacts/codex-windows/OpenAI.Codex_1.2.3.4_arm64__2p2nqsd0c76g0.Msix")" = "1.2.3"
+test "$(python3 "$repo_root/scripts/read-windows-msix-version.py" "$tmp_dir/minimal-9.8.7.Msix")" = "9.8.7"
 
 cat > "$tmp_dir/probe-manifest.json" <<'JSON'
 {
@@ -56,8 +66,8 @@ cat > "$tmp_dir/probe-manifest.json" <<'JSON'
         },
         "arm64": {
           "architecture": "arm64",
-          "status": "catalog-only",
-          "downloadable": false,
+          "status": "downloadable",
+          "downloadable": true,
           "version": "1.2.3.4",
           "packageMoniker": "OpenAI.Codex_1.2.3.4_arm64__2p2nqsd0c76g0",
           "contentLength": 4
@@ -123,89 +133,129 @@ JSON
   grep -F 'codex_version=1.2.3' output.txt
   grep -F 'include_windows=true' output.txt
   grep -F 'include_macos=true' output.txt
+  grep -F 'include_windows_x64=true' output.txt
+  grep -F 'include_windows_arm64=true' output.txt
+  grep -F 'include_macos_arm64=true' output.txt
+  grep -F 'include_macos_x64=true' output.txt
   grep -F 'prerelease=false' output.txt
   grep -F 'publish_latest=true' output.txt
+  grep -F 'sync_latest=true' output.txt
   grep -F 'Codex-mac-arm64.dmg' SHA256SUMS.txt
+  grep -F 'Codex-darwin-x64-1.2.3.zip' SHA256SUMS.txt
   grep -F 'OpenAI.Codex_1.2.3.4_x64__2p2nqsd0c76g0.Msix' SHA256SUMS.txt
+  grep -F 'OpenAI.Codex_1.2.3.4_arm64__2p2nqsd0c76g0.Msix' SHA256SUMS.txt
+  grep -F 'OpenAI.Codex_1.2.3.4_arm64__2p2nqsd0c76g0.Msix' latest-SHA256SUMS.txt
   grep -F '![Codex App Mirror](https://github.com/Wangnov/codex-app-mirror/releases/latest/download/status.png)' release-notes.md
   grep -F '| Windows x64 | `1.2.3` | `1.2.3.4` |' release-notes.md
-  grep -F '| Windows ARM64 | `1.2.3` | `1.2.3.4` |  |  | Microsoft Store 目录已出现，下载 URL 待解析（`catalog-only`） |' release-notes.md
+  grep -F '| Windows ARM64 | `1.2.3` | `1.2.3.4` |' release-notes.md
   grep -F 'Windows x64: https://example.com/latest/win-x64' release-notes.md
   grep -F '| macOS Apple Silicon | `1.2.3` | build `5` |' release-notes.md
-  grep -F 'These links always point to the newest complete mirrored version.' release-notes.md
+  grep -F 'These latest links roll forward per architecture:' release-notes.md
+  test "$(jq -r '.schemaVersion' release-manifest.json)" = "4"
+  test "$(jq -r '.derived.missingArchitectures | length' release-manifest.json)" = "0"
+  test "$(jq -r '.sources.windows.architectures.arm64.currentForCodexVersion' release-manifest.json)" = "true"
 
   if grep -F 'artifacts/' SHA256SUMS.txt; then
     echo "SHA256SUMS.txt should use basenames, not CI artifact paths." >&2
     exit 1
   fi
 
-  jq '
-    .sources.windows.architectures.arm64.downloadable = true
-    | .sources.windows.architectures.arm64.status = "downloadable"
-  ' probe-manifest.json > probe-manifest-arm64-drift.json
+  cp -R artifacts artifacts-arm64-drift
+  rm artifacts-arm64-drift/codex-windows/OpenAI.Codex_1.2.3.4_arm64__2p2nqsd0c76g0.Msix
   mkdir arm64-drift
   (
     cd arm64-drift
     WINDOWS_APP_VERSION=1.2.3 "$repo_root/scripts/prepare-release-metadata.sh" \
-      ../probe-manifest-arm64-drift.json \
+      ../probe-manifest.json \
       ../macos-metadata.json \
-      ../artifacts \
+      ../artifacts-arm64-drift \
       https://example.com > output.txt
 
     grep -F 'include_windows=true' output.txt
-    grep -F 'publish_latest=true' output.txt
+    grep -F 'include_windows_x64=true' output.txt
+    grep -F 'include_windows_arm64=false' output.txt
+    grep -F 'publish_latest=false' output.txt
     grep -F '下载阶段上游版本漂移，待下次探测补齐（`skipped-rollout-drift`）' release-notes.md
-    grep -F 'Upstream version drifted during download; will be completed on the next probe (`skipped-rollout-drift`)' release-notes.md
+    grep -F 'Upstream version drifted during download; will be retried on the next probe (`skipped-rollout-drift`)' release-notes.md
     test "$(jq -r '.sources.windows.architectures.arm64.downloadable' release-manifest.json)" = "false"
     test "$(jq -r '.sources.windows.architectures.arm64.status' release-manifest.json)" = "skipped-rollout-drift"
-  )
-
-  cp -R artifacts artifacts-arm64-mismatch
-  cp minimal.Msix artifacts-arm64-mismatch/codex-windows/OpenAI.Codex_1.2.3.4_arm64__2p2nqsd0c76g0.Msix
-  mkdir arm64-mismatch
-  (
-    cd arm64-mismatch
-    WINDOWS_APP_VERSION=1.2.3 "$repo_root/scripts/prepare-release-metadata.sh" \
-      ../probe-manifest-arm64-drift.json \
-      ../macos-metadata.json \
-      ../artifacts-arm64-mismatch \
-      https://example.com > output.txt
-
-    grep -F 'include_windows=true' output.txt
-    grep -F '内部版本与 Windows x64 `1.2.3` 不一致，待下次探测补齐（`skipped-version-mismatch`）' release-notes.md
-    grep -F 'Internal version differs from Windows x64 `1.2.3`; will be completed on the next probe (`skipped-version-mismatch`)' release-notes.md
-    test "$(jq -r '.sources.windows.architectures.arm64.downloadable' release-manifest.json)" = "false"
-    test "$(jq -r '.sources.windows.architectures.arm64.status' release-manifest.json)" = "skipped-version-mismatch"
-    test "$(jq -r '.sources.windows.architectures.arm64.appVersion' release-manifest.json)" = "9.8.7"
-    if grep -E 'OpenAI\.Codex_.*_arm64__' SHA256SUMS.txt ../artifacts-arm64-mismatch/codex-windows/SHA256SUMS-windows.txt; then
-      echo "Skipped ARM64 package should not appear in checksum files." >&2
+    if grep -E 'OpenAI\.Codex_.*_arm64__' SHA256SUMS.txt ../artifacts-arm64-drift/codex-windows/SHA256SUMS-windows.txt; then
+      echo "Missing ARM64 package should not appear in release checksum files." >&2
       exit 1
     fi
   )
 
-  mkdir partial
+  cp -R artifacts artifacts-arm64-new
+  cp minimal-9.8.7.Msix artifacts-arm64-new/codex-windows/OpenAI.Codex_1.2.3.4_arm64__2p2nqsd0c76g0.Msix
+  mkdir arm64-newer
   (
-    cd partial
-    WINDOWS_APP_VERSION=1.2.2 "$repo_root/scripts/prepare-release-metadata.sh" \
+    cd arm64-newer
+    WINDOWS_APP_VERSION=1.2.3 "$repo_root/scripts/prepare-release-metadata.sh" \
       ../probe-manifest.json \
       ../macos-metadata.json \
+      ../artifacts-arm64-new \
+      https://example.com > output.txt
+
+    grep -F 'tag=codex-app-9.8.7' output.txt
+    grep -F 'include_windows=true' output.txt
+    grep -F 'include_windows_x64=false' output.txt
+    grep -F 'include_windows_arm64=true' output.txt
+    grep -F 'include_macos=false' output.txt
+    grep -F 'publish_latest=false' output.txt
+    grep -F 'OpenAI.Codex_1.2.3.4_arm64__2p2nqsd0c76g0.Msix' SHA256SUMS.txt
+    grep -F 'OpenAI.Codex_1.2.3.4_x64__2p2nqsd0c76g0.Msix' latest-SHA256SUMS.txt
+    if grep -F 'OpenAI.Codex_1.2.3.4_x64__2p2nqsd0c76g0.Msix' SHA256SUMS.txt; then
+      echo "Windows x64 should stay out of the target release checksum when only ARM64 advanced." >&2
+      exit 1
+    fi
+    test "$(jq -r '.sources.windows.architectures.arm64.downloadable' release-manifest.json)" = "true"
+    test "$(jq -r '.sources.windows.architectures.arm64.status' release-manifest.json)" = "downloadable"
+    test "$(jq -r '.sources.windows.architectures.arm64.appVersion' release-manifest.json)" = "9.8.7"
+    test "$(jq -r '.sources.windows.architectures.arm64.currentForCodexVersion' release-manifest.json)" = "true"
+    test "$(jq -r '.sources.windows.architectures.x64.currentForCodexVersion' release-manifest.json)" = "false"
+  )
+
+  jq '.sources.macos.arm64.appcast.shortVersionString = "1.2.4"' \
+    probe-manifest.json > probe-manifest-mac-arm-ahead.json
+  jq '
+    .macos.arm64.bundleShortVersion = "1.2.4"
+    | .commonShortVersion = ""
+    | .versionsMatch = false
+  ' macos-metadata.json > macos-metadata-arm-ahead.json
+  mkdir mac-arm-ahead
+  (
+    cd mac-arm-ahead
+    WINDOWS_APP_VERSION=1.2.3 "$repo_root/scripts/prepare-release-metadata.sh" \
+      ../probe-manifest-mac-arm-ahead.json \
+      ../macos-metadata-arm-ahead.json \
       ../artifacts \
       https://example.com > output.txt
 
-    grep -F 'tag=codex-app-1.2.3' output.txt
+    grep -F 'tag=codex-app-1.2.4' output.txt
     grep -F 'include_windows=false' output.txt
     grep -F 'include_macos=true' output.txt
+    grep -F 'include_macos_arm64=true' output.txt
+    grep -F 'include_macos_x64=false' output.txt
     grep -F 'prerelease=true' output.txt
     grep -F 'publish_latest=false' output.txt
-    grep -F '| Windows x64 |  |  |  |  | 待官方发布对应版本 |' release-notes.md
-    grep -F 'This is a prerelease while platform coverage is incomplete.' release-notes.md
+    grep -F 'sync_latest=true' output.txt
     grep -F 'Codex-mac-arm64.dmg' SHA256SUMS.txt
+    grep -F 'Codex-darwin-arm64-1.2.4.zip' SHA256SUMS.txt
+    grep -F 'Codex-mac-x64.dmg' latest-SHA256SUMS.txt
+    grep -F 'OpenAI.Codex_1.2.3.4_x64__2p2nqsd0c76g0.Msix' latest-SHA256SUMS.txt
+    if grep -F 'Codex-mac-x64.dmg' SHA256SUMS.txt; then
+      echo "macOS x64 should stay out of the target release checksum when only arm64 advanced." >&2
+      exit 1
+    fi
     if grep -F 'OpenAI.Codex_1.2.3.4_x64__2p2nqsd0c76g0.Msix' SHA256SUMS.txt; then
-      echo "Partial macOS-only checksums should not reference Windows assets." >&2
+      echo "Windows x64 should stay out of the target release checksum when only macOS arm64 advanced." >&2
       exit 1
     fi
     test "$(jq -r '.derived.platformCompleteness' release-manifest.json)" = "partial"
-    test "$(jq -r '.derived.missingPlatforms[0]' release-manifest.json)" = "windows"
+    test "$(jq -r '.derived.missingArchitectures | index("macos-x64") != null' release-manifest.json)" = "true"
+    test "$(jq -r '.sources.macos.arm64.currentForCodexVersion' release-manifest.json)" = "true"
+    test "$(jq -r '.sources.macos.x64.currentForCodexVersion' release-manifest.json)" = "false"
+    grep -F '这些 latest 链接按架构滚动' release-notes.md
   )
 
   if WINDOWS_APP_VERSION=1.2.3 "$repo_root/scripts/prepare-release-metadata.sh" \
@@ -219,3 +269,5 @@ JSON
   fi
   grep -F 'Invalid release tag' "$tmp_dir/invalid-tag-output.txt"
 )
+
+echo "prepare-release-metadata fixture test PASS"

--- a/scripts/test-probe-release-preserved-arm64.sh
+++ b/scripts/test-probe-release-preserved-arm64.sh
@@ -1,0 +1,423 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Regression test: after a partial release preserves the old Windows ARM64
+# latest alias, the next probe must not republish the same x64/mac sources just
+# because the live latest manifest intentionally differs from the current ARM64
+# catalog-only state.
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+tmp_dir="$(mktemp -d)"
+cleanup() {
+  rm -rf "$tmp_dir"
+}
+trap cleanup EXIT
+
+mkdir -p "$tmp_dir/bin"
+
+latest_tag="codex-app-1.2.3"
+package="OpenAI.Codex_1.2.3.4_x64__2p2nqsd0c76g0"
+current_arm64_package="OpenAI.Codex_1.2.3.4_arm64__2p2nqsd0c76g0"
+preserved_arm64_package="OpenAI.Codex_1.2.2.4_arm64__2p2nqsd0c76g0"
+gh_log="$tmp_dir/gh.log"
+: > "$gh_log"
+
+cat > "$tmp_dir/latest-release-manifest.json" <<JSON
+{
+  "schemaVersion": 4,
+  "sources": {
+    "windows": {
+      "version": "1.2.3.4",
+      "packageMoniker": "$package",
+      "contentLength": 3,
+      "architectures": {
+        "x64": {
+          "architecture": "x64",
+          "status": "downloadable",
+          "downloadable": true,
+          "version": "1.2.3.4",
+          "packageMoniker": "$package",
+          "contentLength": 3,
+          "catalog": {
+            "packageFullName": "$package",
+            "packageId": "x64-package-id",
+            "contentId": "content-id",
+            "packageFamilyName": "OpenAI.Codex_2p2nqsd0c76g0",
+            "hashAlgorithm": "SHA256",
+            "hash": "x64hash",
+            "contentLength": 3
+          }
+        },
+        "arm64": {
+          "architecture": "arm64",
+          "status": "downloadable",
+          "downloadable": true,
+          "version": "1.2.2.4",
+          "packageMoniker": "$preserved_arm64_package",
+          "contentLength": 3,
+          "currentForCodexVersion": false,
+          "currentLocalArtifact": false,
+          "preservedFromLatest": true,
+          "catalog": {
+            "packageFullName": "$preserved_arm64_package",
+            "packageId": "old-arm64-package-id",
+            "contentId": "old-content-id",
+            "packageFamilyName": "OpenAI.Codex_2p2nqsd0c76g0",
+            "hashAlgorithm": "SHA256",
+            "hash": "oldarm64hash",
+            "contentLength": 3
+          }
+        }
+      }
+    },
+    "macos": {
+      "arm64": {
+        "appcast": {
+          "title": "1.2.3",
+          "pubDate": "Thu, 11 Jun 2026 00:00:00 +0000",
+          "version": "5",
+          "shortVersionString": "1.2.3",
+          "minimumSystemVersion": "12.0",
+          "hardwareRequirements": "arm64",
+          "enclosureUrl": "https://persistent.oaistatic.com/codex-app-prod/Codex-darwin-arm64-1.2.3.zip",
+          "enclosureLength": 3,
+          "enclosureSignature": "arm-signature",
+          "deltas": []
+        },
+        "contentLength": 3,
+        "lastModified": "Thu, 11 Jun 2026 00:00:00 GMT",
+        "etag": "arm-etag"
+      },
+      "x64": {
+        "appcast": {
+          "title": "1.2.3",
+          "pubDate": "Thu, 11 Jun 2026 00:00:00 +0000",
+          "version": "5",
+          "shortVersionString": "1.2.3",
+          "minimumSystemVersion": "12.0",
+          "hardwareRequirements": "",
+          "enclosureUrl": "https://persistent.oaistatic.com/codex-app-prod/Codex-darwin-x64-1.2.3.zip",
+          "enclosureLength": 3,
+          "enclosureSignature": "x64-signature",
+          "deltas": []
+        },
+        "contentLength": 3,
+        "lastModified": "Thu, 11 Jun 2026 00:00:00 GMT",
+        "etag": "x64-etag"
+      }
+    }
+  },
+  "derived": {
+    "latestChecksums": {
+      "$package.Msix": "1111111111111111111111111111111111111111111111111111111111111111",
+      "$preserved_arm64_package.Msix": "2222222222222222222222222222222222222222222222222222222222222222",
+      "Codex-mac-arm64.dmg": "3333333333333333333333333333333333333333333333333333333333333333",
+      "Codex-mac-x64.dmg": "4444444444444444444444444444444444444444444444444444444444444444",
+      "Codex-darwin-arm64-1.2.3.zip": "5555555555555555555555555555555555555555555555555555555555555555",
+      "Codex-darwin-x64-1.2.3.zip": "6666666666666666666666666666666666666666666666666666666666666666"
+    }
+  }
+}
+JSON
+
+cp "$tmp_dir/latest-release-manifest.json" "$tmp_dir/public-manifest.json"
+public_manifest_sha="$(sha256sum "$tmp_dir/public-manifest.json" | awk '{print $1}')"
+
+cat > "$tmp_dir/public-SHA256SUMS.txt" <<SUMS
+1111111111111111111111111111111111111111111111111111111111111111  $package.Msix
+2222222222222222222222222222222222222222222222222222222222222222  $preserved_arm64_package.Msix
+3333333333333333333333333333333333333333333333333333333333333333  Codex-mac-arm64.dmg
+4444444444444444444444444444444444444444444444444444444444444444  Codex-mac-x64.dmg
+5555555555555555555555555555555555555555555555555555555555555555  Codex-darwin-arm64-1.2.3.zip
+6666666666666666666666666666666666666666666666666666666666666666  Codex-darwin-x64-1.2.3.zip
+$public_manifest_sha  release-manifest.json
+SUMS
+
+bash "$repo_root/scripts/build-appcast.sh" arm64 "$tmp_dir/public-manifest.json" "https://codexapp.agentsmirror.com" "$tmp_dir/public-appcast.xml" >/dev/null
+bash "$repo_root/scripts/build-appcast.sh" x64 "$tmp_dir/public-manifest.json" "https://codexapp.agentsmirror.com" "$tmp_dir/public-appcast-x64.xml" >/dev/null
+
+cat > "$tmp_dir/bin/dotnet" <<'DOTNET'
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ "${1:-}" == "run" ]]; then
+  if [[ "$*" == *" arm64" ]]; then
+    echo "No matching package found for 9PLM9XGG6VKS / arm64." >&2
+    exit 1
+  fi
+  printf 'OpenAI.Codex_1.2.3.4_x64__2p2nqsd0c76g0\thttps://download.example/OpenAI.Codex_1.2.3.4_x64__2p2nqsd0c76g0.Msix\n'
+  exit 0
+fi
+
+echo "unexpected dotnet invocation: $*" >&2
+exit 1
+DOTNET
+chmod +x "$tmp_dir/bin/dotnet"
+
+cat > "$tmp_dir/bin/gh" <<'GH'
+#!/usr/bin/env bash
+set -euo pipefail
+
+printf '%s\n' "$*" >> "${TEST_GH_LOG:?TEST_GH_LOG must be set}"
+
+if [[ "${1:-}" != "api" ]]; then
+  echo "unexpected gh invocation: $*" >&2
+  exit 1
+fi
+
+shift
+url="${*: -1}"
+
+case "$url" in
+  repos/\{owner\}/\{repo\}/releases/latest)
+    printf '{"tag_name":"%s"}\n' "${TEST_LATEST_TAG:?TEST_LATEST_TAG must be set}"
+    ;;
+  repos/\{owner\}/\{repo\}/releases/tags/"${TEST_LATEST_TAG}")
+    printf '{"tag_name":"%s","assets":[{"name":"release-manifest.json","url":"https://api.example/assets/release-manifest"}]}\n' "$TEST_LATEST_TAG"
+    ;;
+  https://api.example/assets/release-manifest)
+    cat "${TEST_LATEST_MANIFEST:?TEST_LATEST_MANIFEST must be set}"
+    ;;
+  *)
+    echo "unexpected gh api URL: $url" >&2
+    exit 1
+    ;;
+esac
+GH
+chmod +x "$tmp_dir/bin/gh"
+
+cat > "$tmp_dir/bin/curl" <<'CURL'
+#!/usr/bin/env bash
+set -euo pipefail
+
+head_request=false
+headers_file=""
+url=""
+while (($#)); do
+  case "$1" in
+    -D)
+      headers_file="$2"
+      shift
+      ;;
+    -o)
+      shift
+      ;;
+    --range)
+      shift
+      ;;
+    -I|-*I*)
+      head_request=true
+      ;;
+    http://*|https://*)
+      url="$1"
+      ;;
+  esac
+  shift
+done
+
+emit_headers() {
+  local etag="$1"
+  printf 'HTTP/2 200\r\n'
+  printf 'content-range: bytes 0-0/3\r\n'
+  printf 'content-length: 3\r\n'
+  printf 'last-modified: Thu, 11 Jun 2026 00:00:00 GMT\r\n'
+  printf 'etag: %s\r\n' "$etag"
+  printf '\r\n'
+}
+
+emit_appcast() {
+  local arch="$1"
+  local sig="$2"
+  local hardware="$3"
+
+  cat <<XML
+<?xml version="1.0" encoding="utf-8"?>
+<rss xmlns:sparkle="http://www.andymatuschak.org/xml-namespaces/sparkle" version="2.0">
+  <channel>
+    <item>
+      <title>1.2.3</title>
+      <pubDate>Thu, 11 Jun 2026 00:00:00 +0000</pubDate>
+      <sparkle:version>5</sparkle:version>
+      <sparkle:shortVersionString>1.2.3</sparkle:shortVersionString>
+      <sparkle:minimumSystemVersion>12.0</sparkle:minimumSystemVersion>
+      <sparkle:hardwareRequirements>${hardware}</sparkle:hardwareRequirements>
+      <enclosure url="https://persistent.oaistatic.com/codex-app-prod/Codex-darwin-${arch}-1.2.3.zip" length="3" type="application/octet-stream" sparkle:edSignature="${sig}" />
+    </item>
+  </channel>
+</rss>
+XML
+}
+
+headers_for_url() {
+  case "$url" in
+    *OpenAI.Codex_1.2.3.4_x64__2p2nqsd0c76g0.Msix)
+      emit_headers "windows-etag"
+      ;;
+    *Codex-1.2.3-arm64.dmg)
+      emit_headers "arm-etag"
+      ;;
+    *Codex-1.2.3-x64.dmg)
+      emit_headers "x64-etag"
+      ;;
+    *persistent.oaistatic.com/codex-app-prod/Codex-darwin-arm64-1.2.3.zip|\
+    *persistent.oaistatic.com/codex-app-prod/Codex-darwin-x64-1.2.3.zip)
+      emit_headers "source-zip-etag"
+      ;;
+    *codexapp.agentsmirror.com/latest/win-arm64*)
+      if [[ "${TEST_MISSING_ARM64_ALIAS:-false}" == "true" ]]; then
+        echo "missing preserved arm64 alias: $url" >&2
+        exit 1
+      fi
+      emit_headers "public-etag"
+      ;;
+    *codexapp.agentsmirror.com/latest/win*|\
+    *codexapp.agentsmirror.com/latest/mac-arm64*|\
+    *codexapp.agentsmirror.com/latest/mac-intel*|\
+    *codexapp.agentsmirror.com/latest/mac/arm64/Codex-darwin-arm64-1.2.3.zip*|\
+    *codexapp.agentsmirror.com/latest/mac/intel/Codex-darwin-x64-1.2.3.zip*)
+      emit_headers "public-etag"
+      ;;
+    *)
+      echo "unexpected curl headers URL: $url" >&2
+      exit 1
+      ;;
+  esac
+}
+
+if [[ -n "$headers_file" ]]; then
+  headers_for_url > "$headers_file"
+  exit 0
+fi
+
+if $head_request; then
+  headers_for_url
+  exit 0
+fi
+
+case "$url" in
+  *displaycatalog.mp.microsoft.com/v7.0/products/9PLM9XGG6VKS*)
+    cat <<'JSON'
+{"Product":{"DisplaySkuAvailabilities":[{"Sku":{"Properties":{"Packages":[
+{"PackageFamilyName":"OpenAI.Codex_2p2nqsd0c76g0","PackageFullName":"OpenAI.Codex_1.2.3.4_x64__2p2nqsd0c76g0","Architectures":["x64"],"PackageId":"x64-package-id","ContentId":"content-id","MaxDownloadSizeInBytes":3,"HashAlgorithm":"SHA256","Hash":"x64hash"},
+{"PackageFamilyName":"OpenAI.Codex_2p2nqsd0c76g0","PackageFullName":"OpenAI.Codex_1.2.3.4_arm64__2p2nqsd0c76g0","Architectures":["arm64"],"PackageId":"arm64-package-id","ContentId":"content-id","MaxDownloadSizeInBytes":4,"HashAlgorithm":"SHA256","Hash":"arm64hash"}
+]}}}]}}
+JSON
+    ;;
+  *windows-store-update.json)
+    printf '{"buildVersion":"1.2.3.4","storeProductId":"9PLM9XGG6VKS","packageIdentity":"OpenAI.Codex_2p2nqsd0c76g0"}\n'
+    ;;
+  *codexapp.agentsmirror.com/latest/appcast.xml*)
+    cat "${TEST_PUBLIC_APPCAST:?TEST_PUBLIC_APPCAST must be set}"
+    ;;
+  *codexapp.agentsmirror.com/latest/appcast-x64.xml*)
+    cat "${TEST_PUBLIC_APPCAST_X64:?TEST_PUBLIC_APPCAST_X64 must be set}"
+    ;;
+	  *codexapp.agentsmirror.com/latest/checksums*)
+	    if [[ "${TEST_STALE_MANIFEST_CHECKSUM:-false}" == "true" ]]; then
+	      awk '
+	        $2 == "release-manifest.json" {
+	          print "7777777777777777777777777777777777777777777777777777777777777777  release-manifest.json"
+	          next
+	        }
+	        { print }
+	      ' "${TEST_PUBLIC_CHECKSUMS:?TEST_PUBLIC_CHECKSUMS must be set}"
+	    else
+	      cat "${TEST_PUBLIC_CHECKSUMS:?TEST_PUBLIC_CHECKSUMS must be set}"
+	    fi
+	    if [[ "${TEST_EXTRA_CHECKSUM:-false}" == "true" ]]; then
+	      printf '8888888888888888888888888888888888888888888888888888888888888888  stale-extra.Msix\n'
+	    fi
+	    ;;
+  *codexapp.agentsmirror.com/latest/manifest*)
+    cat "${TEST_PUBLIC_MANIFEST:?TEST_PUBLIC_MANIFEST must be set}"
+    ;;
+  *appcast.xml)
+    emit_appcast arm64 arm-signature arm64
+    ;;
+  *appcast-x64.xml)
+    emit_appcast x64 x64-signature ""
+    ;;
+  *)
+    echo "unexpected curl URL: $url" >&2
+    exit 1
+    ;;
+esac
+CURL
+chmod +x "$tmp_dir/bin/curl"
+
+(
+  cd "$repo_root"
+  PATH="$tmp_dir/bin:$PATH" \
+  TEST_GH_LOG="$gh_log" \
+  TEST_LATEST_TAG="$latest_tag" \
+  TEST_LATEST_MANIFEST="$tmp_dir/latest-release-manifest.json" \
+  TEST_PUBLIC_MANIFEST="$tmp_dir/public-manifest.json" \
+  TEST_PUBLIC_CHECKSUMS="$tmp_dir/public-SHA256SUMS.txt" \
+  TEST_PUBLIC_APPCAST="$tmp_dir/public-appcast.xml" \
+  TEST_PUBLIC_APPCAST_X64="$tmp_dir/public-appcast-x64.xml" \
+  STORE_LINK_MAX_ATTEMPTS=1 \
+  MANIFEST_PATH="$tmp_dir/probe-manifest.json" \
+    scripts/probe-release.sh > "$tmp_dir/output.txt"
+)
+
+grep -F "should_release=false" "$tmp_dir/output.txt"
+grep -F "public mirror latest already matches current sources; GitHub latest remains $latest_tag until all architectures are complete" "$tmp_dir/output.txt"
+test "$(jq -r '.sources.windows.architectures.arm64.status' "$tmp_dir/probe-manifest.json")" = "catalog-only"
+test "$(jq -r '.sources.windows.architectures.arm64.packageMoniker' "$tmp_dir/probe-manifest.json")" = "$current_arm64_package"
+test "$(jq -r '.sources.windows.architectures.arm64.downloadable' "$tmp_dir/probe-manifest.json")" = "false"
+
+(
+  cd "$repo_root"
+  PATH="$tmp_dir/bin:$PATH" \
+  TEST_GH_LOG="$gh_log" \
+  TEST_LATEST_TAG="$latest_tag" \
+  TEST_LATEST_MANIFEST="$tmp_dir/latest-release-manifest.json" \
+  TEST_PUBLIC_MANIFEST="$tmp_dir/public-manifest.json" \
+  TEST_PUBLIC_CHECKSUMS="$tmp_dir/public-SHA256SUMS.txt" \
+  TEST_PUBLIC_APPCAST="$tmp_dir/public-appcast.xml" \
+  TEST_PUBLIC_APPCAST_X64="$tmp_dir/public-appcast-x64.xml" \
+  TEST_MISSING_ARM64_ALIAS=true \
+  STORE_LINK_MAX_ATTEMPTS=1 \
+  MANIFEST_PATH="$tmp_dir/probe-missing-arm64-manifest.json" \
+    scripts/probe-release.sh > "$tmp_dir/missing-arm64-output.txt"
+)
+
+grep -F "should_release=true" "$tmp_dir/missing-arm64-output.txt"
+
+(
+  cd "$repo_root"
+  PATH="$tmp_dir/bin:$PATH" \
+  TEST_GH_LOG="$gh_log" \
+  TEST_LATEST_TAG="$latest_tag" \
+  TEST_LATEST_MANIFEST="$tmp_dir/latest-release-manifest.json" \
+  TEST_PUBLIC_MANIFEST="$tmp_dir/public-manifest.json" \
+  TEST_PUBLIC_CHECKSUMS="$tmp_dir/public-SHA256SUMS.txt" \
+  TEST_PUBLIC_APPCAST="$tmp_dir/public-appcast.xml" \
+  TEST_PUBLIC_APPCAST_X64="$tmp_dir/public-appcast-x64.xml" \
+  TEST_STALE_MANIFEST_CHECKSUM=true \
+  STORE_LINK_MAX_ATTEMPTS=1 \
+  MANIFEST_PATH="$tmp_dir/probe-stale-manifest-checksum-manifest.json" \
+    scripts/probe-release.sh > "$tmp_dir/stale-manifest-checksum-output.txt"
+)
+
+grep -F "should_release=true" "$tmp_dir/stale-manifest-checksum-output.txt"
+
+(
+  cd "$repo_root"
+  PATH="$tmp_dir/bin:$PATH" \
+  TEST_GH_LOG="$gh_log" \
+  TEST_LATEST_TAG="$latest_tag" \
+  TEST_LATEST_MANIFEST="$tmp_dir/latest-release-manifest.json" \
+  TEST_PUBLIC_MANIFEST="$tmp_dir/public-manifest.json" \
+  TEST_PUBLIC_CHECKSUMS="$tmp_dir/public-SHA256SUMS.txt" \
+  TEST_PUBLIC_APPCAST="$tmp_dir/public-appcast.xml" \
+  TEST_PUBLIC_APPCAST_X64="$tmp_dir/public-appcast-x64.xml" \
+  TEST_EXTRA_CHECKSUM=true \
+  STORE_LINK_MAX_ATTEMPTS=1 \
+  MANIFEST_PATH="$tmp_dir/probe-extra-checksum-manifest.json" \
+    scripts/probe-release.sh > "$tmp_dir/extra-checksum-output.txt"
+)
+
+grep -F "should_release=true" "$tmp_dir/extra-checksum-output.txt"
+
+echo "probe-release preserved-arm64 fixture test PASS"

--- a/scripts/test-sync-secondary-s3.sh
+++ b/scripts/test-sync-secondary-s3.sh
@@ -76,6 +76,14 @@ if [[ "${1:-}" == "s3api" && "${2:-}" == "head-object" ]]; then
   exit 0
 fi
 
+if [[ "${1:-}" == "s3" && "${2:-}" == "rm" ]]; then
+  target="${3:-}"
+  printf 'RM %s\n' "$target" >> "$TEST_AWS_LOG"
+  key="${target#s3://*/}"
+  rm -f "$(state_path "$key")"
+  exit 0
+fi
+
 exit 0
 AWS
 chmod +x "$tmp_dir/bin/aws"
@@ -166,5 +174,181 @@ grep -Fq 'max_attempts = 5' "$config_snapshot"
 grep -Fq 'max_concurrent_requests = 1' "$config_snapshot"
 grep -Fq 'multipart_threshold = 16MB' "$config_snapshot"
 grep -Fq 'multipart_chunksize = 32MB' "$config_snapshot"
+
+cat > "$tmp_dir/artifacts/release-manifest-preserved-arm64.json" <<'JSON'
+{
+  "schemaVersion": 4,
+  "sources": {
+    "windows": {
+      "architectures": {
+        "arm64": {
+          "downloadable": true,
+          "currentLocalArtifact": false,
+          "currentForCodexVersion": false
+        }
+      }
+    }
+  }
+}
+JSON
+: > "$aws_log"
+rm -rf "$object_state_dir"
+mkdir -p "$object_state_dir"
+(
+  cd "$repo_root"
+  PATH="$tmp_dir/bin:$PATH" \
+  TEST_AWS_LOG="$aws_log" \
+  TEST_AWS_CONFIG_SNAPSHOT="$config_snapshot" \
+  TEST_OBJECT_STATE_DIR="$object_state_dir" \
+  TEST_FAIL_ONCE_MARKER="$fail_once_marker" \
+  SECONDARY_S3_ENDPOINT="https://s3.example.invalid" \
+  SECONDARY_S3_BUCKET="secondary-bucket" \
+  SECONDARY_S3_REGION="auto" \
+  SECONDARY_S3_ACCESS_KEY_ID="key" \
+  SECONDARY_S3_SECRET_ACCESS_KEY="secret" \
+  SECONDARY_S3_UPLOAD_ATTEMPTS=2 \
+  SECONDARY_S3_RETRY_SLEEP_SECONDS=0 \
+  SECONDARY_S3_CONNECT_TIMEOUT_SECONDS=7 \
+  SECONDARY_S3_READ_TIMEOUT_SECONDS=11 \
+  SECONDARY_S3_AWS_MAX_ATTEMPTS=5 \
+  SECONDARY_S3_AWS_RETRY_MODE=standard \
+  SECONDARY_S3_UPLOAD_MODE=put-object \
+  SECONDARY_S3_MULTIPART_THRESHOLD=16MB \
+  SECONDARY_S3_MULTIPART_CHUNKSIZE=32MB \
+  SECONDARY_S3_MAX_CONCURRENT_REQUESTS=1 \
+    scripts/sync-secondary-s3.sh \
+      "$tmp_dir/artifacts/Codex-mac-arm64.dmg" \
+      "$tmp_dir/artifacts/Codex-mac-x64.dmg" \
+      "$tmp_dir/artifacts/Codex.msix" \
+      "$tmp_dir/artifacts/SHA256SUMS.txt" \
+      "$tmp_dir/artifacts/release-manifest-preserved-arm64.json" \
+      "$tmp_dir/artifacts/Codex-darwin-arm64-1.2.3.zip" \
+      "$tmp_dir/artifacts/Codex-darwin-x64-1.2.3.zip" \
+      "$tmp_dir/artifacts/appcast.xml" \
+      "$tmp_dir/artifacts/appcast-x64.xml" \
+      "$tmp_dir/artifacts/Codex-arm64.msix"
+)
+if grep -Fq 'PUT s3://secondary-bucket/latest/win-arm64' "$aws_log"; then
+  echo "Preserved ARM64 should not upload a local secondary win-arm64 object." >&2
+  exit 1
+fi
+if grep -Fq 'RM s3://secondary-bucket/latest/win-arm64' "$aws_log"; then
+  echo "Preserved ARM64 should not delete the existing secondary win-arm64 object." >&2
+  exit 1
+fi
+
+cat > "$tmp_dir/artifacts/release-manifest-missing-arm64.json" <<'JSON'
+{
+  "schemaVersion": 4,
+  "sources": {
+    "windows": {
+      "architectures": {
+        "arm64": {
+          "downloadable": false,
+          "currentLocalArtifact": false,
+          "currentForCodexVersion": false
+        }
+      }
+    }
+  }
+}
+JSON
+: > "$aws_log"
+rm -rf "$object_state_dir"
+mkdir -p "$object_state_dir"
+(
+  cd "$repo_root"
+  PATH="$tmp_dir/bin:$PATH" \
+  TEST_AWS_LOG="$aws_log" \
+  TEST_AWS_CONFIG_SNAPSHOT="$config_snapshot" \
+  TEST_OBJECT_STATE_DIR="$object_state_dir" \
+  TEST_FAIL_ONCE_MARKER="$fail_once_marker" \
+  SECONDARY_S3_ENDPOINT="https://s3.example.invalid" \
+  SECONDARY_S3_BUCKET="secondary-bucket" \
+  SECONDARY_S3_REGION="auto" \
+  SECONDARY_S3_ACCESS_KEY_ID="key" \
+  SECONDARY_S3_SECRET_ACCESS_KEY="secret" \
+  SECONDARY_S3_UPLOAD_ATTEMPTS=2 \
+  SECONDARY_S3_RETRY_SLEEP_SECONDS=0 \
+  SECONDARY_S3_CONNECT_TIMEOUT_SECONDS=7 \
+  SECONDARY_S3_READ_TIMEOUT_SECONDS=11 \
+  SECONDARY_S3_AWS_MAX_ATTEMPTS=5 \
+  SECONDARY_S3_AWS_RETRY_MODE=standard \
+  SECONDARY_S3_UPLOAD_MODE=put-object \
+  SECONDARY_S3_MULTIPART_THRESHOLD=16MB \
+  SECONDARY_S3_MULTIPART_CHUNKSIZE=32MB \
+  SECONDARY_S3_MAX_CONCURRENT_REQUESTS=1 \
+    scripts/sync-secondary-s3.sh \
+      "$tmp_dir/artifacts/Codex-mac-arm64.dmg" \
+      "$tmp_dir/artifacts/Codex-mac-x64.dmg" \
+      "$tmp_dir/artifacts/Codex.msix" \
+      "$tmp_dir/artifacts/SHA256SUMS.txt" \
+      "$tmp_dir/artifacts/release-manifest-missing-arm64.json" \
+      "$tmp_dir/artifacts/Codex-darwin-arm64-1.2.3.zip" \
+      "$tmp_dir/artifacts/Codex-darwin-x64-1.2.3.zip" \
+      "$tmp_dir/artifacts/appcast.xml" \
+      "$tmp_dir/artifacts/appcast-x64.xml" \
+      "$tmp_dir/artifacts/Codex-arm64.msix"
+)
+if grep -Fq 'PUT s3://secondary-bucket/latest/win-arm64' "$aws_log"; then
+  echo "Missing ARM64 should not upload a secondary win-arm64 object." >&2
+  exit 1
+fi
+grep -Fq 'RM s3://secondary-bucket/latest/win-arm64' "$aws_log"
+
+cat > "$tmp_dir/artifacts/release-manifest-lagging-arm64.json" <<'JSON'
+{
+  "schemaVersion": 4,
+  "sources": {
+    "windows": {
+      "architectures": {
+        "arm64": {
+          "downloadable": true,
+          "currentLocalArtifact": true,
+          "currentForCodexVersion": false
+        }
+      }
+    }
+  }
+}
+JSON
+: > "$aws_log"
+rm -rf "$object_state_dir"
+mkdir -p "$object_state_dir"
+(
+  cd "$repo_root"
+  PATH="$tmp_dir/bin:$PATH" \
+  TEST_AWS_LOG="$aws_log" \
+  TEST_AWS_CONFIG_SNAPSHOT="$config_snapshot" \
+  TEST_OBJECT_STATE_DIR="$object_state_dir" \
+  TEST_FAIL_ONCE_MARKER="$fail_once_marker" \
+  SECONDARY_S3_ENDPOINT="https://s3.example.invalid" \
+  SECONDARY_S3_BUCKET="secondary-bucket" \
+  SECONDARY_S3_REGION="auto" \
+  SECONDARY_S3_ACCESS_KEY_ID="key" \
+  SECONDARY_S3_SECRET_ACCESS_KEY="secret" \
+  SECONDARY_S3_UPLOAD_ATTEMPTS=2 \
+  SECONDARY_S3_RETRY_SLEEP_SECONDS=0 \
+  SECONDARY_S3_CONNECT_TIMEOUT_SECONDS=7 \
+  SECONDARY_S3_READ_TIMEOUT_SECONDS=11 \
+  SECONDARY_S3_AWS_MAX_ATTEMPTS=5 \
+  SECONDARY_S3_AWS_RETRY_MODE=standard \
+  SECONDARY_S3_UPLOAD_MODE=put-object \
+  SECONDARY_S3_MULTIPART_THRESHOLD=16MB \
+  SECONDARY_S3_MULTIPART_CHUNKSIZE=32MB \
+  SECONDARY_S3_MAX_CONCURRENT_REQUESTS=1 \
+    scripts/sync-secondary-s3.sh \
+      "$tmp_dir/artifacts/Codex-mac-arm64.dmg" \
+      "$tmp_dir/artifacts/Codex-mac-x64.dmg" \
+      "$tmp_dir/artifacts/Codex.msix" \
+      "$tmp_dir/artifacts/SHA256SUMS.txt" \
+      "$tmp_dir/artifacts/release-manifest-lagging-arm64.json" \
+      "$tmp_dir/artifacts/Codex-darwin-arm64-1.2.3.zip" \
+      "$tmp_dir/artifacts/Codex-darwin-x64-1.2.3.zip" \
+      "$tmp_dir/artifacts/appcast.xml" \
+      "$tmp_dir/artifacts/appcast-x64.xml" \
+      "$tmp_dir/artifacts/Codex-arm64.msix"
+)
+grep -Fq 'PUT s3://secondary-bucket/latest/win-arm64' "$aws_log"
 
 echo "sync-secondary-s3 retry fixture PASS"


### PR DESCRIPTION
## Summary
- publish partial releases per architecture while only promoting formal latest when all four architectures are complete
- sync rolling latest aliases/checksums/manifest to R2 and secondary S3 for shipped architectures, preserving or deleting Windows ARM64 aliases based on manifest/checksum state
- harden probe checks for public mirror manifests, checksums, preserved ARM64 aliases, and stale objects
- update README and add regression fixtures

## Verification
- codex review --base origin/main
- bash -n scripts/*.sh
- actionlint .github/workflows/ci.yml .github/workflows/mirror.yml
- for t in scripts/test-*.sh; do bash "$t"; done
- npm test --prefix cloudflare/secondary-sync
- git diff --check
- LC_ALL=C rg -n $'\\r' .github scripts README.md || true