### PR TITLE
fix: restore stats badge route and count all installer aliases

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,6 +75,10 @@ jobs:
         shell: bash
         run: scripts/test-sync-secondary-s3.sh
 
+      - name: Test download stats fixture
+        shell: bash
+        run: python3 scripts/test-update-download-stats.py
+
       - uses: actions/setup-node@v6
         with:
           node-version: 24

--- a/cloudflare/download-router/src/index.js
+++ b/cloudflare/download-router/src/index.js
@@ -1,9 +1,14 @@
 const DEFAULT_SECONDARY_COUNTRY_CODES = "CN";
 const DEFAULT_SIGNED_URL_TTL_SECONDS = 3600;
+const STATS_BADGE_PATH = "/stats/downloads.json";
 
 export default {
   async fetch(request, env) {
     const url = new URL(request.url);
+
+    if (url.pathname.startsWith("/stats/")) {
+      return serveStatsBadge(request, env, url.pathname);
+    }
 
     if (!isAllowedLatestPath(url.pathname)) {
       return new Response("Not found", { status: 404 });
@@ -62,6 +67,39 @@ export default {
     });
   },
 };
+
+// The zone apex serves the website, whose SPA fallback would otherwise answer
+// /stats/* with HTML; this worker route owns the prefix so the shields.io
+// badge endpoint keeps returning JSON. Served from R2 directly (no geo
+// routing): the payload is a few hundred bytes and read mostly by shields.io.
+async function serveStatsBadge(request, env, pathname) {
+  if (pathname !== STATS_BADGE_PATH) {
+    return new Response("Not found", { status: 404 });
+  }
+  if (request.method !== "GET" && request.method !== "HEAD") {
+    return new Response("Method not allowed", {
+      status: 405,
+      headers: { Allow: "GET, HEAD" },
+    });
+  }
+  if (!env.GLOBAL_MIRROR_BASE_URL) {
+    return new Response("Missing GLOBAL_MIRROR_BASE_URL", { status: 500 });
+  }
+
+  const target = withPathAndSearch(env.GLOBAL_MIRROR_BASE_URL, STATS_BADGE_PATH, "");
+  const upstream = await fetch(target.toString(), { method: request.method });
+  if (!upstream.ok) {
+    return new Response("Not found", { status: 404 });
+  }
+  return new Response(upstream.body, {
+    status: 200,
+    headers: {
+      "Content-Type": "application/json; charset=utf-8",
+      "Cache-Control": "public, max-age=300",
+      "Access-Control-Allow-Origin": "*",
+    },
+  });
+}
 
 function isAllowedLatestPath(pathname) {
   const aliases = new Set([

--- a/cloudflare/download-router/test/index.test.mjs
+++ b/cloudflare/download-router/test/index.test.mjs
@@ -127,6 +127,69 @@ test("analytics failures do not block redirects", async () => {
   assert.equal(response.headers.get("Location"), "https://r2.example.com/latest/win");
 });
 
+test("serves the stats badge JSON from the global mirror", async () => {
+  const analytics = createAnalytics();
+  const badge = '{"schemaVersion":1,"label":"downloads","message":"281.6k","color":"brightgreen"}';
+  const response = await withFakeFetch(
+    async (input) => {
+      assert.equal(String(input), "https://r2.example.com/stats/downloads.json");
+      return new Response(badge, {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    },
+    () =>
+      worker.fetch(new Request("https://codexapp.agentsmirror.com/stats/downloads.json"), {
+        GLOBAL_MIRROR_BASE_URL: "https://r2.example.com",
+        DOWNLOAD_ANALYTICS: analytics,
+      }),
+  );
+
+  assert.equal(response.status, 200);
+  assert.equal(response.headers.get("Content-Type"), "application/json; charset=utf-8");
+  assert.equal(await response.text(), badge);
+  assert.deepEqual(analytics.points, []);
+});
+
+test("maps upstream badge failures to 404", async () => {
+  const response = await withFakeFetch(
+    async () => new Response("nope", { status: 404 }),
+    () =>
+      worker.fetch(new Request("https://codexapp.agentsmirror.com/stats/downloads.json"), {
+        GLOBAL_MIRROR_BASE_URL: "https://r2.example.com",
+      }),
+  );
+
+  assert.equal(response.status, 404);
+});
+
+test("rejects other stats paths and non-GET badge methods", async () => {
+  const env = { GLOBAL_MIRROR_BASE_URL: "https://r2.example.com" };
+
+  const otherPath = await worker.fetch(
+    new Request("https://codexapp.agentsmirror.com/stats/state.json"),
+    env,
+  );
+  assert.equal(otherPath.status, 404);
+
+  const post = await worker.fetch(
+    new Request("https://codexapp.agentsmirror.com/stats/downloads.json", { method: "POST" }),
+    env,
+  );
+  assert.equal(post.status, 405);
+  assert.equal(post.headers.get("Allow"), "GET, HEAD");
+});
+
+async function withFakeFetch(fake, run) {
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = fake;
+  try {
+    return await run();
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+}
+
 function createAnalytics() {
   return {
     points: [],

--- a/cloudflare/download-router/wrangler.jsonc
+++ b/cloudflare/download-router/wrangler.jsonc
@@ -12,6 +12,10 @@
     {
       "pattern": "codexapp.agentsmirror.com/latest/*",
       "zone_id": "a5bae9b722f3c5fe1a24aaebe7a8e663"
+    },
+    {
+      "pattern": "codexapp.agentsmirror.com/stats/*",
+      "zone_id": "a5bae9b722f3c5fe1a24aaebe7a8e663"
     }
   ],
   "analytics_engine_datasets": [

--- a/scripts/test-update-download-stats.py
+++ b/scripts/test-update-download-stats.py
@@ -1,0 +1,219 @@
+#!/usr/bin/env python3
+"""Fixture tests for update-download-stats.py.
+
+Exercises main() with the S3 and GraphQL layers monkeypatched -- no network
+and no aws CLI. Focus: the incremental pass, the newly-tracked-object
+backfill, and the double-count guard for legacy state without an objects
+list.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import os
+import sys
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+SCRIPT = Path(__file__).resolve().parent / "update-download-stats.py"
+
+# Per-object daily downloads served by the fake GraphQL layer.
+DAILY = {
+    "latest/win": 1,
+    "latest/mac-intel": 2,
+    "latest/mac-arm64": 3,
+    "latest/win-x64": 10,
+    "latest/win-arm64": 20,
+}
+LEGACY_OBJECTS = ["latest/mac-arm64", "latest/mac-intel", "latest/win"]
+
+TODAY = datetime.now(timezone.utc).date()
+YESTERDAY = TODAY - timedelta(days=1)
+WINDOW_START = TODAY - timedelta(days=31)
+
+FAILURES = []
+
+
+def load_module():
+    spec = importlib.util.spec_from_file_location("update_download_stats",
+                                                  SCRIPT)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def run_main(state: dict | None, env_overrides: dict[str, str]):
+    """Run main() with fakes; return (exit_code, writes, graphql_calls)."""
+    mod = load_module()
+    writes: dict[str, dict] = {}
+    graphql_calls: list[tuple[str, str]] = []
+
+    def fake_s3_read(bucket, key, endpoint, allow_missing_aws=False):
+        return json.dumps(state).encode() if state is not None else None
+
+    def fake_s3_write(bucket, key, data, content_type, cache_control,
+                      endpoint):
+        writes[key] = json.loads(data)
+
+    def fake_graphql(account, bucket, object_name, start, end, token):
+        graphql_calls.append((object_name, start))
+        per_day = {}
+        day = datetime.strptime(start[:10], "%Y-%m-%d").date()
+        # Include the in-flight current day: main() must filter it out.
+        while day <= TODAY:
+            per_day[day.isoformat()] = DAILY[object_name]
+            day += timedelta(days=1)
+        return per_day
+
+    mod.s3_read = fake_s3_read
+    mod.s3_write = fake_s3_write
+    mod.graphql_per_day_for_object = fake_graphql
+
+    base_env = {
+        "CF_ANALYTICS_API_TOKEN": "test-token",
+        "CLOUDFLARE_ACCOUNT_ID": "test-account",
+        "STATS_DRY_RUN": "0",
+    }
+    saved = dict(os.environ)
+    os.environ.update(base_env | env_overrides)
+    try:
+        code = mod.main()
+    finally:
+        os.environ.clear()
+        os.environ.update(saved)
+    return code, writes, graphql_calls
+
+
+def check(name: str, cond: bool, detail: str = ""):
+    if cond:
+        print(f"ok   {name}")
+    else:
+        print(f"FAIL {name} {detail}")
+        FAILURES.append(name)
+
+
+def days_between(start, end_inclusive) -> int:
+    return (end_inclusive - start).days + 1
+
+
+def test_backfills_newly_tracked_objects():
+    last_counted = TODAY - timedelta(days=3)
+    stale_day = (TODAY - timedelta(days=4)).isoformat()
+    state = {
+        "schema": 1,
+        "total": 1000,
+        "lastCountedDate": last_counted.isoformat(),
+        "objects": LEGACY_OBJECTS,
+        "perDay": {stale_day: 5},
+    }
+    code, writes, calls = run_main(state, {})
+
+    backfill_days = days_between(WINDOW_START, last_counted)
+    backfill = backfill_days * (DAILY["latest/win-x64"]
+                                + DAILY["latest/win-arm64"])
+    increment_days = days_between(last_counted + timedelta(days=1), YESTERDAY)
+    increment = increment_days * sum(DAILY.values())
+    expected_total = 1000 + backfill + increment
+
+    new_state = writes.get("stats/state.json", {})
+    badge = writes.get("stats/downloads.json", {})
+    backfill_calls = [c for c in calls
+                      if c[1].startswith(WINDOW_START.isoformat())]
+
+    check("backfill: exit code 0", code == 0)
+    check("backfill: total includes backfilled window",
+          new_state.get("total") == expected_total,
+          f"got {new_state.get('total')} want {expected_total}")
+    check("backfill: only new objects queried from window start",
+          sorted(c[0] for c in backfill_calls)
+          == ["latest/win-arm64", "latest/win-x64"],
+          f"got {backfill_calls}")
+    check("backfill: state tracks the expanded object set",
+          new_state.get("objects") == sorted(DAILY),
+          f"got {new_state.get('objects')}")
+    check("backfill: existing perDay values are added to, not overwritten",
+          new_state.get("perDay", {}).get(stale_day)
+          == 5 + DAILY["latest/win-x64"] + DAILY["latest/win-arm64"],
+          f"got {new_state.get('perDay', {}).get(stale_day)}")
+    check("backfill: lastCountedDate advances to yesterday",
+          new_state.get("lastCountedDate") == YESTERDAY.isoformat())
+    check("backfill: badge reflects the new total",
+          badge.get("message") == load_module().human(expected_total))
+
+
+def test_unchanged_object_set_skips_backfill():
+    last_counted = TODAY - timedelta(days=3)
+    state = {
+        "schema": 1,
+        "total": 500,
+        "lastCountedDate": last_counted.isoformat(),
+        "objects": LEGACY_OBJECTS,
+        "perDay": {},
+    }
+    objects_env = ",".join(LEGACY_OBJECTS)
+    code, writes, calls = run_main(state, {"STATS_OBJECTS": objects_env})
+
+    increment = days_between(last_counted + timedelta(days=1), YESTERDAY) \
+        * sum(DAILY[o] for o in LEGACY_OBJECTS)
+    start_iso = (last_counted + timedelta(days=1)).isoformat()
+
+    check("no-change: exit code 0", code == 0)
+    check("no-change: every query starts at lastCountedDate + 1",
+          all(c[1].startswith(start_iso) for c in calls), f"got {calls}")
+    check("no-change: total only grows by the increment",
+          writes.get("stats/state.json", {}).get("total") == 500 + increment)
+
+
+def test_cold_start_counts_full_window():
+    code, writes, calls = run_main(None, {})
+
+    expected = days_between(WINDOW_START, YESTERDAY) * sum(DAILY.values())
+    new_state = writes.get("stats/state.json", {})
+
+    check("cold start: exit code 0", code == 0)
+    check("cold start: seeds the full retention window",
+          new_state.get("total") == expected,
+          f"got {new_state.get('total')} want {expected}")
+    check("cold start: queries all objects from window start",
+          sorted(c[0] for c in calls) == sorted(DAILY)
+          and all(c[1].startswith(WINDOW_START.isoformat()) for c in calls),
+          f"got {calls}")
+
+
+def test_legacy_state_without_objects_list_never_backfills():
+    last_counted = TODAY - timedelta(days=3)
+    state = {
+        "schema": 1,
+        "total": 500,
+        "lastCountedDate": last_counted.isoformat(),
+        "perDay": {},
+    }
+    code, writes, calls = run_main(state, {})
+
+    increment = days_between(last_counted + timedelta(days=1), YESTERDAY) \
+        * sum(DAILY.values())
+    backfill_calls = [c for c in calls
+                      if c[1].startswith(WINDOW_START.isoformat())]
+
+    check("legacy state: exit code 0", code == 0)
+    check("legacy state: no backfill queries", backfill_calls == [],
+          f"got {backfill_calls}")
+    check("legacy state: total only grows by the increment (no double count)",
+          writes.get("stats/state.json", {}).get("total") == 500 + increment)
+
+
+def main() -> int:
+    test_backfills_newly_tracked_objects()
+    test_unchanged_object_set_skips_backfill()
+    test_cold_start_counts_full_window()
+    test_legacy_state_without_objects_list_never_backfills()
+    if FAILURES:
+        print(f"\n{len(FAILURES)} test(s) failed")
+        return 1
+    print("\nall update-download-stats tests passed")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/update-download-stats.py
+++ b/scripts/update-download-stats.py
@@ -7,9 +7,15 @@ state file in R2 (stats/state.json) and, on each run, adds the download
 counts for the **fully elapsed** UTC days that have not been counted yet.
 It then writes a shields.io endpoint badge (stats/downloads.json).
 
-Counted metric: GetObject requests against the three installer aliases
-(latest/win, latest/mac-intel, latest/mac-arm64). Vulnerability-scanner
-noise (.env, wp-login.php, ...) and staging/* objects are excluded.
+Counted metric: GetObject requests against the installer aliases
+(latest/win, latest/win-x64, latest/win-arm64, latest/mac-intel,
+latest/mac-arm64). Vulnerability-scanner noise (.env, wp-login.php, ...)
+and staging/* objects are excluded.
+
+When an object is added to STATS_OBJECTS after launch, its already-elapsed
+days inside the retention window would be skipped by the incremental pass
+(which resumes at lastCountedDate + 1). Runs detect objects missing from
+the persisted state and backfill them once over the counted window.
 
 Token safety: the Cloudflare Analytics API token is read from the
 CF_ANALYTICS_API_TOKEN env var (a GitHub Secret in CI). It is only ever
@@ -26,7 +32,8 @@ Optional env:
   R2_S3_ENDPOINT           default: https://<CLOUDFLARE_ACCOUNT_ID>.r2.cloudflarestorage.com
   STATS_STATE_KEY          default: stats/state.json
   STATS_BADGE_KEY          default: stats/downloads.json
-  STATS_OBJECTS            default: latest/win,latest/mac-intel,latest/mac-arm64
+  STATS_OBJECTS            default: latest/win,latest/win-x64,latest/win-arm64,
+                                    latest/mac-intel,latest/mac-arm64
   STATS_BADGE_LABEL        default: downloads
   STATS_BADGE_COLOR        default: brightgreen
   STATS_DRY_RUN            if set to 1/true, compute and print but do NOT write R2
@@ -219,7 +226,8 @@ def main() -> int:
     badge_key = env("STATS_BADGE_KEY", "stats/downloads.json")
     objects = {s.strip() for s in env(
         "STATS_OBJECTS",
-        "latest/win,latest/mac-intel,latest/mac-arm64").split(",") if s.strip()}
+        "latest/win,latest/win-x64,latest/win-arm64,"
+        "latest/mac-intel,latest/mac-arm64").split(",") if s.strip()}
     label = env("STATS_BADGE_LABEL", "downloads")
     color = env("STATS_BADGE_COLOR", "brightgreen")
     dry_run = is_truthy(env("STATS_DRY_RUN", "0"))
@@ -236,6 +244,7 @@ def main() -> int:
     raw = s3_read(bucket, state_key, endpoint, allow_missing_aws=dry_run)
     state = json.loads(raw) if raw else None
 
+    backfill_per_day: dict[str, int] = {}
     if state is None:
         # Cold start: seed the cumulative total from the entire retention
         # window. While the bucket is younger than 32 days this captures the
@@ -259,6 +268,32 @@ def main() -> int:
                   f"permanently lost from the cumulative total.")
             start_date = window_start
 
+        # Objects newly added to STATS_OBJECTS have already-elapsed days in
+        # [window_start, lastCountedDate] that the incremental pass below
+        # (which resumes at lastCountedDate + 1) would never revisit. Query
+        # the still-retained part of that range once, for the new objects
+        # only; days past lastCountedDate are covered by the incremental
+        # pass, so the two ranges never overlap.
+        prev_objects = state.get("objects")
+        if prev_objects is None:
+            # Without the previously tracked set we cannot tell new objects
+            # from already-counted ones; backfilling would double count.
+            print("   WARNING: state has no objects list; skipping backfill")
+            added_objects: set[str] = set()
+        else:
+            added_objects = objects - set(prev_objects)
+        backfill_end = min(last_counted, yesterday)
+        if added_objects and backfill_end >= window_start:
+            print(f"   backfilling newly tracked objects: "
+                  f"{sorted(added_objects)}")
+            bf = graphql_per_day(
+                account, bucket, added_objects,
+                f"{window_start.isoformat()}T00:00:00Z", today_iso, token)
+            backfill_per_day = {
+                d.isoformat(): bf.get(d.isoformat(), 0)
+                for d in daterange(window_start, backfill_end)
+            }
+
     if start_date > yesterday:
         # Already counted through yesterday; nothing new (today is in-flight).
         print("   up to date: no fully-elapsed new day to add")
@@ -274,6 +309,7 @@ def main() -> int:
         }
 
     increment = sum(per_day_new.values())
+    backfill_total = sum(backfill_per_day.values())
 
     if state is None:
         base_total = 0
@@ -281,8 +317,12 @@ def main() -> int:
     else:
         base_total = int(state.get("total", 0))
         per_day_hist = dict(state.get("perDay", {}))
+    # Backfilled days already hold the previously tracked objects' counts,
+    # so add rather than overwrite.
+    for day, count in backfill_per_day.items():
+        per_day_hist[day] = per_day_hist.get(day, 0) + count
     per_day_hist.update(per_day_new)
-    total = base_total + increment
+    total = base_total + backfill_total + increment
 
     new_state = {
         "schema": 1,
@@ -306,6 +346,9 @@ def main() -> int:
     }
 
     # Report
+    if backfill_per_day:
+        print(f"   backfill: +{backfill_total} over {len(backfill_per_day)} "
+              f"day(s) for newly tracked object(s)")
     if per_day_new:
         print("   new days added:")
         for d, c in sorted(per_day_new.items()):


### PR DESCRIPTION
## 问题

1. **README 累计下载徽标损坏**：官网部署在 zone 根路径后，SPA fallback 把 `/stats/downloads.json` 也接管了，返回 HTML；shields.io 渲染为 "unparseable json response"。
2. **下载量被系统性低估**：`update-download-stats.py` 的 `STATS_OBJECTS` 只统计 `latest/win, latest/mac-intel, latest/mac-arm64`，README 主推的 `latest/win-x64` 和 `latest/win-arm64` 从未计入。实测过去 31 天两者合计约 **4.9 万次**下载（win-x64 45,130 + win-arm64 3,900）。

## 修复

- **download-router**：新增 `codexapp.agentsmirror.com/stats/*` 路由（worker route 优先于站点），worker 只放行 `/stats/downloads.json` 并从 R2 proxy（JSON content-type、max-age=300、CORS），其余 `/stats/*` 返回 404。
- **stats 脚本**：默认对象集扩为 5 个安装包别名；利用 state 里已有的 `objects` 列表自动检测新增跟踪对象，对 `[window_start, lastCountedDate]` 做一次性回补（与增量区间无重叠）；state 缺 `objects` 字段时跳过回补防止双计。
- **测试**：worker 新增 3 个用例（badge proxy / 上游失败映射 404 / 非法路径与方法）；新增 `scripts/test-update-download-stats.py`（回补算术、无变化、冷启动、防双计共 16 项断言）并接入 CI。

## 已部署与验证

- ✅ worker 已 `wrangler deploy`（routes 已生效，secrets 完好）：徽标 endpoint 已恢复 JSON，shields 已渲染 `downloads: 281.6k`
- ✅ `latest/*` 短链回归验证：CN 分流 → IHEP presigned URL 正常签发
- ✅ `npm run check` 9/9、stats fixture 16/16

## Merge 后

merge 后手动 `gh workflow run stats.yml`（或等每日 cron），首次运行会自动回补 win-x64/win-arm64 的历史量，累计数预计从 281.6k 提升到约 **33 万**。