### PR TITLE
fix: guard against stale Windows store probes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,6 +63,10 @@ jobs:
         shell: bash
         run: scripts/test-probe-release-windows-rollout.sh
 
+      - name: Test release probe stale-FE3 fixture
+        shell: bash
+        run: scripts/test-probe-release-stale-fe3.sh
+
       - name: Test Windows download retry fixture
         shell: bash
         run: scripts/test-download-windows-retry.sh

--- a/scripts/probe-release.sh
+++ b/scripts/probe-release.sh
@@ -738,8 +738,79 @@ resolve_store_link() {
   return 1
 }
 
+require_positive_integer() {
+  local name="$1"
+  local value="$2"
+
+  if [[ ! "$value" =~ ^[1-9][0-9]*$ ]]; then
+    echo "$name must be a positive integer, got '$value'." >&2
+    exit 2
+  fi
+}
+
+require_non_negative_integer() {
+  local name="$1"
+  local value="$2"
+
+  if [[ ! "$value" =~ ^[0-9]+$ ]]; then
+    echo "$name must be a non-negative integer, got '$value'." >&2
+    exit 2
+  fi
+}
+
+resolve_store_package_line() {
+  local desired_arch="$1"
+  local max_attempts="$2"
+  local delay="$3"
+  local line
+
+  line="$(resolve_store_link "$desired_arch" "$max_attempts" "$delay" |
+    awk '/^OpenAI\.Codex_/ { print; exit }')"
+  if [[ -z "$line" ]]; then
+    echo "No Microsoft Store package link was resolved." >&2
+    exit 1
+  fi
+
+  printf '%s\n' "$line"
+}
+
 package_version() {
   sed -E 's/^OpenAI\.Codex_([^_]+)_.*/\1/' <<<"$1"
+}
+
+version_less_than() {
+  local left="$1"
+  local right="$2"
+  local -a left_parts
+  local -a right_parts
+  local max_parts
+  local i
+  local left_part
+  local right_part
+
+  if [[ ! "$left" =~ ^[0-9]+([.][0-9]+)*$ || ! "$right" =~ ^[0-9]+([.][0-9]+)*$ ]]; then
+    return 1
+  fi
+
+  IFS=. read -r -a left_parts <<<"$left"
+  IFS=. read -r -a right_parts <<<"$right"
+  max_parts="${#left_parts[@]}"
+  if ((${#right_parts[@]} > max_parts)); then
+    max_parts="${#right_parts[@]}"
+  fi
+
+  for ((i = 0; i < max_parts; i++)); do
+    left_part="${left_parts[$i]:-0}"
+    right_part="${right_parts[$i]:-0}"
+    if ((10#$left_part < 10#$right_part)); then
+      return 0
+    fi
+    if ((10#$left_part > 10#$right_part)); then
+      return 1
+    fi
+  done
+
+  return 1
 }
 
 catalog_package_for_arch() {
@@ -765,26 +836,73 @@ catalog_field() {
 windows_catalog_json="$(curl_get "Windows DisplayCatalog" "$windows_display_catalog_url")"
 windows_x64_catalog="$(catalog_package_for_arch x64)"
 windows_arm64_catalog="$(catalog_package_for_arch arm64)"
-
-link_line="$(resolve_store_link "$architecture" "${STORE_LINK_MAX_ATTEMPTS:-3}" "${STORE_LINK_RETRY_DELAY_SECONDS:-10}" |
-  awk '/^OpenAI\.Codex_/ { print; exit }')"
-
-if [[ -z "$link_line" ]]; then
-  echo "No Microsoft Store package link was resolved." >&2
-  exit 1
-fi
-
-windows_package="${link_line%%$'\t'*}"
-windows_url="${link_line#*$'\t'}"
-windows_version="$(package_version "$windows_package")"
 windows_update_json="$(curl_get "Windows update manifest" "$windows_update_manifest_url")"
 windows_update_version="$(jq -r '.buildVersion // empty' <<<"$windows_update_json")"
 windows_update_product_id="$(jq -r '.storeProductId // empty' <<<"$windows_update_json")"
 windows_update_package_identity="$(jq -r '.packageIdentity // empty' <<<"$windows_update_json")"
-windows_headers="$(curl_head "Windows MSIX" "$windows_url")"
-windows_content_length="$(header_value "$windows_headers" "content-length")"
-windows_last_modified="$(header_value "$windows_headers" "last-modified")"
-windows_etag="$(header_value "$windows_headers" "etag")"
+windows_x64_catalog_package="$(catalog_field "$windows_x64_catalog" PackageFullName)"
+windows_x64_catalog_version=""
+if [[ -n "$windows_x64_catalog_package" ]]; then
+  windows_x64_catalog_version="$(package_version "$windows_x64_catalog_package")"
+fi
+
+store_link_max_attempts="${STORE_LINK_MAX_ATTEMPTS:-3}"
+store_link_retry_delay_seconds="${STORE_LINK_RETRY_DELAY_SECONDS:-10}"
+store_link_stability_max_attempts="${STORE_LINK_STABILITY_MAX_ATTEMPTS:-12}"
+store_link_stability_retry_delay_seconds="${STORE_LINK_STABILITY_RETRY_DELAY_SECONDS:-30}"
+require_positive_integer STORE_LINK_MAX_ATTEMPTS "$store_link_max_attempts"
+require_non_negative_integer STORE_LINK_RETRY_DELAY_SECONDS "$store_link_retry_delay_seconds"
+require_positive_integer STORE_LINK_STABILITY_MAX_ATTEMPTS "$store_link_stability_max_attempts"
+require_non_negative_integer STORE_LINK_STABILITY_RETRY_DELAY_SECONDS "$store_link_stability_retry_delay_seconds"
+
+windows_x64_stale_fe3=false
+windows_x64_stale_fe3_notice=""
+for ((stability_attempt = 1; stability_attempt <= store_link_stability_max_attempts; stability_attempt++)); do
+  link_line="$(resolve_store_package_line "$architecture" "$store_link_max_attempts" "$store_link_retry_delay_seconds")"
+  windows_package="${link_line%%$'\t'*}"
+  windows_version="$(package_version "$windows_package")"
+  windows_x64_fe3_behind_catalog=false
+  if [[ "$windows_update_version" == "$windows_x64_catalog_version" ]] &&
+    version_less_than "$windows_version" "$windows_x64_catalog_version"; then
+    windows_x64_fe3_behind_catalog=true
+  fi
+
+  if [[ "$architecture" == "x64" &&
+        -n "$windows_x64_catalog_package" &&
+        -n "$windows_update_version" &&
+        "$windows_update_version" == "$windows_x64_catalog_version" &&
+        "$windows_x64_fe3_behind_catalog" == "true" &&
+        "$windows_package" != "$windows_x64_catalog_package" ]]; then
+    windows_x64_stale_fe3=true
+    windows_x64_stale_fe3_notice="Windows x64 DisplayCatalog/update manifest advertise $windows_x64_catalog_package, but FE3 returned $windows_package."
+    if ((stability_attempt < store_link_stability_max_attempts)); then
+      echo "$windows_x64_stale_fe3_notice Re-probing in ${store_link_stability_retry_delay_seconds}s (${stability_attempt}/${store_link_stability_max_attempts})." >&2
+      if ((store_link_stability_retry_delay_seconds > 0)); then
+        sleep "$store_link_stability_retry_delay_seconds"
+      fi
+      continue
+    fi
+  else
+    windows_x64_stale_fe3=false
+    windows_x64_stale_fe3_notice=""
+  fi
+
+  break
+done
+
+windows_package="${link_line%%$'\t'*}"
+windows_url="${link_line#*$'\t'}"
+windows_version="$(package_version "$windows_package")"
+if [[ "$windows_x64_stale_fe3" == "true" ]]; then
+  windows_content_length=0
+  windows_last_modified=""
+  windows_etag=""
+else
+  windows_headers="$(curl_head "Windows MSIX" "$windows_url")"
+  windows_content_length="$(header_value "$windows_headers" "content-length")"
+  windows_last_modified="$(header_value "$windows_headers" "last-modified")"
+  windows_etag="$(header_value "$windows_headers" "etag")"
+fi
 
 windows_arm64_package="$(catalog_field "$windows_arm64_catalog" PackageFullName)"
 windows_arm64_version=""
@@ -818,8 +936,9 @@ else
   echo "Windows arm64 Store package link is not downloadable yet; recording catalog metadata only." >&2
 fi
 
-windows_x64_catalog_package="$(catalog_field "$windows_x64_catalog" PackageFullName)"
-if [[ -n "$windows_x64_catalog_package" && "$windows_x64_catalog_package" != "$windows_package" ]]; then
+if [[ "$windows_x64_stale_fe3" == "true" ]]; then
+  echo "Windows x64 FE3 snapshot is stale; waiting instead of using $windows_package." >&2
+elif [[ -n "$windows_x64_catalog_package" && "$windows_x64_catalog_package" != "$windows_package" ]]; then
   echo "Windows x64 DisplayCatalog package ($windows_x64_catalog_package) differs from FE3 downloadable package ($windows_package); using downloadable package." >&2
 fi
 
@@ -974,7 +1093,10 @@ release_tag_fallback=""
 tmp_dir="$(mktemp -d)"
 trap 'rm -rf "$tmp_dir"' EXIT
 
-if [[ "$force_release" == "true" ]]; then
+if [[ "$windows_x64_stale_fe3" == "true" ]]; then
+  should_release="false"
+  skip_reason="$windows_x64_stale_fe3_notice Waiting for a consistent downloadable MSIX."
+elif [[ "$force_release" == "true" ]]; then
   skip_reason="force_release=true"
 else
   latest_tag="$(latest_release_tag)"

--- a/scripts/test-probe-release-stale-fe3.sh
+++ b/scripts/test-probe-release-stale-fe3.sh
@@ -1,0 +1,256 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Regression test for Microsoft Store rollback snapshots.
+#
+# Scenario: DisplayCatalog and the OpenAI update manifest both advertise the new
+# Windows x64 package, but FE3 still returns an older downloadable package. The
+# probe must not treat that older FE3 link as a releasable source, because a later
+# download step would either fail the package-moniker guard or, worse, publish a
+# rollback snapshot if the guard were relaxed.
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+tmp_dir="$(mktemp -d)"
+cleanup() {
+  rm -rf "$tmp_dir"
+}
+trap cleanup EXIT
+
+mkdir -p "$tmp_dir/bin"
+
+old_package="OpenAI.Codex_26.623.13972.0_x64__2p2nqsd0c76g0"
+new_x64_package="OpenAI.Codex_26.623.19656.0_x64__2p2nqsd0c76g0"
+new_arm64_package="OpenAI.Codex_26.623.19656.0_arm64__2p2nqsd0c76g0"
+ahead_x64_package="OpenAI.Codex_26.624.100.0_x64__2p2nqsd0c76g0"
+
+cat > "$tmp_dir/bin/dotnet" <<'DOTNET'
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ "${1:-}" == "run" ]]; then
+  case "$*" in
+    *" arm64")
+      printf '%s\thttps://download.example/%s.Msix\n' \
+        "${TEST_NEW_ARM64_PACKAGE:?TEST_NEW_ARM64_PACKAGE must be set}" \
+        "$TEST_NEW_ARM64_PACKAGE"
+      ;;
+    *)
+      package="${TEST_OLD_PACKAGE:?TEST_OLD_PACKAGE must be set}"
+      if [[ -n "${TEST_X64_COUNTER:-}" ]]; then
+        count="$(cat "$TEST_X64_COUNTER")"
+        count=$((count + 1))
+        printf '%s' "$count" > "$TEST_X64_COUNTER"
+        if ((count >= ${TEST_X64_NEW_ON_ATTEMPT:?TEST_X64_NEW_ON_ATTEMPT must be set})); then
+          package="${TEST_NEW_X64_PACKAGE:?TEST_NEW_X64_PACKAGE must be set}"
+        fi
+      fi
+      printf '%s\thttps://download.example/%s.Msix\n' "$package" "$package"
+      ;;
+  esac
+  exit 0
+fi
+
+echo "unexpected dotnet invocation: $*" >&2
+exit 1
+DOTNET
+chmod +x "$tmp_dir/bin/dotnet"
+
+cat > "$tmp_dir/bin/gh" <<'GH'
+#!/usr/bin/env bash
+set -euo pipefail
+
+echo "gh should not be called when the Windows x64 FE3 snapshot is stale: $*" >&2
+exit 1
+GH
+chmod +x "$tmp_dir/bin/gh"
+
+cat > "$tmp_dir/bin/curl" <<'CURL'
+#!/usr/bin/env bash
+set -euo pipefail
+
+head_request=false
+headers_file=""
+url=""
+while (($#)); do
+  case "$1" in
+    -D)
+      headers_file="$2"
+      shift
+      ;;
+    -o)
+      shift
+      ;;
+    --range)
+      shift
+      ;;
+    -I|-*I*)
+      head_request=true
+      ;;
+    http://*|https://*)
+      url="$1"
+      ;;
+  esac
+  shift
+done
+
+emit_headers() {
+  local etag="$1"
+  local size="$2"
+
+  printf 'HTTP/2 200\r\n'
+  printf 'content-range: bytes 0-0/%s\r\n' "$size"
+  printf 'content-length: %s\r\n' "$size"
+  printf 'last-modified: Tue, 07 Jul 2026 00:35:59 GMT\r\n'
+  printf 'etag: %s\r\n' "$etag"
+  printf '\r\n'
+}
+
+emit_appcast() {
+  local arch="$1"
+  local sig="$2"
+  local hardware="$3"
+
+  cat <<XML
+<?xml version="1.0" encoding="utf-8"?>
+<rss xmlns:sparkle="http://www.andymatuschak.org/xml-namespaces/sparkle" version="2.0">
+  <channel>
+    <item>
+      <title>26.623.141536</title>
+      <pubDate>Tue, 07 Jul 2026 00:35:59 +0000</pubDate>
+      <sparkle:version>4753</sparkle:version>
+      <sparkle:shortVersionString>26.623.141536</sparkle:shortVersionString>
+      <sparkle:minimumSystemVersion>12.0</sparkle:minimumSystemVersion>
+      <sparkle:hardwareRequirements>${hardware}</sparkle:hardwareRequirements>
+      <enclosure url="https://persistent.oaistatic.com/codex-app-prod/Codex-darwin-${arch}-26.623.141536.zip" length="9" type="application/octet-stream" sparkle:edSignature="${sig}" />
+    </item>
+  </channel>
+</rss>
+XML
+}
+
+if $head_request; then
+  case "$url" in
+    *OpenAI.Codex_26.623.13972.0_x64__2p2nqsd0c76g0.Msix) emit_headers "old-windows-etag" 3 ;;
+    *OpenAI.Codex_26.623.19656.0_x64__2p2nqsd0c76g0.Msix) emit_headers "new-windows-etag" 4 ;;
+    *OpenAI.Codex_26.624.100.0_x64__2p2nqsd0c76g0.Msix) emit_headers "ahead-windows-etag" 10 ;;
+    *OpenAI.Codex_26.623.19656.0_arm64__2p2nqsd0c76g0.Msix) emit_headers "new-arm64-etag" 4 ;;
+    *Codex-26.623.141536-arm64.dmg) emit_headers "arm-dmg-etag" 5 ;;
+    *Codex-26.623.141536-x64.dmg) emit_headers "x64-dmg-etag" 6 ;;
+    *) echo "unexpected curl headers URL: $url" >&2; exit 1 ;;
+  esac
+  exit 0
+fi
+
+if [[ -n "$headers_file" ]]; then
+  case "$url" in
+    *Codex-darwin-arm64-26.623.141536.zip) emit_headers "arm-zip-etag" 7 > "$headers_file" ;;
+    *Codex-darwin-x64-26.623.141536.zip) emit_headers "x64-zip-etag" 8 > "$headers_file" ;;
+    *) echo "unexpected curl range URL: $url" >&2; exit 1 ;;
+  esac
+  exit 0
+fi
+
+case "$url" in
+  *displaycatalog.mp.microsoft.com/v7.0/products/9PLM9XGG6VKS*)
+    cat <<JSON
+{"Product":{"DisplaySkuAvailabilities":[{"Sku":{"Properties":{"Packages":[
+{"PackageFamilyName":"OpenAI.Codex_2p2nqsd0c76g0","PackageFullName":"${TEST_NEW_X64_PACKAGE:?TEST_NEW_X64_PACKAGE must be set}","Architectures":["x64"],"PackageId":"x64-package-id","ContentId":"content-id","MaxDownloadSizeInBytes":671019430,"HashAlgorithm":"SHA256","Hash":"x64hash"},
+{"PackageFamilyName":"OpenAI.Codex_2p2nqsd0c76g0","PackageFullName":"${TEST_NEW_ARM64_PACKAGE:?TEST_NEW_ARM64_PACKAGE must be set}","Architectures":["arm64"],"PackageId":"arm64-package-id","ContentId":"content-id","MaxDownloadSizeInBytes":670125154,"HashAlgorithm":"SHA256","Hash":"arm64hash"}
+]}}}]}}
+JSON
+    ;;
+  *windows-store-update.json)
+    printf '{"buildVersion":"26.623.19656.0","storeProductId":"9PLM9XGG6VKS","packageIdentity":"OpenAI.Codex"}\n'
+    ;;
+  *appcast-x64.xml)
+    emit_appcast x64 x64-signature ""
+    ;;
+  *appcast.xml)
+    emit_appcast arm64 arm-signature arm64
+    ;;
+  *)
+    echo "unexpected curl URL: $url" >&2
+    exit 1
+    ;;
+esac
+CURL
+chmod +x "$tmp_dir/bin/curl"
+
+(
+  cd "$repo_root"
+  PATH="$tmp_dir/bin:$PATH" \
+  TEST_OLD_PACKAGE="$old_package" \
+  TEST_NEW_X64_PACKAGE="$new_x64_package" \
+  TEST_NEW_ARM64_PACKAGE="$new_arm64_package" \
+  STORE_LINK_MAX_ATTEMPTS=1 \
+  STORE_LINK_STABILITY_MAX_ATTEMPTS=1 \
+  STORE_LINK_STABILITY_RETRY_DELAY_SECONDS=0 \
+  MANIFEST_PATH="$tmp_dir/probe-manifest.json" \
+    scripts/probe-release.sh > "$tmp_dir/output.txt"
+)
+
+grep -F "should_release=false" "$tmp_dir/output.txt"
+grep -F "Windows x64 DisplayCatalog/update manifest advertise $new_x64_package, but FE3 returned $old_package. Waiting for a consistent downloadable MSIX." "$tmp_dir/output.txt"
+
+manifest_windows_package="$(jq -r '.sources.windows.architectures.x64.packageMoniker' "$tmp_dir/probe-manifest.json")"
+if [[ "$manifest_windows_package" != "$old_package" ]]; then
+  echo "Expected manifest to preserve observed FE3 package for diagnostics, got '$manifest_windows_package'." >&2
+  exit 1
+fi
+
+counter_path="$tmp_dir/x64-counter"
+printf '0' > "$counter_path"
+(
+  cd "$repo_root"
+  PATH="$tmp_dir/bin:$PATH" \
+  TEST_OLD_PACKAGE="$old_package" \
+  TEST_NEW_X64_PACKAGE="$new_x64_package" \
+  TEST_NEW_ARM64_PACKAGE="$new_arm64_package" \
+  TEST_X64_COUNTER="$counter_path" \
+  TEST_X64_NEW_ON_ATTEMPT=2 \
+  STORE_LINK_MAX_ATTEMPTS=1 \
+  STORE_LINK_STABILITY_MAX_ATTEMPTS=2 \
+  STORE_LINK_STABILITY_RETRY_DELAY_SECONDS=0 \
+  FORCE_RELEASE=true \
+  MANIFEST_PATH="$tmp_dir/probe-manifest-retry.json" \
+    scripts/probe-release.sh > "$tmp_dir/output-retry.txt"
+)
+
+grep -F "should_release=true" "$tmp_dir/output-retry.txt"
+retry_manifest_windows_package="$(jq -r '.sources.windows.architectures.x64.packageMoniker' "$tmp_dir/probe-manifest-retry.json")"
+if [[ "$retry_manifest_windows_package" != "$new_x64_package" ]]; then
+  echo "Expected re-probe to converge on $new_x64_package, got '$retry_manifest_windows_package'." >&2
+  exit 1
+fi
+if [[ "$(cat "$counter_path")" != "2" ]]; then
+  echo "Expected x64 store link to be resolved twice, got '$(cat "$counter_path")'." >&2
+  exit 1
+fi
+
+(
+  cd "$repo_root"
+  PATH="$tmp_dir/bin:$PATH" \
+  TEST_OLD_PACKAGE="$ahead_x64_package" \
+  TEST_NEW_X64_PACKAGE="$new_x64_package" \
+  TEST_NEW_ARM64_PACKAGE="$new_arm64_package" \
+  STORE_LINK_MAX_ATTEMPTS=1 \
+  STORE_LINK_STABILITY_MAX_ATTEMPTS=1 \
+  STORE_LINK_STABILITY_RETRY_DELAY_SECONDS=0 \
+  FORCE_RELEASE=true \
+  MANIFEST_PATH="$tmp_dir/probe-manifest-ahead.json" \
+    scripts/probe-release.sh > "$tmp_dir/output-ahead.txt"
+)
+
+grep -F "should_release=true" "$tmp_dir/output-ahead.txt"
+if grep -F "Waiting for a consistent downloadable MSIX." "$tmp_dir/output-ahead.txt"; then
+  echo "FE3 returned a newer package than DisplayCatalog/update manifest, but probe treated it as stale." >&2
+  cat "$tmp_dir/output-ahead.txt" >&2
+  exit 1
+fi
+ahead_manifest_windows_package="$(jq -r '.sources.windows.architectures.x64.packageMoniker' "$tmp_dir/probe-manifest-ahead.json")"
+if [[ "$ahead_manifest_windows_package" != "$ahead_x64_package" ]]; then
+  echo "Expected FE3-ahead manifest to keep $ahead_x64_package, got '$ahead_manifest_windows_package'." >&2
+  exit 1
+fi
+
+echo "probe-release stale-FE3 fixture test PASS"


### PR DESCRIPTION
## Summary
- re-probe Windows x64 when DisplayCatalog/update manifest advertise a newer package than FE3
- no-op stale FE3 snapshots instead of publishing or downloading a rollback candidate
- add a stale-FE3 probe fixture and wire it into CI

## Tests
- scripts/test-probe-release-stale-fe3.sh
- scripts/test-probe-release-windows-rollout.sh
- scripts/test-probe-release.sh
- scripts/test-probe-release-preserved-arm64.sh
- scripts/test-prepare-release-metadata.sh
- scripts/test-download-windows-retry.sh
- bash -n scripts/*.sh
- actionlint
- git diff --check
- live read-only probe with STORE_LINK_STABILITY_MAX_ATTEMPTS=2