### PR TITLE
Record bundled backend versions in release metadata

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,6 +54,10 @@ jobs:
         shell: bash
         run: actionlint
 
+      - name: Test backend version reader fixture
+        shell: bash
+        run: scripts/test-read-codex-backend-version.sh
+
       - name: Test release metadata fixture
         shell: bash
         run: scripts/test-prepare-release-metadata.sh

--- a/.github/workflows/mirror.yml
+++ b/.github/workflows/mirror.yml
@@ -84,7 +84,16 @@ jobs:
             dist/macos/Codex-mac-arm64.dmg \
             dist/macos/Codex-mac-x64.dmg \
             "dist/macos/$arm_zip_basename" \
-            "dist/macos/$x64_zip_basename"
+            "dist/macos/$x64_zip_basename" \
+            dist/macos-x64-backend-input
+
+      - name: Upload macOS Intel backend input
+        continue-on-error: true
+        uses: actions/upload-artifact@v7
+        with:
+          name: codex-macos-x64-backend-input
+          path: dist/macos-x64-backend-input/*
+          if-no-files-found: error
 
       - name: Upload macOS artifacts
         uses: actions/upload-artifact@v7
@@ -240,6 +249,31 @@ jobs:
           path: dist/windows-arm64-backend/*
           if-no-files-found: error
 
+  macos_x64_backend:
+    name: Read macOS Intel backend metadata
+    runs-on: macos-15-intel
+    continue-on-error: true
+    timeout-minutes: 30
+    needs:
+      - probe
+      - macos
+    if: needs.probe.outputs.should_release == 'true'
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/download-artifact@v8
+        with:
+          name: codex-macos-x64-backend-input
+          path: dist/macos-x64-backend-input
+
+      - name: Read macOS Intel backend metadata
+        run: bash scripts/read-macos-backend-metadata.sh dist/macos-x64-backend/macos-backend-x64.json x64 dist/macos-x64-backend-input/backend-input.json
+
+      - uses: actions/upload-artifact@v7
+        with:
+          name: codex-macos-x64-backend
+          path: dist/macos-x64-backend/*
+          if-no-files-found: error
   release:
     name: Publish release
     runs-on: ubuntu-latest
@@ -251,6 +285,7 @@ jobs:
       - macos
       - windows
       - windows_arm64_backend
+      - macos_x64_backend
     steps:
       - uses: actions/checkout@v6
 

--- a/.github/workflows/mirror.yml
+++ b/.github/workflows/mirror.yml
@@ -110,6 +110,80 @@ jobs:
 
           ./scripts/download-windows.ps1 -OutDir dist/windows -ManifestPath probe-manifest.json
 
+      - name: Read Windows x64 backend metadata
+        shell: pwsh
+        run: |
+          $msix = Get-ChildItem -LiteralPath dist/windows -Filter '*_x64__*.Msix' | Select-Object -First 1
+          if ($null -eq $msix) {
+            throw 'Missing Windows x64 MSIX.'
+          }
+          $msixPath = $msix.FullName
+          $metadataPath = 'dist/windows/windows-backend-x64.json'
+          try {
+            $metadata = python scripts/read-codex-backend-version.py --json --platform windows --architecture x64 "$msixPath"
+            if ($LASTEXITCODE -ne 0) {
+              throw "Backend reader exited with code $LASTEXITCODE."
+            }
+            $metadataText = $metadata -join [Environment]::NewLine
+            $null = ConvertFrom-Json -InputObject $metadataText -ErrorAction Stop
+            $metadataText | Set-Content -Encoding utf8 -Path $metadataPath
+          }
+          catch {
+            Write-Warning "Could not read Windows x64 backend metadata: $($_.Exception.Message)"
+            '{"architecture":"x64","platform":"windows","status":"unavailable"}' |
+              Set-Content -Encoding utf8 -Path $metadataPath
+          }
+
+      - name: Prepare Windows ARM64 backend input
+        shell: pwsh
+        run: |
+          $inputDir = 'dist/windows-arm64-backend-input'
+          $inputManifestPath = Join-Path $inputDir 'backend-input.json'
+          New-Item -ItemType Directory -Force -Path $inputDir | Out-Null
+          $writeUnavailable = {
+            Remove-Item -LiteralPath (Join-Path $inputDir 'codex.exe') -Force -ErrorAction SilentlyContinue
+            Remove-Item -LiteralPath (Join-Path $inputDir 'codex') -Force -ErrorAction SilentlyContinue
+            '{"architecture":"arm64","platform":"windows","schemaVersion":1,"status":"unavailable"}' |
+              Set-Content -Encoding utf8 -Path $inputManifestPath
+          }
+
+          $msix = Get-ChildItem -LiteralPath dist/windows -Filter '*_arm64__*.Msix' | Select-Object -First 1
+          if ($null -eq $msix) {
+            & $writeUnavailable
+            return
+          }
+
+          try {
+            $sourceSha256 = (Get-FileHash -Algorithm SHA256 -LiteralPath $msix.FullName).Hash.ToLowerInvariant()
+            $prepareOutput = python scripts/read-codex-backend-version.py `
+              --prepare-input-dir $inputDir `
+              --source-package $msix.FullName `
+              --source-package-sha256 $sourceSha256 `
+              --platform windows `
+              --architecture arm64 `
+              $msix.FullName
+            if ($LASTEXITCODE -ne 0) {
+              throw "Backend input preparation exited with code $LASTEXITCODE."
+            }
+            $inputManifest = Get-Content -Raw -LiteralPath $inputManifestPath | ConvertFrom-Json -ErrorAction Stop
+            if ($inputManifest.status -notin @('ready', 'unavailable')) {
+              throw 'Backend input manifest has an invalid status.'
+            }
+            $prepareOutput | Write-Host
+          }
+          catch {
+            Write-Warning "Could not prepare Windows ARM64 backend input: $($_.Exception.Message)"
+            & $writeUnavailable
+          }
+
+      - name: Upload Windows ARM64 backend input
+        continue-on-error: true
+        uses: actions/upload-artifact@v7
+        with:
+          name: codex-windows-arm64-backend-input
+          path: dist/windows-arm64-backend-input/*
+          if-no-files-found: error
+
       - name: Upload Windows artifact
         uses: actions/upload-artifact@v7
         with:
@@ -117,16 +191,66 @@ jobs:
           path: dist/windows/*
           if-no-files-found: error
 
+  windows_arm64_backend:
+    name: Read Windows ARM64 backend metadata
+    runs-on: windows-11-arm
+    continue-on-error: true
+    timeout-minutes: 30
+    needs:
+      - probe
+      - windows
+    if: needs.probe.outputs.should_release == 'true'
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/download-artifact@v8
+        with:
+          name: codex-windows-arm64-backend-input
+          path: dist/windows-arm64-backend-input
+
+      - name: Read Windows ARM64 backend metadata
+        shell: pwsh
+        run: |
+          New-Item -ItemType Directory -Force -Path dist/windows-arm64-backend | Out-Null
+          $inputManifestPath = 'dist/windows-arm64-backend-input/backend-input.json'
+          $metadataPath = 'dist/windows-arm64-backend/windows-backend-arm64.json'
+          try {
+            $metadata = python scripts/read-codex-backend-version.py `
+              --prepared-input `
+              --json `
+              --platform windows `
+              --architecture arm64 `
+              $inputManifestPath
+            if ($LASTEXITCODE -ne 0) {
+              throw "Backend reader exited with code $LASTEXITCODE."
+            }
+            $metadataText = $metadata -join [Environment]::NewLine
+            $null = ConvertFrom-Json -InputObject $metadataText -ErrorAction Stop
+            $metadataText | Set-Content -Encoding utf8 -Path $metadataPath
+          }
+          catch {
+            Write-Warning "Could not read Windows ARM64 backend metadata: $($_.Exception.Message)"
+            '{"architecture":"arm64","platform":"windows","status":"unavailable"}' |
+              Set-Content -Encoding utf8 -Path $metadataPath
+          }
+
+      - uses: actions/upload-artifact@v7
+        with:
+          name: codex-windows-arm64-backend
+          path: dist/windows-arm64-backend/*
+          if-no-files-found: error
+
   release:
     name: Publish release
     runs-on: ubuntu-latest
-    if: needs.probe.outputs.should_release == 'true'
+    if: always() && needs.probe.outputs.should_release == 'true' && needs.macos.result == 'success' && needs.windows.result == 'success'
     permissions:
       contents: write
     needs:
       - probe
       - macos
       - windows
+      - windows_arm64_backend
     steps:
       - uses: actions/checkout@v6
 

--- a/scripts/prepare-release-metadata.sh
+++ b/scripts/prepare-release-metadata.sh
@@ -295,8 +295,11 @@ if [[ "$windows_arm64_probe_downloadable" == "true" && -n "$windows_arm64_packag
 fi
 
 windows_arm64_release_app_version="$windows_arm64_app_version"
-mac_arm_backend_version=""
-mac_x64_backend_version=""
+mac_arm_backend_version="$(jq -r '.macos.arm64.backendVersion // empty' "$macos_metadata")"
+mac_x64_backend_version="$(jq -r '.macos.x64.backendVersion // empty' "$macos_metadata")"
+if [[ -z "$mac_x64_backend_version" ]]; then
+  mac_x64_backend_version="$(json_backend_version "$artifacts_dir/codex-macos-x64-backend/macos-backend-x64.json")"
+fi
 
 previous_latest_available=false
 previous_windows_arm64_json="null"
@@ -448,6 +451,8 @@ jq \
   --arg windowsArm64Status "$windows_arm64_status" \
   --arg windowsArm64AppVersion "$windows_arm64_app_version" \
   --arg windowsArm64BackendVersion "$windows_arm64_backend_version" \
+  --arg macosArm64BackendVersion "$mac_arm_backend_version" \
+  --arg macosX64BackendVersion "$mac_x64_backend_version" \
   --arg platformCompleteness "$platform_completeness" \
   '
   .schemaVersion = 5
@@ -500,6 +505,11 @@ jq \
   | .sources.macos.arm64.sparkleArchiveIdentityVerified = ($mac[0].macos.arm64.sparkleArchiveIdentityVerified // false)
   | .sources.macos.arm64.minimumSystemVersion = $mac[0].macos.arm64.minimumSystemVersion
   | .sources.macos.arm64.sha256 = $mac[0].macos.arm64.sha256
+  | if $macosArm64BackendVersion != "" then
+      .sources.macos.arm64.backendVersion = $macosArm64BackendVersion
+    else
+      del(.sources.macos.arm64.backendVersion)
+    end
   | .sources.macos.arm64.downloadable = true
   | .sources.macos.arm64.status = "downloadable"
   | .sources.macos.arm64.currentForCodexVersion = $includeMacosArm64
@@ -516,6 +526,11 @@ jq \
   | .sources.macos.x64.sparkleArchiveIdentityVerified = ($mac[0].macos.x64.sparkleArchiveIdentityVerified // false)
   | .sources.macos.x64.minimumSystemVersion = $mac[0].macos.x64.minimumSystemVersion
   | .sources.macos.x64.sha256 = $mac[0].macos.x64.sha256
+  | if $macosX64BackendVersion != "" then
+      .sources.macos.x64.backendVersion = $macosX64BackendVersion
+    else
+      del(.sources.macos.x64.backendVersion)
+    end
   | .sources.macos.x64.downloadable = true
   | .sources.macos.x64.status = "downloadable"
   | .sources.macos.x64.currentForCodexVersion = $includeMacosX64
@@ -539,6 +554,8 @@ jq \
       macosCommonShortVersion: $mac[0].commonShortVersion,
       macosCommonBundleVersion: $mac[0].commonBundleVersion,
       macosVersionsMatch: $mac[0].versionsMatch,
+      macosArm64BackendVersion: $macosArm64BackendVersion,
+      macosX64BackendVersion: $macosX64BackendVersion,
       missingPlatforms: ([if $includeWindows then empty else "windows" end, if $includeMacos then empty else "macos" end]),
       missingArchitectures: ([
         if $includeWindowsX64 then empty else "windows-x64" end,

--- a/scripts/prepare-release-metadata.sh
+++ b/scripts/prepare-release-metadata.sh
@@ -118,6 +118,23 @@ table_cell() {
   fi
 }
 
+table_code_cell() {
+  local value="${1:-}"
+  if [[ -n "$value" && "$value" != "null" ]]; then
+    printf '`%s`' "$value"
+  else
+    printf ''
+  fi
+}
+
+json_backend_version() {
+  local path="$1"
+  if [[ -f "$path" ]]; then
+    jq -r '.backendVersion // empty' "$path" 2>/dev/null || true
+  else
+    printf ''
+  fi
+}
 require find
 require jq
 require python3
@@ -228,6 +245,8 @@ windows_arm64_downloadable=false
 windows_arm64_local_latest=false
 windows_arm64_missing_reason="${windows_arm64_status:-catalog-only}"
 windows_arm64_app_version=""
+windows_backend_version="${WINDOWS_BACKEND_VERSION:-}"
+windows_arm64_backend_version="${WINDOWS_ARM64_BACKEND_VERSION:-}"
 windows_app_version="${WINDOWS_APP_VERSION:-}"
 if [[ -z "$windows_app_version" ]]; then
   windows_app_version="$(jq -r '.sources.windows.appVersion // .sources.windows.architectures.x64.appVersion // empty' "$probe_manifest")"
@@ -245,11 +264,18 @@ if [[ -z "$windows_app_version" || "$windows_app_version" == "null" ]]; then
   exit 1
 fi
 
+if [[ -z "$windows_backend_version" ]]; then
+  windows_backend_version="$(json_backend_version "$artifacts_dir/codex-windows/windows-backend-x64.json")"
+fi
+
 if [[ -n "$windows_arm64_msix" ]]; then
   if ! windows_arm64_app_version="$(python3 "$script_dir/read-windows-msix-version.py" "$windows_arm64_msix")"; then
     windows_arm64_app_version=""
     windows_arm64_status="skipped-version-unreadable"
     windows_arm64_missing_reason="$windows_arm64_status"
+  fi
+  if [[ -z "$windows_arm64_backend_version" ]]; then
+    windows_arm64_backend_version="$(json_backend_version "$artifacts_dir/codex-windows-arm64-backend/windows-backend-arm64.json")"
   fi
 fi
 
@@ -267,7 +293,10 @@ if [[ "$windows_arm64_probe_downloadable" == "true" && -n "$windows_arm64_packag
     windows_arm64_missing_reason=""
   fi
 fi
+
 windows_arm64_release_app_version="$windows_arm64_app_version"
+mac_arm_backend_version=""
+mac_x64_backend_version=""
 
 previous_latest_available=false
 previous_windows_arm64_json="null"
@@ -312,6 +341,9 @@ if [[ "$previous_latest_available" == "true" &&
     windows_arm64_package_version="$(jq -r '.sources.windows.architectures.arm64.version // empty' "$tmp_previous_manifest")"
     windows_arm64_status="$(jq -r '.sources.windows.architectures.arm64.status // "downloadable"' "$tmp_previous_manifest")"
     windows_arm64_app_version="$(jq -r '.sources.windows.architectures.arm64.appVersion // empty' "$tmp_previous_manifest")"
+    if [[ -z "$windows_arm64_backend_version" ]]; then
+      windows_arm64_backend_version="$(jq -r '.sources.windows.architectures.arm64.backendVersion // empty' "$tmp_previous_manifest")"
+    fi
     windows_arm64_last_modified="$(jq -r '.sources.windows.architectures.arm64.lastModified // empty' "$tmp_previous_manifest")"
     windows_arm64_missing_reason=""
     preserved_windows_arm64=true
@@ -400,6 +432,7 @@ jq \
   --arg publishedAt "$published_at" \
   --arg windowsPackageVersion "$windows_package_version" \
   --arg windowsAppVersion "$windows_app_version" \
+  --arg windowsBackendVersion "$windows_backend_version" \
   --argjson includeWindows "$include_windows" \
   --argjson includeMacos "$include_macos" \
   --argjson includeWindowsX64 "$include_windows_x64" \
@@ -414,6 +447,7 @@ jq \
   --argjson previousWindowsArm64 "$previous_windows_arm64_json" \
   --arg windowsArm64Status "$windows_arm64_status" \
   --arg windowsArm64AppVersion "$windows_arm64_app_version" \
+  --arg windowsArm64BackendVersion "$windows_arm64_backend_version" \
   --arg platformCompleteness "$platform_completeness" \
   '
   .schemaVersion = 5
@@ -421,8 +455,10 @@ jq \
   | .publishedAt = $publishedAt
   | .sources.windows.version = $windowsPackageVersion
   | .sources.windows.appVersion = $windowsAppVersion
+  | if $windowsBackendVersion != "" then .sources.windows.backendVersion = $windowsBackendVersion else del(.sources.windows.backendVersion) end
   | .sources.windows.architectures.x64.version = $windowsPackageVersion
   | .sources.windows.architectures.x64.appVersion = $windowsAppVersion
+  | if $windowsBackendVersion != "" then .sources.windows.architectures.x64.backendVersion = $windowsBackendVersion else del(.sources.windows.architectures.x64.backendVersion) end
   | .sources.windows.architectures.x64.downloadable = true
   | .sources.windows.architectures.x64.status = (.sources.windows.architectures.x64.status // "downloadable")
   | .sources.windows.architectures.x64.currentForCodexVersion = $includeWindowsX64
@@ -442,6 +478,11 @@ jq \
           .sources.windows.architectures.arm64.appVersion = $windowsArm64AppVersion
         else
           del(.sources.windows.architectures.arm64.appVersion)
+        end
+      | if $windowsArm64BackendVersion != "" then
+          .sources.windows.architectures.arm64.backendVersion = $windowsArm64BackendVersion
+        else
+          del(.sources.windows.architectures.arm64.backendVersion)
         end
     else
       .
@@ -492,7 +533,9 @@ jq \
       syncLatest: $syncLatest,
       windowsPackageVersion: $windowsPackageVersion,
       windowsAppVersion: $windowsAppVersion,
+      windowsBackendVersion: $windowsBackendVersion,
       windowsArm64AppVersion: $windowsArm64AppVersion,
+      windowsArm64BackendVersion: $windowsArm64BackendVersion,
       macosCommonShortVersion: $mac[0].commonShortVersion,
       macosCommonBundleVersion: $mac[0].commonBundleVersion,
       macosVersionsMatch: $mac[0].versionsMatch,
@@ -710,37 +753,37 @@ mv "$tmp_manifest" release-manifest.json
   echo
   echo "## 版本与发布时间"
   echo
-  echo "| 平台 | Codex 版本 | 平台包 / build | 官方发布时间 | 镜像发布时间 | 状态 |"
-  echo "|---|---:|---:|---|---|---|"
+  echo "| 平台 | Codex 版本 | 后端版本 | 平台包 / build | 官方发布时间 | 镜像发布时间 | 状态 |"
+  echo "|---|---:|---:|---:|---|---|---|"
   if [[ "$include_windows_x64" == "true" ]]; then
-    echo "| Windows x64 | \`${windows_app_version}\` | \`${windows_package_version}\` | $(table_cell "$windows_x64_last_modified") | ${published_at_label} | 已发布 |"
+    echo "| Windows x64 | \`${windows_app_version}\` | $(table_code_cell "$windows_backend_version") | \`${windows_package_version}\` | $(table_cell "$windows_x64_last_modified") | ${published_at_label} | 已发布 |"
   else
-    echo "| Windows x64 | \`${windows_app_version}\` | \`${windows_package_version}\` | $(table_cell "$windows_x64_last_modified") |  | 当前 latest，待目标版本 |"
+    echo "| Windows x64 | \`${windows_app_version}\` | $(table_code_cell "$windows_backend_version") | \`${windows_package_version}\` | $(table_cell "$windows_x64_last_modified") |  | 当前 latest，待目标版本 |"
   fi
   if [[ "$include_windows_arm64" == "true" ]]; then
-    echo "| Windows ARM64 | \`${windows_arm64_app_version}\` | \`${windows_arm64_package_version:-$windows_package_version}\` | $(table_cell "$windows_arm64_last_modified") | ${published_at_label} | 已发布 |"
+    echo "| Windows ARM64 | \`${windows_arm64_app_version}\` | $(table_code_cell "$windows_arm64_backend_version") | \`${windows_arm64_package_version:-$windows_package_version}\` | $(table_cell "$windows_arm64_last_modified") | ${published_at_label} | 已发布 |"
   elif [[ -n "$windows_arm64_package" ]]; then
     if [[ "$windows_arm64_downloadable" == "true" ]]; then
-      echo "| Windows ARM64 | \`${windows_arm64_app_version}\` | \`${windows_arm64_package_version:-$windows_package_version}\` | $(table_cell "$windows_arm64_last_modified") |  | 当前 latest，待目标版本 |"
+      echo "| Windows ARM64 | \`${windows_arm64_app_version}\` | $(table_code_cell "$windows_arm64_backend_version") | \`${windows_arm64_package_version:-$windows_package_version}\` | $(table_cell "$windows_arm64_last_modified") |  | 当前 latest，待目标版本 |"
     elif [[ "$windows_arm64_missing_reason" == "skipped-rollout-drift" ]]; then
-      echo "| Windows ARM64 |  | \`${windows_arm64_package_version:-$windows_package_version}\` |  |  | 下载阶段上游版本漂移，待下次探测补齐（\`${windows_arm64_status}\`） |"
+      echo "| Windows ARM64 |  |  | \`${windows_arm64_package_version:-$windows_package_version}\` |  |  | 下载阶段上游版本漂移，待下次探测补齐（\`${windows_arm64_status}\`） |"
     elif [[ "$windows_arm64_missing_reason" == "skipped-version-unreadable" ]]; then
-      echo "| Windows ARM64 |  | \`${windows_arm64_package_version:-$windows_package_version}\` |  |  | 无法读取内部版本，待下次探测补齐（\`${windows_arm64_status}\`） |"
+      echo "| Windows ARM64 |  |  | \`${windows_arm64_package_version:-$windows_package_version}\` |  |  | 无法读取内部版本，待下次探测补齐（\`${windows_arm64_status}\`） |"
     else
-      echo "| Windows ARM64 |  | \`${windows_arm64_package_version:-$windows_package_version}\` |  |  | Microsoft Store 目录已出现，下载 URL 待解析（\`${windows_arm64_status:-catalog-only}\`） |"
+      echo "| Windows ARM64 |  |  | \`${windows_arm64_package_version:-$windows_package_version}\` |  |  | Microsoft Store 目录已出现，下载 URL 待解析（\`${windows_arm64_status:-catalog-only}\`） |"
     fi
   else
-    echo "| Windows ARM64 |  |  |  |  | 待官方发布对应版本 |"
+    echo "| Windows ARM64 |  |  |  |  |  | 待官方发布对应版本 |"
   fi
   if [[ "$include_macos_arm64" == "true" ]]; then
-    echo "| macOS Apple Silicon | \`${mac_arm_version}\` | build \`${mac_arm_build}\` | $(table_cell "$mac_arm_pub_date") | ${published_at_label} | 已发布 |"
+    echo "| macOS Apple Silicon | \`${mac_arm_version}\` | $(table_code_cell "$mac_arm_backend_version") | build \`${mac_arm_build}\` | $(table_cell "$mac_arm_pub_date") | ${published_at_label} | 已发布 |"
   else
-    echo "| macOS Apple Silicon | \`${mac_arm_version}\` | build \`${mac_arm_build}\` | $(table_cell "$mac_arm_pub_date") |  | 当前 latest，待目标版本 |"
+    echo "| macOS Apple Silicon | \`${mac_arm_version}\` | $(table_code_cell "$mac_arm_backend_version") | build \`${mac_arm_build}\` | $(table_cell "$mac_arm_pub_date") |  | 当前 latest，待目标版本 |"
   fi
   if [[ "$include_macos_x64" == "true" ]]; then
-    echo "| macOS Intel | \`${mac_x64_version}\` | build \`${mac_x64_build}\` | $(table_cell "$mac_x64_pub_date") | ${published_at_label} | 已发布 |"
+    echo "| macOS Intel | \`${mac_x64_version}\` | $(table_code_cell "$mac_x64_backend_version") | build \`${mac_x64_build}\` | $(table_cell "$mac_x64_pub_date") | ${published_at_label} | 已发布 |"
   else
-    echo "| macOS Intel | \`${mac_x64_version}\` | build \`${mac_x64_build}\` | $(table_cell "$mac_x64_pub_date") |  | 当前 latest，待目标版本 |"
+    echo "| macOS Intel | \`${mac_x64_version}\` | $(table_code_cell "$mac_x64_backend_version") | build \`${mac_x64_build}\` | $(table_cell "$mac_x64_pub_date") |  | 当前 latest，待目标版本 |"
   fi
   echo
   echo "本仓库以 Codex 内部版本聚合平台安装包；Windows MSIX 的四段包版本会单独列在“平台包 / build”列。"
@@ -816,37 +859,37 @@ mv "$tmp_manifest" release-manifest.json
   echo
   echo "## Versions and publish times"
   echo
-  echo "| Platform | Codex version | Platform package / build | Official publish time | Mirror publish time | Status |"
-  echo "|---|---:|---:|---|---|---|"
+  echo "| Platform | Codex version | Backend version | Platform package / build | Official publish time | Mirror publish time | Status |"
+  echo "|---|---:|---:|---:|---|---|---|"
   if [[ "$include_windows_x64" == "true" ]]; then
-    echo "| Windows x64 | \`${windows_app_version}\` | \`${windows_package_version}\` | $(table_cell "$windows_x64_last_modified") | ${published_at_label} | Published |"
+    echo "| Windows x64 | \`${windows_app_version}\` | $(table_code_cell "$windows_backend_version") | \`${windows_package_version}\` | $(table_cell "$windows_x64_last_modified") | ${published_at_label} | Published |"
   else
-    echo "| Windows x64 | \`${windows_app_version}\` | \`${windows_package_version}\` | $(table_cell "$windows_x64_last_modified") |  | Current latest, waiting for target version |"
+    echo "| Windows x64 | \`${windows_app_version}\` | $(table_code_cell "$windows_backend_version") | \`${windows_package_version}\` | $(table_cell "$windows_x64_last_modified") |  | Current latest, waiting for target version |"
   fi
   if [[ "$include_windows_arm64" == "true" ]]; then
-    echo "| Windows ARM64 | \`${windows_arm64_app_version}\` | \`${windows_arm64_package_version:-$windows_package_version}\` | $(table_cell "$windows_arm64_last_modified") | ${published_at_label} | Published |"
+    echo "| Windows ARM64 | \`${windows_arm64_app_version}\` | $(table_code_cell "$windows_arm64_backend_version") | \`${windows_arm64_package_version:-$windows_package_version}\` | $(table_cell "$windows_arm64_last_modified") | ${published_at_label} | Published |"
   elif [[ -n "$windows_arm64_package" ]]; then
     if [[ "$windows_arm64_downloadable" == "true" ]]; then
-      echo "| Windows ARM64 | \`${windows_arm64_app_version}\` | \`${windows_arm64_package_version:-$windows_package_version}\` | $(table_cell "$windows_arm64_last_modified") |  | Current latest, waiting for target version |"
+      echo "| Windows ARM64 | \`${windows_arm64_app_version}\` | $(table_code_cell "$windows_arm64_backend_version") | \`${windows_arm64_package_version:-$windows_package_version}\` | $(table_cell "$windows_arm64_last_modified") |  | Current latest, waiting for target version |"
     elif [[ "$windows_arm64_missing_reason" == "skipped-rollout-drift" ]]; then
-      echo "| Windows ARM64 |  | \`${windows_arm64_package_version:-$windows_package_version}\` |  |  | Upstream version drifted during download; will be retried on the next probe (\`${windows_arm64_status}\`) |"
+      echo "| Windows ARM64 |  |  | \`${windows_arm64_package_version:-$windows_package_version}\` |  |  | Upstream version drifted during download; will be retried on the next probe (\`${windows_arm64_status}\`) |"
     elif [[ "$windows_arm64_missing_reason" == "skipped-version-unreadable" ]]; then
-      echo "| Windows ARM64 |  | \`${windows_arm64_package_version:-$windows_package_version}\` |  |  | Could not read internal version; will be retried on the next probe (\`${windows_arm64_status}\`) |"
+      echo "| Windows ARM64 |  |  | \`${windows_arm64_package_version:-$windows_package_version}\` |  |  | Could not read internal version; will be retried on the next probe (\`${windows_arm64_status}\`) |"
     else
-      echo "| Windows ARM64 |  | \`${windows_arm64_package_version:-$windows_package_version}\` |  |  | Present in Microsoft Store catalog, download URL unresolved (\`${windows_arm64_status:-catalog-only}\`) |"
+      echo "| Windows ARM64 |  |  | \`${windows_arm64_package_version:-$windows_package_version}\` |  |  | Present in Microsoft Store catalog, download URL unresolved (\`${windows_arm64_status:-catalog-only}\`) |"
     fi
   else
-    echo "| Windows ARM64 |  |  |  |  | Waiting for matching upstream package |"
+    echo "| Windows ARM64 |  |  |  |  |  | Waiting for matching upstream package |"
   fi
   if [[ "$include_macos_arm64" == "true" ]]; then
-    echo "| macOS Apple Silicon | \`${mac_arm_version}\` | build \`${mac_arm_build}\` | $(table_cell "$mac_arm_pub_date") | ${published_at_label} | Published |"
+    echo "| macOS Apple Silicon | \`${mac_arm_version}\` | $(table_code_cell "$mac_arm_backend_version") | build \`${mac_arm_build}\` | $(table_cell "$mac_arm_pub_date") | ${published_at_label} | Published |"
   else
-    echo "| macOS Apple Silicon | \`${mac_arm_version}\` | build \`${mac_arm_build}\` | $(table_cell "$mac_arm_pub_date") |  | Current latest, waiting for target version |"
+    echo "| macOS Apple Silicon | \`${mac_arm_version}\` | $(table_code_cell "$mac_arm_backend_version") | build \`${mac_arm_build}\` | $(table_cell "$mac_arm_pub_date") |  | Current latest, waiting for target version |"
   fi
   if [[ "$include_macos_x64" == "true" ]]; then
-    echo "| macOS Intel | \`${mac_x64_version}\` | build \`${mac_x64_build}\` | $(table_cell "$mac_x64_pub_date") | ${published_at_label} | Published |"
+    echo "| macOS Intel | \`${mac_x64_version}\` | $(table_code_cell "$mac_x64_backend_version") | build \`${mac_x64_build}\` | $(table_cell "$mac_x64_pub_date") | ${published_at_label} | Published |"
   else
-    echo "| macOS Intel | \`${mac_x64_version}\` | build \`${mac_x64_build}\` | $(table_cell "$mac_x64_pub_date") |  | Current latest, waiting for target version |"
+    echo "| macOS Intel | \`${mac_x64_version}\` | $(table_code_cell "$mac_x64_backend_version") | build \`${mac_x64_build}\` | $(table_cell "$mac_x64_pub_date") |  | Current latest, waiting for target version |"
   fi
   echo
   echo "This mirror groups platform installers by the Codex app's internal version; the four-part Windows MSIX package version is listed separately in the platform package / build column."

--- a/scripts/read-codex-backend-version.py
+++ b/scripts/read-codex-backend-version.py
@@ -1,0 +1,345 @@
+#!/usr/bin/env python3
+import argparse
+import hashlib
+import json
+import os
+import re
+import shutil
+import stat
+import subprocess
+import sys
+import tempfile
+import zipfile
+from pathlib import PurePosixPath
+
+
+BACKEND_VERSION_RE = re.compile(r"(?im)^\s*(?:codex-cli\s+)?([0-9]+\.[0-9]+\.[0-9][0-9A-Za-z._+-]*)\s*$")
+SHA256_RE = re.compile(r"^[0-9a-f]{64}$")
+MACOS_BACKEND_PATH = ("Contents", "Resources", "codex")
+WINDOWS_BACKEND_PATH = "app/resources/codex.exe"
+PREPARED_INPUT_MANIFEST = "backend-input.json"
+PREPARED_INPUT_SCHEMA_VERSION = 1
+BACKEND_FILE_NAMES = {
+    "macos": "codex",
+    "windows": "codex.exe",
+}
+
+
+def die(message):
+    print(message, file=sys.stderr)
+    raise SystemExit(1)
+
+
+def parse_version(output):
+    match = BACKEND_VERSION_RE.search(output)
+    return match.group(1) if match else ""
+
+
+def normalized_path(path):
+    return PurePosixPath(path.replace("\\", "/")).as_posix().lower()
+
+
+def sha256_file(path):
+    digest = hashlib.sha256()
+    with open(path, "rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def isolated_env(tmp_dir):
+    env = os.environ.copy()
+    home = os.path.join(tmp_dir, "home")
+    os.makedirs(home, exist_ok=True)
+    paths = {
+        "HOME": home,
+        "USERPROFILE": home,
+        "APPDATA": os.path.join(tmp_dir, "appdata"),
+        "LOCALAPPDATA": os.path.join(tmp_dir, "localappdata"),
+        "XDG_CONFIG_HOME": os.path.join(tmp_dir, "xdg-config"),
+        "XDG_CACHE_HOME": os.path.join(tmp_dir, "xdg-cache"),
+        "CODEX_HOME": os.path.join(tmp_dir, "codex-home"),
+    }
+    for key, value in paths.items():
+        os.makedirs(value, exist_ok=True)
+        env[key] = value
+    return env
+
+
+def run_backend(binary_path):
+    with tempfile.TemporaryDirectory(prefix="codex-backend-version-") as tmp_dir:
+        env = isolated_env(tmp_dir)
+        try:
+            completed = subprocess.run(
+                [binary_path, "--version"],
+                cwd=tmp_dir,
+                env=env,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                text=True,
+                timeout=20,
+                check=False,
+            )
+        except (OSError, subprocess.TimeoutExpired):
+            return ""
+
+    if completed.returncode != 0:
+        return ""
+    return parse_version((completed.stdout or "") + "\n" + (completed.stderr or ""))
+
+
+def iter_backend_paths(root):
+    root = os.path.abspath(root)
+    if os.path.isfile(root):
+        yield root
+        return
+
+    candidate = os.path.join(root, *MACOS_BACKEND_PATH)
+    if os.path.isfile(candidate):
+        yield candidate
+
+
+def ensure_executable(path):
+    if os.name == "nt":
+        return
+    try:
+        current = os.stat(path).st_mode
+        os.chmod(path, current | stat.S_IXUSR)
+    except OSError:
+        pass
+
+
+def zip_backend_entries(zip_file):
+    entries = [
+        info
+        for info in zip_file.infolist()
+        if normalized_path(info.filename) == WINDOWS_BACKEND_PATH
+    ]
+    entries.sort(key=lambda info: normalized_path(info.filename))
+    return entries
+
+
+def copy_windows_backend(path, target):
+    with zipfile.ZipFile(path) as zip_file:
+        entries = zip_backend_entries(zip_file)
+        if len(entries) != 1 or entries[0].is_dir():
+            return False
+        with zip_file.open(entries[0]) as source, open(target, "wb") as output:
+            shutil.copyfileobj(source, output)
+    return True
+
+
+def copy_macos_backend(path, target):
+    candidate = os.path.join(os.path.abspath(path), *MACOS_BACKEND_PATH)
+    if not os.path.isfile(candidate) or os.path.islink(candidate):
+        return False
+    shutil.copyfile(candidate, target)
+    return True
+
+
+def copy_packaged_backend(path, platform, target):
+    if platform == "windows":
+        if not os.path.isfile(path) or not zipfile.is_zipfile(path):
+            return False
+        return copy_windows_backend(path, target)
+    if platform == "macos":
+        return copy_macos_backend(path, target)
+    return False
+
+
+def read_backend_version_from_zip(path):
+    with tempfile.TemporaryDirectory(prefix="codex-backend-msix-") as tmp_dir:
+        target = os.path.join(tmp_dir, BACKEND_FILE_NAMES["windows"])
+        if copy_windows_backend(path, target):
+            ensure_executable(target)
+            return run_backend(target)
+    return ""
+
+
+def read_backend_version(path):
+    if os.path.isfile(path) and zipfile.is_zipfile(path):
+        return read_backend_version_from_zip(path)
+
+    for candidate in iter_backend_paths(path):
+        ensure_executable(candidate)
+        version = run_backend(candidate)
+        if version:
+            return version
+    return ""
+
+
+def remove_known_prepared_files(output_dir):
+    for name in (PREPARED_INPUT_MANIFEST, *BACKEND_FILE_NAMES.values()):
+        path = os.path.join(output_dir, name)
+        try:
+            if os.path.isfile(path) or os.path.islink(path):
+                os.remove(path)
+        except OSError:
+            pass
+
+
+def write_json(path, payload):
+    tmp_path = f"{path}.tmp"
+    try:
+        with open(tmp_path, "w", encoding="utf-8", newline="\n") as handle:
+            json.dump(payload, handle, indent=2, sort_keys=True)
+            handle.write("\n")
+        os.replace(tmp_path, path)
+    finally:
+        if os.path.exists(tmp_path):
+            os.remove(tmp_path)
+
+
+def prepare_backend_input(path, output_dir, source_package, source_sha256, platform, architecture):
+    output_dir = os.path.abspath(output_dir)
+    os.makedirs(output_dir, exist_ok=True)
+    remove_known_prepared_files(output_dir)
+
+    payload = {
+        "architecture": architecture,
+        "platform": platform,
+        "schemaVersion": PREPARED_INPUT_SCHEMA_VERSION,
+        "status": "unavailable",
+    }
+    source_sha256 = source_sha256.strip().lower()
+    try:
+        if not os.path.isfile(source_package):
+            raise ValueError("source package is missing")
+        if not source_sha256:
+            source_sha256 = sha256_file(source_package)
+        if not SHA256_RE.fullmatch(source_sha256):
+            raise ValueError("source package SHA256 is invalid")
+
+        payload["sourcePackageFileName"] = os.path.basename(source_package)
+        payload["sourcePackageSha256"] = source_sha256
+        backend_file_name = BACKEND_FILE_NAMES[platform]
+        backend_path = os.path.join(output_dir, backend_file_name)
+        backend_tmp_path = f"{backend_path}.tmp"
+        try:
+            if not copy_packaged_backend(path, platform, backend_tmp_path):
+                raise ValueError("fixed-path backend is unavailable")
+            backend_sha256 = sha256_file(backend_tmp_path)
+            os.replace(backend_tmp_path, backend_path)
+        finally:
+            if os.path.exists(backend_tmp_path):
+                os.remove(backend_tmp_path)
+
+        payload.update(
+            {
+                "backendFileName": backend_file_name,
+                "backendSha256": backend_sha256,
+                "status": "ready",
+            }
+        )
+    except (OSError, ValueError, zipfile.BadZipFile):
+        remove_known_prepared_files(output_dir)
+
+    manifest_path = os.path.join(output_dir, PREPARED_INPUT_MANIFEST)
+    write_json(manifest_path, payload)
+    return payload
+
+
+def read_prepared_backend_version(manifest_path, platform, architecture):
+    try:
+        with open(manifest_path, encoding="utf-8-sig") as handle:
+            payload = json.load(handle)
+        if not isinstance(payload, dict) or payload.get("status") != "ready":
+            return ""
+        if payload.get("schemaVersion") != PREPARED_INPUT_SCHEMA_VERSION:
+            return ""
+
+        prepared_platform = payload.get("platform")
+        prepared_architecture = payload.get("architecture")
+        if prepared_platform not in BACKEND_FILE_NAMES:
+            return ""
+        if platform and prepared_platform != platform:
+            return ""
+        if architecture and prepared_architecture != architecture:
+            return ""
+
+        source_file_name = payload.get("sourcePackageFileName")
+        source_sha256 = payload.get("sourcePackageSha256")
+        backend_file_name = payload.get("backendFileName")
+        backend_sha256 = payload.get("backendSha256")
+        if (
+            not isinstance(source_file_name, str)
+            or not source_file_name
+            or os.path.basename(source_file_name) != source_file_name
+            or not isinstance(source_sha256, str)
+            or not SHA256_RE.fullmatch(source_sha256.lower())
+            or backend_file_name != BACKEND_FILE_NAMES[prepared_platform]
+            or not isinstance(backend_sha256, str)
+            or not SHA256_RE.fullmatch(backend_sha256.lower())
+        ):
+            return ""
+
+        backend_path = os.path.join(os.path.dirname(os.path.abspath(manifest_path)), backend_file_name)
+        if not os.path.isfile(backend_path) or os.path.islink(backend_path):
+            return ""
+        if sha256_file(backend_path) != backend_sha256.lower():
+            return ""
+        ensure_executable(backend_path)
+        return run_backend(backend_path)
+    except (OSError, TypeError, ValueError, json.JSONDecodeError):
+        return ""
+
+
+def main(argv):
+    parser = argparse.ArgumentParser(description="Read the bundled Codex backend version by running the packaged backend binary.")
+    parser.add_argument("path", help="MSIX/ZIP, backend executable, mounted Codex.app, or prepared input manifest")
+    parser.add_argument("--json", action="store_true", help="Always emit a JSON metadata object and exit 0")
+    parser.add_argument("--platform", default="", help="Platform label for --json output")
+    parser.add_argument("--architecture", default="", help="Architecture label for --json output")
+    parser.add_argument("--prepare-input-dir", default="", help="Extract a fixed-path backend into a small native-job input directory")
+    parser.add_argument("--prepared-input", action="store_true", help="Validate and run a backend from a prepared input manifest")
+    parser.add_argument("--source-package", default="", help="Source package recorded by --prepare-input-dir")
+    parser.add_argument("--source-package-sha256", default="", help="Known source package SHA256 for --prepare-input-dir")
+    args = parser.parse_args(argv[1:])
+
+    if args.prepare_input_dir and args.prepared_input:
+        die("--prepare-input-dir and --prepared-input are mutually exclusive.")
+    if args.prepare_input_dir:
+        if args.platform not in BACKEND_FILE_NAMES:
+            die("--prepare-input-dir requires --platform windows or macos.")
+        if not args.architecture:
+            die("--prepare-input-dir requires --architecture.")
+        if not args.source_package:
+            die("--prepare-input-dir requires --source-package.")
+        payload = prepare_backend_input(
+            args.path,
+            args.prepare_input_dir,
+            args.source_package,
+            args.source_package_sha256,
+            args.platform,
+            args.architecture,
+        )
+        json.dump(payload, sys.stdout, indent=2, sort_keys=True)
+        sys.stdout.write("\n")
+        return
+
+    if args.prepared_input:
+        version = read_prepared_backend_version(args.path, args.platform, args.architecture)
+    else:
+        version = read_backend_version(args.path)
+    if args.json:
+        payload = {
+            "status": "found" if version else "unavailable",
+        }
+        if args.platform:
+            payload["platform"] = args.platform
+        if args.architecture:
+            payload["architecture"] = args.architecture
+        if version:
+            payload["backendVersion"] = version
+        json.dump(payload, sys.stdout, indent=2, sort_keys=True)
+        sys.stdout.write("\n")
+        return
+
+    if version:
+        print(version)
+        return
+    die("Could not read Codex backend version by running the packaged backend binary.")
+
+
+if __name__ == "__main__":
+    main(sys.argv)

--- a/scripts/read-macos-backend-metadata.sh
+++ b/scripts/read-macos-backend-metadata.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+output_path="${1:?output path is required}"
+arch="${2:?architecture is required}"
+input_manifest="${3:?prepared backend input manifest is required}"
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+tmp_output="$(mktemp)"
+
+cleanup() {
+  rm -f "$tmp_output"
+}
+trap cleanup EXIT
+
+mkdir -p "$(dirname "$output_path")"
+if python3 "$script_dir/read-codex-backend-version.py" \
+  --prepared-input \
+  --json \
+  --platform macos \
+  --architecture "$arch" \
+  "$input_manifest" > "$tmp_output" &&
+  python3 -m json.tool "$tmp_output" >/dev/null; then
+  mv "$tmp_output" "$output_path"
+else
+  echo "Could not read macOS $arch backend metadata; leaving it unavailable." >&2
+  printf '%s\n' \
+    "{\"architecture\":\"$arch\",\"platform\":\"macos\",\"status\":\"unavailable\"}" \
+    > "$output_path"
+fi
+
+cat "$output_path"

--- a/scripts/read-macos-metadata.sh
+++ b/scripts/read-macos-metadata.sh
@@ -6,6 +6,8 @@ arm64_dmg="${2:-dist/macos/Codex-mac-arm64.dmg}"
 x64_dmg="${3:-dist/macos/Codex-mac-x64.dmg}"
 arm64_zip="${4:-}"
 x64_zip="${5:-}"
+x64_backend_input_dir="${6:-}"
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 require() {
   if ! command -v "$1" >/dev/null 2>&1; then
@@ -196,7 +198,9 @@ inspect_dmg() {
   local arch="$1"
   local dmg="$2"
   local json_path="$3"
+  local backend_input_dir="${4:-}"
   local volume
+  local backend_version
   local sha256
 
   mount_dmg "$dmg"
@@ -205,8 +209,29 @@ inspect_dmg() {
   find_single_top_level_app "$volume" "$dmg"
   inspect_app_identity "$dmg" "$found_app_path"
   sha256="$(shasum -a 256 "$dmg" | awk '{print $1}')"
+  backend_version="$(python3 "$script_dir/read-codex-backend-version.py" "$found_app_path" 2>/dev/null || true)"
 
-  python3 - "$json_path" "$arch" "$dmg" "$sha256" "$identity_short_version" "$identity_bundle_version" "$identity_bundle_id" "$identity_bundle_name" "$identity_bundle_executable" "$identity_minimum_system_version" "$identity_team_identifier" "$identity_sparkle_public_ed_key" <<'PY'
+  if [[ -n "$backend_input_dir" ]]; then
+    mkdir -p "$backend_input_dir"
+    if ! python3 "$script_dir/read-codex-backend-version.py" \
+      --prepare-input-dir "$backend_input_dir" \
+      --source-package "$dmg" \
+      --source-package-sha256 "$sha256" \
+      --platform macos \
+      --architecture "$arch" \
+      "$found_app_path" > "$tmp_dir/backend-input-$arch.log"; then
+      echo "Could not prepare macOS $arch backend input; metadata will remain unavailable." >&2
+      rm -f \
+        "$backend_input_dir/codex" \
+        "$backend_input_dir/codex.exe" \
+        "$backend_input_dir/backend-input.json"
+      printf '%s\n' \
+        "{\"architecture\":\"$arch\",\"platform\":\"macos\",\"schemaVersion\":1,\"status\":\"unavailable\"}" \
+        > "$backend_input_dir/backend-input.json"
+    fi
+  fi
+
+  python3 - "$json_path" "$arch" "$dmg" "$sha256" "$identity_short_version" "$identity_bundle_version" "$identity_bundle_id" "$identity_bundle_name" "$identity_bundle_executable" "$identity_minimum_system_version" "$identity_team_identifier" "$identity_sparkle_public_ed_key" "$backend_version" <<'PY'
 import json
 import os
 import sys
@@ -224,6 +249,7 @@ import sys
     minimum,
     team_identifier,
     sparkle_public_ed_key,
+    backend,
 ) = sys.argv[1:]
 payload = {
     "architecture": arch,
@@ -238,6 +264,8 @@ payload = {
     "teamIdentifier": team_identifier,
     "sparklePublicEdKey": sparkle_public_ed_key,
 }
+if backend:
+    payload["backendVersion"] = backend
 with open(out, "w", encoding="utf-8") as handle:
     json.dump(payload, handle, indent=2, sort_keys=True)
     handle.write("\n")
@@ -300,7 +328,7 @@ PY
 mkdir -p "$(dirname "$output_path")"
 
 inspect_dmg arm64 "$arm64_dmg" "$tmp_dir/arm64.json"
-inspect_dmg x64 "$x64_dmg" "$tmp_dir/x64.json"
+inspect_dmg x64 "$x64_dmg" "$tmp_dir/x64.json" "$x64_backend_input_dir"
 
 if [[ -n "$arm64_zip" ]]; then
   verify_sparkle_archive arm64 "$arm64_zip" "$tmp_dir/arm64.json"

--- a/scripts/test-prepare-release-metadata.sh
+++ b/scripts/test-prepare-release-metadata.sh
@@ -34,7 +34,7 @@ PY
 }
 
 mkdir -p "$tmp_dir/artifacts/codex-macos" "$tmp_dir/artifacts/codex-windows"
-mkdir -p "$tmp_dir/artifacts/codex-windows-arm64-backend"
+mkdir -p "$tmp_dir/artifacts/codex-windows-arm64-backend" "$tmp_dir/artifacts/codex-macos-x64-backend"
 mkdir -p "$tmp_dir/bin"
 
 printf 'arm' > "$tmp_dir/artifacts/codex-macos/Codex-mac-arm64.dmg"
@@ -111,6 +111,7 @@ cat > "$tmp_dir/macos-metadata.json" <<'JSON'
     "arm64": {
       "bundleShortVersion": "1.2.3",
       "bundleVersion": "5",
+      "backendVersion": "0.140.1",
       "bundleIdentifier": "com.openai.codex",
       "bundleName": "ChatGPT",
       "bundleExecutable": "ChatGPT",
@@ -163,6 +164,14 @@ cat > "$tmp_dir/artifacts/codex-windows-arm64-backend/windows-backend-arm64.json
 }
 JSON
 
+cat > "$tmp_dir/artifacts/codex-macos-x64-backend/macos-backend-x64.json" <<'JSON'
+{
+  "architecture": "x64",
+  "backendVersion": "0.140.2",
+  "platform": "macos",
+  "status": "found"
+}
+JSON
 (
   cd "$tmp_dir"
 
@@ -198,7 +207,7 @@ JSON
   test "$(jq -r '.sources.windows.architectures.arm64.backendVersion' release-manifest.json)" = "0.1.3"
   test "$(jq -r '.derived.windowsBackendVersion' release-manifest.json)" = "0.1.2"
   test "$(jq -r '.derived.windowsArm64BackendVersion' release-manifest.json)" = "0.1.3"
-  grep -F '| macOS Apple Silicon | `1.2.3` |  | build `5` |' release-notes.md
+  grep -F '| macOS Apple Silicon | `1.2.3` | `0.140.1` | build `5` |' release-notes.md
   grep -F 'These latest links roll forward per architecture:' release-notes.md
   test "$(jq -r '.schemaVersion' release-manifest.json)" = "5"
   test "$(jq -r '.sources.macos.arm64.appcast.sourceBasename' release-manifest.json)" = "ChatGPT-darwin-arm64-1.2.3.zip"
@@ -208,6 +217,10 @@ JSON
   test "$(jq -r '.derived.missingArchitectures | length' release-manifest.json)" = "0"
   test "$(jq -r '.sources.windows.architectures.arm64.currentForCodexVersion' release-manifest.json)" = "true"
   test "$(jq -r '.sources.windows.architectures.arm64.currentLocalArtifact' release-manifest.json)" = "true"
+  test "$(jq -r '.sources.macos.arm64.backendVersion' release-manifest.json)" = "0.140.1"
+  test "$(jq -r '.sources.macos.x64.backendVersion' release-manifest.json)" = "0.140.2"
+  test "$(jq -r '.derived.macosArm64BackendVersion' release-manifest.json)" = "0.140.1"
+  test "$(jq -r '.derived.macosX64BackendVersion' release-manifest.json)" = "0.140.2"
   test "$(jq -r '.derived.latestChecksums["Codex-mac-arm64.dmg"] | test("^[0-9a-f]{64}$")' release-manifest.json)" = "true"
   test "$(jq -r '.derived.latestChecksums["OpenAI.Codex_1.2.3.4_arm64__2p2nqsd0c76g0.Msix"] | test("^[0-9a-f]{64}$")' release-manifest.json)" = "true"
 
@@ -547,6 +560,10 @@ SUMS
     test "$(jq -r '.sources.macos.x64.currentForCodexVersion' release-manifest.json)" = "false"
     test "$(jq -r '.sources.windows.architectures.arm64.currentForCodexVersion' release-manifest.json)" = "false"
     test "$(jq -r '.sources.windows.architectures.arm64.currentLocalArtifact' release-manifest.json)" = "true"
+    test "$(jq -r '.sources.macos.arm64.backendVersion' release-manifest.json)" = "0.140.1"
+    test "$(jq -r '.sources.macos.x64.backendVersion' release-manifest.json)" = "0.140.2"
+    test "$(jq -r '.derived.macosArm64BackendVersion' release-manifest.json)" = "0.140.1"
+    test "$(jq -r '.derived.macosX64BackendVersion' release-manifest.json)" = "0.140.2"
     grep -F '这些 latest 链接按架构滚动' release-notes.md
   )
 

--- a/scripts/test-prepare-release-metadata.sh
+++ b/scripts/test-prepare-release-metadata.sh
@@ -29,10 +29,12 @@ header_size = 8 + len(header_json)
 asar = struct.pack("<IIII", 4, header_size, len(header_json) + 4, len(header_json)) + header_json + package_json
 with zipfile.ZipFile(msix_path, "w") as archive:
     archive.writestr("app/resources/app.asar", asar)
+    archive.writestr("app/resources/codex.exe", b"binary-prefix 0.1.2https://chatgpt.com/backend-api/ binary-suffix")
 PY
 }
 
 mkdir -p "$tmp_dir/artifacts/codex-macos" "$tmp_dir/artifacts/codex-windows"
+mkdir -p "$tmp_dir/artifacts/codex-windows-arm64-backend"
 mkdir -p "$tmp_dir/bin"
 
 printf 'arm' > "$tmp_dir/artifacts/codex-macos/Codex-mac-arm64.dmg"
@@ -40,13 +42,13 @@ printf 'x64' > "$tmp_dir/artifacts/codex-macos/Codex-mac-x64.dmg"
 printf 'armzip123' > "$tmp_dir/artifacts/codex-macos/Codex-darwin-arm64-1.2.3.zip"
 printf 'armzip124' > "$tmp_dir/artifacts/codex-macos/Codex-darwin-arm64-1.2.4.zip"
 printf 'x64zip123' > "$tmp_dir/artifacts/codex-macos/Codex-darwin-x64-1.2.3.zip"
-printf 'win' > "$tmp_dir/artifacts/codex-windows/OpenAI.Codex_1.2.3.4_x64__2p2nqsd0c76g0.Msix"
+write_minimal_msix "$tmp_dir/artifacts/codex-windows/OpenAI.Codex_1.2.3.4_x64__2p2nqsd0c76g0.Msix" 1.2.3
 write_minimal_msix "$tmp_dir/artifacts/codex-windows/OpenAI.Codex_1.2.3.4_arm64__2p2nqsd0c76g0.Msix" 1.2.3
 write_minimal_msix "$tmp_dir/minimal-9.8.7.Msix" 9.8.7
 
+test "$(python3 "$repo_root/scripts/read-windows-msix-version.py" "$tmp_dir/artifacts/codex-windows/OpenAI.Codex_1.2.3.4_x64__2p2nqsd0c76g0.Msix")" = "1.2.3"
 test "$(python3 "$repo_root/scripts/read-windows-msix-version.py" "$tmp_dir/artifacts/codex-windows/OpenAI.Codex_1.2.3.4_arm64__2p2nqsd0c76g0.Msix")" = "1.2.3"
 test "$(python3 "$repo_root/scripts/read-windows-msix-version.py" "$tmp_dir/minimal-9.8.7.Msix")" = "9.8.7"
-
 cat > "$tmp_dir/probe-manifest.json" <<'JSON'
 {
   "schemaVersion": 1,
@@ -143,8 +145,27 @@ cat > "$tmp_dir/macos-metadata.json" <<'JSON'
 }
 JSON
 
+cat > "$tmp_dir/artifacts/codex-windows/windows-backend-x64.json" <<'JSON'
+{
+  "architecture": "x64",
+  "backendVersion": "0.1.2",
+  "platform": "windows",
+  "status": "found"
+}
+JSON
+
+cat > "$tmp_dir/artifacts/codex-windows-arm64-backend/windows-backend-arm64.json" <<'JSON'
+{
+  "architecture": "arm64",
+  "backendVersion": "0.1.3",
+  "platform": "windows",
+  "status": "found"
+}
+JSON
+
 (
   cd "$tmp_dir"
+
   WINDOWS_APP_VERSION=1.2.3 "$repo_root/scripts/prepare-release-metadata.sh" \
     probe-manifest.json \
     macos-metadata.json \
@@ -169,10 +190,15 @@ JSON
   grep -F 'OpenAI.Codex_1.2.3.4_arm64__2p2nqsd0c76g0.Msix' SHA256SUMS.txt
   grep -F 'OpenAI.Codex_1.2.3.4_arm64__2p2nqsd0c76g0.Msix' latest-SHA256SUMS.txt
   grep -F '![Codex App Mirror](https://github.com/Wangnov/codex-app-mirror/releases/latest/download/status.png)' release-notes.md
-  grep -F '| Windows x64 | `1.2.3` | `1.2.3.4` |' release-notes.md
-  grep -F '| Windows ARM64 | `1.2.3` | `1.2.3.4` |' release-notes.md
+  grep -F '| Windows x64 | `1.2.3` | `0.1.2` | `1.2.3.4` |' release-notes.md
+  grep -F '| Windows ARM64 | `1.2.3` | `0.1.3` | `1.2.3.4` |' release-notes.md
   grep -F 'Windows x64: https://example.com/latest/win-x64' release-notes.md
-  grep -F '| macOS Apple Silicon | `1.2.3` | build `5` |' release-notes.md
+  test "$(jq -r '.sources.windows.backendVersion' release-manifest.json)" = "0.1.2"
+  test "$(jq -r '.sources.windows.architectures.x64.backendVersion' release-manifest.json)" = "0.1.2"
+  test "$(jq -r '.sources.windows.architectures.arm64.backendVersion' release-manifest.json)" = "0.1.3"
+  test "$(jq -r '.derived.windowsBackendVersion' release-manifest.json)" = "0.1.2"
+  test "$(jq -r '.derived.windowsArm64BackendVersion' release-manifest.json)" = "0.1.3"
+  grep -F '| macOS Apple Silicon | `1.2.3` |  | build `5` |' release-notes.md
   grep -F 'These latest links roll forward per architecture:' release-notes.md
   test "$(jq -r '.schemaVersion' release-manifest.json)" = "5"
   test "$(jq -r '.sources.macos.arm64.appcast.sourceBasename' release-manifest.json)" = "ChatGPT-darwin-arm64-1.2.3.zip"
@@ -189,6 +215,39 @@ JSON
     echo "SHA256SUMS.txt should use basenames, not CI artifact paths." >&2
     exit 1
   fi
+
+  cp -R artifacts artifacts-backend-unavailable
+  printf '{invalid-json\n' > artifacts-backend-unavailable/codex-windows/windows-backend-x64.json
+  printf '{"architecture":"arm64","platform":"windows","status":"unavailable"}\n' \
+    > artifacts-backend-unavailable/codex-windows-arm64-backend/windows-backend-arm64.json
+  printf '{"architecture":"x64","platform":"macos","status":"unavailable"}\n' \
+    > artifacts-backend-unavailable/codex-macos-x64-backend/macos-backend-x64.json
+  jq 'del(.macos.arm64.backendVersion, .macos.x64.backendVersion)' \
+    macos-metadata.json > macos-metadata-backend-unavailable.json
+  mkdir backend-unavailable
+  (
+    cd backend-unavailable
+    WINDOWS_APP_VERSION=1.2.3 "$repo_root/scripts/prepare-release-metadata.sh" \
+      ../probe-manifest.json \
+      ../macos-metadata-backend-unavailable.json \
+      ../artifacts-backend-unavailable \
+      https://example.com > output.txt
+
+    test "$(jq -r '.derived.platformCompleteness' release-manifest.json)" = "complete"
+    jq -e '
+      (.sources.windows | has("backendVersion") | not)
+      and (.sources.windows.architectures.x64 | has("backendVersion") | not)
+      and (.sources.windows.architectures.arm64 | has("backendVersion") | not)
+      and (.sources.macos.arm64 | has("backendVersion") | not)
+      and (.sources.macos.x64 | has("backendVersion") | not)
+      and (.derived.windowsBackendVersion == "")
+      and (.derived.windowsArm64BackendVersion == "")
+      and (.derived.macosArm64BackendVersion == "")
+      and (.derived.macosX64BackendVersion == "")
+    ' release-manifest.json
+    grep -F '| Windows x64 | `1.2.3` |  | `1.2.3.4` |' release-notes.md
+    grep -F '| macOS Intel | `1.2.3` |  | build `5` |' release-notes.md
+  )
 
   cp -R artifacts artifacts-arm64-drift
   rm artifacts-arm64-drift/codex-windows/OpenAI.Codex_1.2.3.4_arm64__2p2nqsd0c76g0.Msix
@@ -320,6 +379,7 @@ CURL
           "downloadable": true,
           "version": "1.2.3.4",
           "appVersion": "1.2.3",
+          "backendVersion": "0.1.1",
           "packageMoniker": "OpenAI.Codex_1.2.3.4_arm64__2p2nqsd0c76g0",
           "contentLength": 12,
           "lastModified": "Wed, 10 Jun 2026 00:00:00 GMT"
@@ -353,6 +413,9 @@ SUMS
     test "$(jq -r '.sources.windows.architectures.arm64.currentForCodexVersion' release-manifest.json)" = "true"
     test "$(jq -r '.sources.windows.architectures.arm64.currentLocalArtifact' release-manifest.json)" = "false"
     test "$(jq -r '.sources.windows.architectures.arm64.preservedFromLatest' release-manifest.json)" = "true"
+    test "$(jq -r '.sources.windows.architectures.arm64.backendVersion' release-manifest.json)" = "0.1.1"
+    test "$(jq -r '.derived.windowsArm64BackendVersion' release-manifest.json)" = "0.1.1"
+    grep -F '| Windows ARM64 | `1.2.3` | `0.1.1` | `1.2.3.4` |' release-notes.md
     test "$(jq -r '.derived.latestChecksums["OpenAI.Codex_1.2.3.4_arm64__2p2nqsd0c76g0.Msix"]' release-manifest.json)" = "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
   )
 

--- a/scripts/test-read-codex-backend-version.sh
+++ b/scripts/test-read-codex-backend-version.sh
@@ -1,0 +1,248 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+tmp_dir="$(mktemp -d)"
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cleanup() {
+  rm -rf "$tmp_dir"
+}
+trap cleanup EXIT
+
+mkdir -p \
+  "$tmp_dir/Codex.app/Contents/MacOS" \
+  "$tmp_dir/Codex.app/Contents/Resources" \
+  "$tmp_dir/msix/app/resources"
+
+cat > "$tmp_dir/Codex.app/Contents/MacOS/Codex" <<'SH'
+#!/usr/bin/env bash
+printf 'Codex 149.0.7827.197\n'
+SH
+chmod +x "$tmp_dir/Codex.app/Contents/MacOS/Codex"
+
+cat > "$tmp_dir/Codex.app/Contents/Resources/codex" <<'SH'
+#!/usr/bin/env bash
+printf 'codex-cli 0.142.5\n'
+SH
+chmod +x "$tmp_dir/Codex.app/Contents/Resources/codex"
+
+test "$(python3 "$repo_root/scripts/read-codex-backend-version.py" "$tmp_dir/Codex.app")" = "0.142.5"
+
+cat > "$tmp_dir/msix/app/Codex.exe" <<'SH'
+#!/usr/bin/env bash
+printf 'Codex 149.0.7827.197\n'
+SH
+chmod +x "$tmp_dir/msix/app/Codex.exe"
+
+cat > "$tmp_dir/msix/app/resources/codex.exe" <<'SH'
+#!/usr/bin/env bash
+printf '0.143.0\n'
+SH
+chmod +x "$tmp_dir/msix/app/resources/codex.exe"
+(
+  cd "$tmp_dir/msix"
+  zip -q -r "$tmp_dir/backend.Msix" app
+)
+
+test "$(python3 "$repo_root/scripts/read-codex-backend-version.py" "$tmp_dir/backend.Msix")" = "0.143.0"
+python3 "$repo_root/scripts/read-codex-backend-version.py" \
+  --json \
+  --platform windows \
+  --architecture x64 \
+  "$tmp_dir/backend.Msix" > "$tmp_dir/backend.json"
+test "$(jq -r '.backendVersion' "$tmp_dir/backend.json")" = "0.143.0"
+test "$(jq -r '.status' "$tmp_dir/backend.json")" = "found"
+
+windows_input_dir="$tmp_dir/windows-arm64-input"
+windows_source_sha256="$(sha256sum "$tmp_dir/backend.Msix" | awk '{print $1}')"
+python3 "$repo_root/scripts/read-codex-backend-version.py" \
+  --prepare-input-dir "$windows_input_dir" \
+  --source-package "$tmp_dir/backend.Msix" \
+  --source-package-sha256 "$windows_source_sha256" \
+  --platform windows \
+  --architecture arm64 \
+  "$tmp_dir/backend.Msix" > "$tmp_dir/windows-input.log"
+
+windows_input_manifest="$windows_input_dir/backend-input.json"
+test "$(jq -r '.status' "$windows_input_manifest")" = "ready"
+test "$(jq -r '.platform' "$windows_input_manifest")" = "windows"
+test "$(jq -r '.architecture' "$windows_input_manifest")" = "arm64"
+test "$(jq -r '.sourcePackageFileName' "$windows_input_manifest")" = "backend.Msix"
+test "$(jq -r '.sourcePackageSha256' "$windows_input_manifest")" = "$windows_source_sha256"
+test "$(jq -r '.backendFileName' "$windows_input_manifest")" = "codex.exe"
+test "$(jq -r '.backendSha256' "$windows_input_manifest")" = "$(sha256sum "$windows_input_dir/codex.exe" | awk '{print $1}')"
+test "$(find "$windows_input_dir" -maxdepth 1 -type f | wc -l | tr -d ' ')" = "2"
+test -z "$(find "$windows_input_dir" -maxdepth 1 -name '*.tmp' -print -quit)"
+
+python3 "$repo_root/scripts/read-codex-backend-version.py" \
+  --prepared-input \
+  --json \
+  --platform windows \
+  --architecture arm64 \
+  "$windows_input_manifest" > "$tmp_dir/windows-native.json"
+test "$(jq -r '.status' "$tmp_dir/windows-native.json")" = "found"
+test "$(jq -r '.backendVersion' "$tmp_dir/windows-native.json")" = "0.143.0"
+
+cp -R "$windows_input_dir" "$tmp_dir/windows-tampered-input"
+printf '\ntampered\n' >> "$tmp_dir/windows-tampered-input/codex.exe"
+python3 "$repo_root/scripts/read-codex-backend-version.py" \
+  --prepared-input \
+  --json \
+  --platform windows \
+  --architecture arm64 \
+  "$tmp_dir/windows-tampered-input/backend-input.json" > "$tmp_dir/windows-tampered.json"
+test "$(jq -r '.status' "$tmp_dir/windows-tampered.json")" = "unavailable"
+test "$(jq -r '.backendVersion // empty' "$tmp_dir/windows-tampered.json")" = ""
+
+cp -R "$windows_input_dir" "$tmp_dir/windows-invalid-source-input"
+python3 - "$tmp_dir/windows-invalid-source-input/backend-input.json" <<'PY'
+import json
+import sys
+
+path = sys.argv[1]
+with open(path, encoding="utf-8") as handle:
+    payload = json.load(handle)
+payload["sourcePackageSha256"] = "invalid"
+with open(path, "w", encoding="utf-8") as handle:
+    json.dump(payload, handle)
+PY
+python3 "$repo_root/scripts/read-codex-backend-version.py" \
+  --prepared-input \
+  --json \
+  --platform windows \
+  --architecture arm64 \
+  "$tmp_dir/windows-invalid-source-input/backend-input.json" > "$tmp_dir/windows-invalid-source.json"
+test "$(jq -r '.status' "$tmp_dir/windows-invalid-source.json")" = "unavailable"
+
+cp -R "$windows_input_dir" "$tmp_dir/windows-wrong-arch-input"
+python3 "$repo_root/scripts/read-codex-backend-version.py" \
+  --prepared-input \
+  --json \
+  --platform windows \
+  --architecture x64 \
+  "$tmp_dir/windows-wrong-arch-input/backend-input.json" > "$tmp_dir/windows-wrong-arch.json"
+test "$(jq -r '.status' "$tmp_dir/windows-wrong-arch.json")" = "unavailable"
+
+mkdir -p "$tmp_dir/no-backend-msix/app"
+cp "$tmp_dir/msix/app/Codex.exe" "$tmp_dir/no-backend-msix/app/Codex.exe"
+(
+  cd "$tmp_dir/no-backend-msix"
+  zip -q -r "$tmp_dir/no-backend.Msix" app
+)
+python3 "$repo_root/scripts/read-codex-backend-version.py" \
+  --prepare-input-dir "$tmp_dir/unavailable-windows-input" \
+  --source-package "$tmp_dir/no-backend.Msix" \
+  --platform windows \
+  --architecture arm64 \
+  "$tmp_dir/no-backend.Msix" > "$tmp_dir/unavailable-windows-input.log"
+test "$(jq -r '.status' "$tmp_dir/unavailable-windows-input/backend-input.json")" = "unavailable"
+test "$(find "$tmp_dir/unavailable-windows-input" -maxdepth 1 -type f | wc -l | tr -d ' ')" = "1"
+
+mkdir -p \
+  "$tmp_dir/electron-app/Codex.app/Contents/MacOS" \
+  "$tmp_dir/electron-app/Codex.app/Contents/Resources" \
+  "$tmp_dir/electron-app/Codex.app/Nested.app/Contents/Resources"
+cat > "$tmp_dir/electron-app/Codex.app/Contents/MacOS/Codex" <<'SH'
+#!/usr/bin/env bash
+printf 'Codex 149.0.7827.197\n'
+SH
+chmod +x "$tmp_dir/electron-app/Codex.app/Contents/MacOS/Codex"
+cat > "$tmp_dir/electron-app/Codex.app/Contents/Resources/codex" <<'SH'
+#!/usr/bin/env bash
+printf 'Codex 149.0.7827.197\n'
+SH
+chmod +x "$tmp_dir/electron-app/Codex.app/Contents/Resources/codex"
+cat > "$tmp_dir/electron-app/Codex.app/Nested.app/Contents/Resources/codex" <<'SH'
+#!/usr/bin/env bash
+printf 'codex-cli 9.9.9\n'
+SH
+chmod +x "$tmp_dir/electron-app/Codex.app/Nested.app/Contents/Resources/codex"
+if python3 "$repo_root/scripts/read-codex-backend-version.py" "$tmp_dir/electron-app/Codex.app" >/dev/null 2>&1; then
+  echo "Expected invalid canonical macOS backend to remain unavailable." >&2
+  exit 1
+fi
+python3 "$repo_root/scripts/read-codex-backend-version.py" \
+  --json \
+  --platform macos \
+  --architecture arm64 \
+  "$tmp_dir/electron-app/Codex.app" > "$tmp_dir/electron-app.json"
+test "$(jq -r '.status' "$tmp_dir/electron-app.json")" = "unavailable"
+test "$(jq -r '.backendVersion // empty' "$tmp_dir/electron-app.json")" = ""
+
+mkdir -p \
+  "$tmp_dir/electron-msix/app" \
+  "$tmp_dir/electron-msix/app/resources" \
+  "$tmp_dir/electron-msix/decoy/app/resources"
+cat > "$tmp_dir/electron-msix/app/Codex.exe" <<'SH'
+#!/usr/bin/env bash
+printf 'Codex 149.0.7827.197\n'
+SH
+chmod +x "$tmp_dir/electron-msix/app/Codex.exe"
+cat > "$tmp_dir/electron-msix/app/resources/codex.exe" <<'SH'
+#!/usr/bin/env bash
+printf 'Codex 149.0.7827.197\n'
+SH
+chmod +x "$tmp_dir/electron-msix/app/resources/codex.exe"
+cat > "$tmp_dir/electron-msix/decoy/app/resources/codex.exe" <<'SH'
+#!/usr/bin/env bash
+printf 'codex-cli 9.9.9\n'
+SH
+chmod +x "$tmp_dir/electron-msix/decoy/app/resources/codex.exe"
+(
+  cd "$tmp_dir/electron-msix"
+  zip -q -r "$tmp_dir/electron-only.Msix" app decoy
+)
+python3 - "$tmp_dir/electron-only.Msix" <<'PY'
+import sys
+import zipfile
+
+decoy = b"#!/usr/bin/env bash\nprintf 'codex-cli 9.9.8\\n'\n"
+with zipfile.ZipFile(sys.argv[1], "a") as archive:
+    archive.writestr("../app/resources/codex.exe", decoy)
+    archive.writestr("/app/resources/codex.exe", decoy)
+PY
+if python3 "$repo_root/scripts/read-codex-backend-version.py" "$tmp_dir/electron-only.Msix" >/dev/null 2>&1; then
+  echo "Expected invalid canonical Windows backend to remain unavailable." >&2
+  exit 1
+fi
+python3 "$repo_root/scripts/read-codex-backend-version.py" \
+  --json \
+  --platform windows \
+  --architecture x64 \
+  "$tmp_dir/electron-only.Msix" > "$tmp_dir/electron-msix.json"
+test "$(jq -r '.status' "$tmp_dir/electron-msix.json")" = "unavailable"
+test "$(jq -r '.backendVersion // empty' "$tmp_dir/electron-msix.json")" = ""
+
+cat > "$tmp_dir/electron-direct" <<'SH'
+#!/usr/bin/env bash
+printf 'Codex 149.0.7827.197\n'
+SH
+chmod +x "$tmp_dir/electron-direct"
+if python3 "$repo_root/scripts/read-codex-backend-version.py" "$tmp_dir/electron-direct" >/dev/null 2>&1; then
+  echo "Expected Electron version output to be rejected." >&2
+  exit 1
+fi
+
+cat > "$tmp_dir/failing-backend" <<'SH'
+#!/usr/bin/env bash
+printf 'codex-cli 9.9.7\n'
+exit 1
+SH
+chmod +x "$tmp_dir/failing-backend"
+if python3 "$repo_root/scripts/read-codex-backend-version.py" "$tmp_dir/failing-backend" >/dev/null 2>&1; then
+  echo "Expected nonzero backend exit status to be rejected." >&2
+  exit 1
+fi
+python3 "$repo_root/scripts/read-codex-backend-version.py" --json "$tmp_dir/failing-backend" > "$tmp_dir/failing-backend.json"
+test "$(jq -r '.status' "$tmp_dir/failing-backend.json")" = "unavailable"
+test "$(jq -r '.backendVersion // empty' "$tmp_dir/failing-backend.json")" = ""
+
+printf 'not executable' > "$tmp_dir/missing"
+if python3 "$repo_root/scripts/read-codex-backend-version.py" "$tmp_dir/missing" >/dev/null 2>&1; then
+  echo "Expected missing backend version to fail." >&2
+  exit 1
+fi
+python3 "$repo_root/scripts/read-codex-backend-version.py" --json "$tmp_dir/missing" > "$tmp_dir/missing.json"
+test "$(jq -r '.status' "$tmp_dir/missing.json")" = "unavailable"
+test "$(jq -r '.backendVersion // empty' "$tmp_dir/missing.json")" = ""
+
+echo "read-codex-backend-version fixture PASS"

--- a/scripts/test-read-macos-metadata.sh
+++ b/scripts/test-read-macos-metadata.sh
@@ -109,7 +109,7 @@ add_app() {
   local bundle_version="${9:-5059}"
   local app_path="$tmp_dir/volumes/$fixture_name/$app_name"
 
-  mkdir -p "$app_path/Contents/MacOS"
+  mkdir -p "$app_path/Contents/MacOS" "$app_path/Contents/Resources"
   python3 - "$app_path/Contents/Info.plist" "$bundle_name" "$bundle_executable" "$bundle_identifier" "$sparkle_public_ed_key" "$bundle_short_version" "$bundle_version" <<'PY'
 import plistlib
 import sys
@@ -129,6 +129,8 @@ with open(path, "wb") as handle:
 PY
   printf '#!/bin/sh\nexit 0\n' > "$app_path/Contents/MacOS/$bundle_executable"
   chmod +x "$app_path/Contents/MacOS/$bundle_executable"
+  printf '#!/bin/sh\nprintf "codex-cli 0.142.5\\n"\n' > "$app_path/Contents/Resources/codex"
+  chmod +x "$app_path/Contents/Resources/codex"
   printf '%s\n' "$team_identifier" > "$app_path/.fixture-team-identifier"
 }
 
@@ -164,6 +166,10 @@ make_volume invalid-signature
 add_app invalid-signature ChatGPT.app ChatGPT ChatGPT "$expected_bundle_identifier" "$expected_sparkle_public_ed_key"
 touch "$tmp_dir/volumes/invalid-signature/ChatGPT.app/.fixture-invalid-signature"
 
+make_volume missing-backend
+add_app missing-backend ChatGPT.app ChatGPT ChatGPT "$expected_bundle_identifier" "$expected_sparkle_public_ed_key"
+rm "$tmp_dir/volumes/missing-backend/ChatGPT.app/Contents/Resources/codex"
+
 printf '%s\n' "$tmp_dir/volumes/codex-zip" > "$tmp_dir/codex.zip"
 printf '%s\n' "$tmp_dir/volumes/chatgpt-zip" > "$tmp_dir/chatgpt.zip"
 printf '%s\n' "$tmp_dir/volumes/classic" > "$tmp_dir/classic.zip"
@@ -180,18 +186,34 @@ run_reader() {
 }
 
 output_json="$tmp_dir/macos-metadata.json"
+backend_input_dir="$tmp_dir/macos-x64-backend-input"
 run_reader \
   "$output_json" \
   "$tmp_dir/codex.dmg" \
   "$tmp_dir/chatgpt.dmg" \
   "$tmp_dir/codex.zip" \
-  "$tmp_dir/chatgpt.zip" > "$tmp_dir/success.log"
+  "$tmp_dir/chatgpt.zip" \
+  "$backend_input_dir" > "$tmp_dir/success.log"
 
-python3 - "$output_json" "$expected_sparkle_public_ed_key" <<'PY'
+python3 - \
+  "$output_json" \
+  "$expected_sparkle_public_ed_key" \
+  "$backend_input_dir/backend-input.json" \
+  "$backend_input_dir/codex" \
+  "$tmp_dir/chatgpt.dmg" <<'PY'
+import hashlib
 import json
+import os
 import sys
 
-path, expected_key = sys.argv[1:]
+path, expected_key, input_manifest_path, backend_path, source_package_path = sys.argv[1:]
+
+
+def sha256(path):
+    with open(path, "rb") as handle:
+        return hashlib.sha256(handle.read()).hexdigest()
+
+
 with open(path, encoding="utf-8") as handle:
     payload = json.load(handle)
 
@@ -208,8 +230,63 @@ for item in (arm64, x64):
     assert item["sparkleArchiveIdentityVerified"] is True, item
     assert item["bundleVersion"] == "5059", item
     assert item["sparkleArchiveBundleVersion"] == "5060", item
+    assert item["backendVersion"] == "0.142.5", item
 assert payload["versionsMatch"] is True, payload
+
+with open(input_manifest_path, encoding="utf-8") as handle:
+    prepared = json.load(handle)
+assert prepared["schemaVersion"] == 1, prepared
+assert prepared["status"] == "ready", prepared
+assert prepared["platform"] == "macos", prepared
+assert prepared["architecture"] == "x64", prepared
+assert prepared["sourcePackageFileName"] == "chatgpt.dmg", prepared
+assert prepared["sourcePackageSha256"] == sha256(source_package_path), prepared
+assert prepared["backendFileName"] == "codex", prepared
+assert prepared["backendSha256"] == sha256(backend_path), prepared
+assert sorted(os.listdir(os.path.dirname(input_manifest_path))) == ["backend-input.json", "codex"]
 PY
+
+backend_output_json="$tmp_dir/macos-x64-backend.json"
+env \
+  PATH="$tmp_dir/bin:$PATH" \
+  bash "$repo_root/scripts/read-macos-backend-metadata.sh" \
+    "$backend_output_json" \
+    x64 \
+    "$backend_input_dir/backend-input.json" > "$tmp_dir/backend-success.log"
+
+python3 - "$backend_output_json" <<'PY'
+import json
+import sys
+
+with open(sys.argv[1], encoding="utf-8") as handle:
+    payload = json.load(handle)
+
+assert payload["architecture"] == "x64", payload
+assert payload["platform"] == "macos", payload
+assert payload["status"] == "found", payload
+assert payload["backendVersion"] == "0.142.5", payload
+PY
+
+printf '\ntampered\n' >> "$backend_input_dir/codex"
+tampered_output_json="$tmp_dir/macos-x64-tampered-backend.json"
+env \
+  PATH="$tmp_dir/bin:$PATH" \
+  bash "$repo_root/scripts/read-macos-backend-metadata.sh" \
+    "$tampered_output_json" \
+    x64 \
+    "$backend_input_dir/backend-input.json" > "$tmp_dir/backend-tampered.log"
+test "$(python3 -c 'import json, sys; print(json.load(open(sys.argv[1], encoding="utf-8"))["status"])' "$tampered_output_json")" = "unavailable"
+
+missing_backend_input_dir="$tmp_dir/macos-missing-backend-input"
+run_reader \
+  "$tmp_dir/missing-backend-output.json" \
+  "$tmp_dir/codex.dmg" \
+  "$tmp_dir/missing-backend.dmg" \
+  "" \
+  "" \
+  "$missing_backend_input_dir" > "$tmp_dir/missing-backend.log"
+test "$(python3 -c 'import json, sys; print(json.load(open(sys.argv[1], encoding="utf-8"))["status"])' "$missing_backend_input_dir/backend-input.json")" = "unavailable"
+test ! -e "$missing_backend_input_dir/codex"
 
 if ! grep -Fq -- '--verify --deep --strict --verbose=2' "$codesign_log"; then
   echo "Expected strict deep code signature verification" >&2


### PR DESCRIPTION
## Summary

- expose the bundled Codex backend version as optional release metadata
- record backend versions independently for Windows x64, Windows ARM64, macOS Apple Silicon, and macOS Intel
- show the values in `release-manifest.json` and generated release notes
- keep backend metadata strictly informational and non-blocking

## Motivation

Codex App releases expose the app and package versions, but not the version of the bundled Codex backend. Determining it currently requires installing the app or manually extracting and running the packaged backend.

Different app releases can bundle the same backend version, so exposing this metadata provides a more direct signal of backend changes without changing any release decision.

## Scope

This PR only covers the Stable mirror workflow and its generated release metadata/notes. The Windows Beta emergency workflow is intentionally out of scope.

## Implementation

The packaged backend is extracted and queried using `codex --version`.

Only the fixed package-root paths are accepted:

- Windows: `app/resources/codex.exe`
- macOS: `Contents/Resources/codex`

A version is accepted only when the process exits successfully and its output matches the expected Codex CLI version format. Electron/Chromium output such as `Codex 149.x`, nested candidates, absolute ZIP paths, and parent-directory paths are rejected.

For cross-architecture reads, the existing Windows/macOS download jobs extract the fixed-path backend from the package they already downloaded and verified. They upload a separate small input artifact containing only the backend binary plus a manifest with the source package SHA256 and backend binary SHA256. The Windows ARM64 and macOS Intel native jobs download that input, validate its platform/architecture and SHA256 metadata, recompute the backend binary SHA256, and only then run `codex --version`. They no longer download the full installer artifacts.

Preparation, input upload, checksum validation, malformed optional JSON, unavailable binaries, and version-read failures all result in omitted metadata and never block publication. The existing Windows MSIX version reader remains unchanged.

## Manifest compatibility

The current base already uses schema version 5. This PR retains `schemaVersion: 5` and adds only optional `backendVersion` fields.

Existing field meanings and release-selection behavior are unchanged. Missing backend metadata is omitted, and no backend mismatch or readability check acts as a release gate.

## Validation

- Repository CI, actionlint, shell and PowerShell validation, Linux backend fixtures, and macOS identity/input fixtures all pass:
  https://github.com/GImDX/codex-app-mirror/actions/runs/29160450617
- Full fork Mirror flow validated probe, both installer download jobs, both native backend jobs, manifest generation, appcast generation, and GitHub Release publication:
  https://github.com/GImDX/codex-app-mirror/actions/runs/29160614694
- Artifact transfer for the native jobs dropped from about 4.28 GB total (`codex-windows` 1,445,127,836 bytes plus `codex-macos` 2,831,228,902 bytes) to about 219 MB total (109,988,355-byte Windows input plus 109,127,116-byte macOS input), a reduction of about 4.06 GB per release.
- The generated release manifest reports `0.144.0-alpha.4` for all four platform/architecture entries:
  https://github.com/GImDX/codex-app-mirror/releases/tag/codex-app-26.707.41301
- The only failed step is Cloudflare R2 sync because the fork does not have the maintainer's private R2 credentials.

The branch is based on upstream `b466b28` and contains separate Windows and macOS commits.