### PR TITLE
Record macOS backend version in release manifest

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,6 +51,10 @@ jobs:
         shell: bash
         run: scripts/test-prepare-release-metadata.sh
 
+      - name: Test backend version reader fixture
+        shell: bash
+        run: bash scripts/test-read-codex-backend-version.sh
+
       - name: Test release probe fixture
         shell: bash
         run: scripts/test-probe-release.sh

--- a/scripts/prepare-release-metadata.sh
+++ b/scripts/prepare-release-metadata.sh
@@ -407,6 +407,11 @@ jq \
   | .sources.macos.arm64.bundleIdentifier = $mac[0].macos.arm64.bundleIdentifier
   | .sources.macos.arm64.minimumSystemVersion = $mac[0].macos.arm64.minimumSystemVersion
   | .sources.macos.arm64.sha256 = $mac[0].macos.arm64.sha256
+  | if ($mac[0].macos.arm64.backendVersion // "") != "" then
+      .sources.macos.arm64.backendVersion = $mac[0].macos.arm64.backendVersion
+    else
+      del(.sources.macos.arm64.backendVersion)
+    end
   | .sources.macos.arm64.downloadable = true
   | .sources.macos.arm64.status = "downloadable"
   | .sources.macos.arm64.currentForCodexVersion = $includeMacosArm64
@@ -415,6 +420,11 @@ jq \
   | .sources.macos.x64.bundleIdentifier = $mac[0].macos.x64.bundleIdentifier
   | .sources.macos.x64.minimumSystemVersion = $mac[0].macos.x64.minimumSystemVersion
   | .sources.macos.x64.sha256 = $mac[0].macos.x64.sha256
+  | if ($mac[0].macos.x64.backendVersion // "") != "" then
+      .sources.macos.x64.backendVersion = $mac[0].macos.x64.backendVersion
+    else
+      del(.sources.macos.x64.backendVersion)
+    end
   | .sources.macos.x64.downloadable = true
   | .sources.macos.x64.status = "downloadable"
   | .sources.macos.x64.currentForCodexVersion = $includeMacosX64
@@ -436,6 +446,8 @@ jq \
       macosCommonShortVersion: $mac[0].commonShortVersion,
       macosCommonBundleVersion: $mac[0].commonBundleVersion,
       macosVersionsMatch: $mac[0].versionsMatch,
+      macosArm64BackendVersion: ($mac[0].macos.arm64.backendVersion // ""),
+      macosX64BackendVersion: ($mac[0].macos.x64.backendVersion // ""),
       missingPlatforms: ([if $includeWindows then empty else "windows" end, if $includeMacos then empty else "macos" end]),
       missingArchitectures: ([
         if $includeWindowsX64 then empty else "windows-x64" end,

--- a/scripts/read-codex-backend-version.py
+++ b/scripts/read-codex-backend-version.py
@@ -1,0 +1,73 @@
+#!/usr/bin/env python3
+import os
+import re
+import sys
+
+
+BACKEND_VERSION_PATTERNS = (
+    re.compile(rb"\bcodex-cli ([0-9]+(?:\.[0-9A-Za-z][0-9A-Za-z._+-]*)*)\b"),
+    re.compile(rb"\b([0-9]+\.[0-9]+\.[0-9][0-9A-Za-z._+-]*)https://chatgpt\.com/backend-api/"),
+)
+
+
+def die(message):
+    print(message, file=sys.stderr)
+    raise SystemExit(1)
+
+
+def iter_paths(root):
+    if os.path.isfile(root):
+        yield root
+        return
+
+    if not os.path.isdir(root):
+        return
+
+    for dirpath, dirnames, filenames in os.walk(root):
+        dirnames.sort()
+        for filename in sorted(filenames):
+            yield os.path.join(dirpath, filename)
+
+
+def backend_version_from_file(path):
+    overlap = b""
+    try:
+        with open(path, "rb") as handle:
+            while True:
+                chunk = handle.read(1024 * 1024)
+                if not chunk:
+                    return ""
+
+                data = overlap + chunk
+                for pattern in BACKEND_VERSION_PATTERNS:
+                    match = pattern.search(data)
+                    if match:
+                        return match.group(1).decode("ascii")
+
+                overlap = data[-128:]
+    except OSError:
+        return ""
+
+
+def read_backend_version(root):
+    for path in iter_paths(root):
+        version = backend_version_from_file(path)
+        if version:
+            return version
+    return ""
+
+
+def main(argv):
+    if len(argv) != 2:
+        die("Usage: read-codex-backend-version.py <file-or-directory>")
+
+    version = read_backend_version(argv[1])
+    if version:
+        print(version)
+        return
+
+    die("Could not find Codex backend version.")
+
+
+if __name__ == "__main__":
+    main(sys.argv)

--- a/scripts/read-macos-metadata.sh
+++ b/scripts/read-macos-metadata.sh
@@ -4,6 +4,7 @@ set -euo pipefail
 output_path="${1:-dist/macos/macos-metadata.json}"
 arm64_dmg="${2:-dist/macos/Codex-mac-arm64.dmg}"
 x64_dmg="${3:-dist/macos/Codex-mac-x64.dmg}"
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 require() {
   if ! command -v "$1" >/dev/null 2>&1; then
@@ -84,6 +85,7 @@ inspect_dmg() {
   local bundle_version
   local bundle_id
   local minimum_system_version
+  local backend_version
   local sha256
 
   mount_dmg "$dmg"
@@ -99,6 +101,7 @@ inspect_dmg() {
   bundle_version="$(plist_value "$plist" CFBundleVersion)"
   bundle_id="$(plist_value "$plist" CFBundleIdentifier)"
   minimum_system_version="$(plist_value "$plist" LSMinimumSystemVersion)"
+  backend_version="$(python3 "$script_dir/read-codex-backend-version.py" "$volume/Codex.app" 2>/dev/null || true)"
   sha256="$(shasum -a 256 "$dmg" | awk '{print $1}')"
 
   if [[ -z "$short_version" || -z "$bundle_version" ]]; then
@@ -106,12 +109,12 @@ inspect_dmg() {
     exit 1
   fi
 
-  python3 - "$json_path" "$arch" "$dmg" "$sha256" "$short_version" "$bundle_version" "$bundle_id" "$minimum_system_version" <<'PY'
+  python3 - "$json_path" "$arch" "$dmg" "$sha256" "$short_version" "$bundle_version" "$bundle_id" "$minimum_system_version" "$backend_version" <<'PY'
 import json
 import os
 import sys
 
-out, arch, dmg, sha256, short, build, bundle_id, minimum = sys.argv[1:]
+out, arch, dmg, sha256, short, build, bundle_id, minimum, backend = sys.argv[1:]
 payload = {
     "architecture": arch,
     "fileName": os.path.basename(dmg),
@@ -121,6 +124,8 @@ payload = {
     "bundleIdentifier": bundle_id,
     "minimumSystemVersion": minimum,
 }
+if backend:
+    payload["backendVersion"] = backend
 with open(out, "w", encoding="utf-8") as handle:
     json.dump(payload, handle, indent=2, sort_keys=True)
     handle.write("\n")

--- a/scripts/test-prepare-release-metadata.sh
+++ b/scripts/test-prepare-release-metadata.sh
@@ -103,6 +103,7 @@ cat > "$tmp_dir/macos-metadata.json" <<'JSON'
     "arm64": {
       "bundleShortVersion": "1.2.3",
       "bundleVersion": "5",
+      "backendVersion": "0.140.1",
       "bundleIdentifier": "com.openai.codex",
       "minimumSystemVersion": "12.0",
       "sha256": "arm64-sha256"
@@ -110,6 +111,7 @@ cat > "$tmp_dir/macos-metadata.json" <<'JSON'
     "x64": {
       "bundleShortVersion": "1.2.3",
       "bundleVersion": "5",
+      "backendVersion": "0.140.2",
       "bundleIdentifier": "com.openai.codex",
       "minimumSystemVersion": "12.0",
       "sha256": "x64-sha256"
@@ -156,6 +158,10 @@ JSON
   test "$(jq -r '.derived.missingArchitectures | length' release-manifest.json)" = "0"
   test "$(jq -r '.sources.windows.architectures.arm64.currentForCodexVersion' release-manifest.json)" = "true"
   test "$(jq -r '.sources.windows.architectures.arm64.currentLocalArtifact' release-manifest.json)" = "true"
+  test "$(jq -r '.sources.macos.arm64.backendVersion' release-manifest.json)" = "0.140.1"
+  test "$(jq -r '.sources.macos.x64.backendVersion' release-manifest.json)" = "0.140.2"
+  test "$(jq -r '.derived.macosArm64BackendVersion' release-manifest.json)" = "0.140.1"
+  test "$(jq -r '.derived.macosX64BackendVersion' release-manifest.json)" = "0.140.2"
   test "$(jq -r '.derived.latestChecksums["Codex-mac-arm64.dmg"] | test("^[0-9a-f]{64}$")' release-manifest.json)" = "true"
   test "$(jq -r '.derived.latestChecksums["OpenAI.Codex_1.2.3.4_arm64__2p2nqsd0c76g0.Msix"] | test("^[0-9a-f]{64}$")' release-manifest.json)" = "true"
 

--- a/scripts/test-read-codex-backend-version.sh
+++ b/scripts/test-read-codex-backend-version.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+tmp_dir="$(mktemp -d)"
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cleanup() {
+  rm -rf "$tmp_dir"
+}
+trap cleanup EXIT
+
+mkdir -p "$tmp_dir/Codex.app/Contents/Resources"
+
+printf 'noise codex-cli 0.142.5 more noise' > "$tmp_dir/Codex.app/Contents/Resources/codex"
+test "$(python3 "$repo_root/scripts/read-codex-backend-version.py" "$tmp_dir/Codex.app")" = "0.142.5"
+
+printf 'prefix 0.143.0https://chatgpt.com/backend-api/ suffix' > "$tmp_dir/backend"
+test "$(python3 "$repo_root/scripts/read-codex-backend-version.py" "$tmp_dir/backend")" = "0.143.0"
+
+printf 'no backend version here' > "$tmp_dir/missing"
+if python3 "$repo_root/scripts/read-codex-backend-version.py" "$tmp_dir/missing" >/dev/null 2>&1; then
+  echo "Expected missing backend version to fail." >&2
+  exit 1
+fi
+
+echo "read-codex-backend-version fixture PASS"


### PR DESCRIPTION
## Summary
- add a small streaming backend-version reader for files or mounted app directories
- record macOS arm64/x64 backend versions while `read-macos-metadata.sh` has each DMG mounted
- copy macOS backend versions into `release-manifest.json` sources and derived metadata
- add a focused backend-version fixture to CI

## Notes
The macOS backend version is recorded opportunistically. If the scanner cannot find the version in a mounted `Codex.app`, the macOS metadata and release flow continue without a `backendVersion` field.

This PR is independent from #29, but its derived-field insertion was placed to merge cleanly after #29 lands.

## Validation
- `bash -n scripts/*.sh`
- `bash scripts/test-read-codex-backend-version.sh` with local Python313 injected as `python3`
- `python -m py_compile scripts/read-codex-backend-version.py`
- `git diff --check`
- `git merge-tree --write-tree refs/remotes/upstream/main HEAD`
- `git merge-tree --write-tree aa578e6419ef1fc24b1f1f4a8bac671099333079 HEAD`

Full `scripts/test-prepare-release-metadata.sh` was not run locally because this Windows Git Bash environment is missing `jq`; GitHub Actions should cover the bash fixture.