### PR TITLE
ci: add emergency Stable candidate release

### DIFF
--- a/.github/workflows/emergency-stable-release.yml
+++ b/.github/workflows/emergency-stable-release.yml
@@ -1,0 +1,315 @@
+name: Emergency Stable candidate release
+
+on:
+  workflow_dispatch:
+    inputs:
+      expected_codex_version:
+        description: Exact Stable Codex app version to stage
+        required: true
+        default: "26.707.31428"
+        type: string
+      expected_windows_package_version:
+        description: Exact Microsoft Store package version to stage
+        required: true
+        default: "26.707.3748.0"
+        type: string
+
+permissions:
+  contents: read
+
+env:
+  R2_BUCKET_NAME: codex-app-mirror
+  R2_ROUTED_PUBLIC_BASE_URL: https://codexapp.agentsmirror.com
+  R2_DIRECT_PUBLIC_BASE_URL: https://codexapp-r2.agentsmirror.com
+
+# Share the production publication lock. This prevents the regular mirror job
+# from advancing shared latest while the emergency candidate snapshot is built.
+concurrency:
+  group: codex-app-mirror
+  cancel-in-progress: false
+
+jobs:
+  probe:
+    name: Freeze Stable source snapshot
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-dotnet@v5
+        with:
+          dotnet-version: 10.0.x
+
+      - name: Probe authoritative Stable sources
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+          EXPECTED_CODEX_VERSION: ${{ inputs.expected_codex_version }}
+          EXPECTED_WINDOWS_PACKAGE_VERSION: ${{ inputs.expected_windows_package_version }}
+          R2_PUBLIC_BASE_URL: ${{ env.R2_ROUTED_PUBLIC_BASE_URL }}
+        run: bash scripts/emergency-probe-rebrand.sh probe-manifest.json
+
+      - name: Snapshot shared latest before emergency work
+        shell: bash
+        run: |
+          set -euo pipefail
+          curl -fsSL --retry 5 --retry-all-errors \
+            "$R2_DIRECT_PUBLIC_BASE_URL/latest/manifest?before=$GITHUB_RUN_ID" \
+            -o shared-latest-r2-before.json
+          curl -fsSL --retry 5 --retry-all-errors \
+            "$R2_ROUTED_PUBLIC_BASE_URL/latest/manifest?before=$GITHUB_RUN_ID" \
+            -o shared-latest-routed-before.json
+          sha256sum shared-latest-r2-before.json shared-latest-routed-before.json
+
+      - uses: actions/upload-artifact@v7
+        with:
+          name: emergency-probe
+          path: |
+            probe-manifest.json
+            shared-latest-r2-before.json
+            shared-latest-routed-before.json
+          if-no-files-found: error
+          retention-days: 3
+
+  macos:
+    name: Download and verify macOS Stable
+    needs: probe
+    runs-on: macos-latest
+    timeout-minutes: 120
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/download-artifact@v8
+        with:
+          name: emergency-probe
+          path: .
+
+      - name: Download source names and save mirror ABI names
+        run: bash scripts/emergency-download-macos.sh probe-manifest.json dist/macos
+
+      - name: Enforce Stable identity on DMGs and Sparkle ZIPs
+        run: bash scripts/emergency-verify-macos.sh probe-manifest.json dist/macos dist/macos/macos-metadata.json
+
+      - uses: actions/upload-artifact@v7
+        with:
+          name: codex-macos
+          path: dist/macos/*
+          if-no-files-found: error
+          compression-level: 0
+          retention-days: 3
+
+  windows:
+    name: Download and verify Windows Stable
+    needs: probe
+    runs-on: windows-latest
+    timeout-minutes: 90
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-dotnet@v5
+        with:
+          dotnet-version: 10.0.x
+
+      - uses: actions/download-artifact@v8
+        with:
+          name: emergency-probe
+          path: .
+
+      - name: Download exact probed MSIX packages
+        shell: pwsh
+        run: ./scripts/download-windows.ps1 -OutDir dist/windows -ManifestPath probe-manifest.json
+
+      - name: Verify package identity and manifest entrypoint
+        shell: pwsh
+        run: ./scripts/emergency-verify-windows.ps1 -ManifestPath probe-manifest.json -ArtifactsDir dist/windows -OutputPath dist/windows/windows-identity.json
+
+      - uses: actions/upload-artifact@v7
+        with:
+          name: codex-windows
+          path: dist/windows/*
+          if-no-files-found: error
+          compression-level: 0
+          retention-days: 3
+
+  release:
+    name: Publish immutable candidate to GitHub, R2, and secondary S3
+    needs:
+      - probe
+      - macos
+      - windows
+    runs-on: ubuntu-latest
+    timeout-minutes: 240
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/download-artifact@v8
+        with:
+          path: artifacts
+
+      - name: Prepare canonical release metadata
+        env:
+          RELEASE_TAG: codex-app-${{ inputs.expected_codex_version }}
+          INHERIT_LATEST_FROM_MIRROR: "false"
+        shell: bash
+        run: |
+          set -euo pipefail
+          bash scripts/prepare-release-metadata.sh \
+            artifacts/emergency-probe/probe-manifest.json \
+            artifacts/codex-macos/macos-metadata.json \
+            artifacts \
+            "$R2_ROUTED_PUBLIC_BASE_URL" \
+            "$RELEASE_TAG"
+
+      - name: Freeze candidate contract and build versioned appcasts
+        shell: bash
+        run: |
+          set -euo pipefail
+          bash scripts/emergency-finalize-candidate.sh \
+            release-manifest.json \
+            artifacts/codex-macos/macos-metadata.json \
+            artifacts/codex-windows/windows-identity.json \
+            artifacts \
+            "${{ inputs.expected_codex_version }}" \
+            "$R2_DIRECT_PUBLIC_BASE_URL" \
+            "codex-app-${{ inputs.expected_codex_version }}"
+
+      - name: Publish GitHub prerelease without moving GitHub latest
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+          RELEASE_TAG: codex-app-${{ inputs.expected_codex_version }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          bash scripts/emergency-publish-release.sh \
+            "$RELEASE_TAG" \
+            "Codex App Mirror ${{ inputs.expected_codex_version }} (staged Stable candidate)" \
+            release-notes.md \
+            release-manifest.json \
+            SHA256SUMS.txt \
+            candidate-appcast.xml \
+            candidate-appcast-x64.xml \
+            artifacts
+
+      - name: Ensure AWS CLI
+        shell: bash
+        run: |
+          set -euo pipefail
+          if ! command -v aws >/dev/null 2>&1; then
+            python3 -m pip install --user awscli
+            echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+          fi
+          aws --version
+
+      - name: Upload versioned candidate snapshot to Cloudflare R2
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+          AWS_DEFAULT_REGION: auto
+          S3_ENDPOINT: https://${{ secrets.CLOUDFLARE_ACCOUNT_ID }}.r2.cloudflarestorage.com
+          S3_BUCKET: ${{ env.R2_BUCKET_NAME }}
+          S3_BACKEND_LABEL: Cloudflare-R2
+          S3_UPLOAD_ATTEMPTS: 4
+        shell: bash
+        run: |
+          set -euo pipefail
+          bash scripts/emergency-sync-candidate-s3.sh \
+            release-manifest.json \
+            artifacts \
+            latest-SHA256SUMS.txt \
+            candidate-appcast.xml \
+            candidate-appcast-x64.xml \
+            "releases/codex-app-${{ inputs.expected_codex_version }}"
+
+      - name: Upload the same candidate snapshot to secondary S3
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.SECONDARY_S3_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.SECONDARY_S3_SECRET_ACCESS_KEY }}
+          AWS_DEFAULT_REGION: ${{ secrets.SECONDARY_S3_REGION }}
+          S3_ENDPOINT: ${{ secrets.SECONDARY_S3_ENDPOINT }}
+          S3_BUCKET: ${{ secrets.SECONDARY_S3_BUCKET }}
+          S3_BACKEND_LABEL: Secondary-S3
+          S3_UPLOAD_ATTEMPTS: 4
+          S3_CONNECT_TIMEOUT_SECONDS: 15
+          S3_READ_TIMEOUT_SECONDS: 300
+        shell: bash
+        run: |
+          set -euo pipefail
+          bash scripts/emergency-sync-candidate-s3.sh \
+            release-manifest.json \
+            artifacts \
+            latest-SHA256SUMS.txt \
+            candidate-appcast.xml \
+            candidate-appcast-x64.xml \
+            "releases/codex-app-${{ inputs.expected_codex_version }}"
+
+      - name: Verify public candidate and prove shared latest was untouched
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+          RELEASE_TAG: codex-app-${{ inputs.expected_codex_version }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          prefix="releases/$RELEASE_TAG/latest"
+
+          fetch_and_compare() {
+            local url="$1"
+            local expected="$2"
+            local output
+            output="$(mktemp)"
+            curl -fsSL --retry 5 --retry-delay 2 --retry-all-errors \
+              "$url?verify=$GITHUB_RUN_ID-$GITHUB_RUN_ATTEMPT" -o "$output"
+            cmp "$expected" "$output"
+            rm -f "$output"
+          }
+
+          range_size() {
+            local url="$1"
+            local headers size
+            headers="$(mktemp)"
+            curl -fsSL -L --retry 5 --retry-delay 2 --retry-all-errors \
+              --range 0-0 --max-filesize 2 \
+              -D "$headers" -o /dev/null \
+              "$url?verify=$GITHUB_RUN_ID-$GITHUB_RUN_ATTEMPT"
+            size="$(tr -d '\r' < "$headers" | awk 'tolower($1) == "content-range:" { value=$0 } END { sub(/^.*\//, "", value); print value }')"
+            rm -f "$headers"
+            [[ "$size" =~ ^[0-9]+$ ]] || { echo "No valid Content-Range size for $url" >&2; return 1; }
+            printf '%s' "$size"
+          }
+
+          fetch_and_compare "$R2_DIRECT_PUBLIC_BASE_URL/$prefix/manifest" release-manifest.json
+          fetch_and_compare "$R2_DIRECT_PUBLIC_BASE_URL/$prefix/appcast.xml" candidate-appcast.xml
+          fetch_and_compare "$R2_DIRECT_PUBLIC_BASE_URL/$prefix/appcast-x64.xml" candidate-appcast-x64.xml
+
+          test "$(range_size "$R2_DIRECT_PUBLIC_BASE_URL/$prefix/win-x64")" = "$(jq -r '.sources.windows.architectures.x64.contentLength' release-manifest.json)"
+          test "$(range_size "$R2_DIRECT_PUBLIC_BASE_URL/$prefix/win-arm64")" = "$(jq -r '.sources.windows.architectures.arm64.contentLength' release-manifest.json)"
+          test "$(range_size "$R2_DIRECT_PUBLIC_BASE_URL/$prefix/mac-arm64")" = "$(jq -r '.sources.macos.arm64.contentLength' release-manifest.json)"
+          test "$(range_size "$R2_DIRECT_PUBLIC_BASE_URL/$prefix/mac-intel")" = "$(jq -r '.sources.macos.x64.contentLength' release-manifest.json)"
+
+          curl -fsSL --retry 5 --retry-all-errors \
+            "$R2_DIRECT_PUBLIC_BASE_URL/latest/manifest?after=$GITHUB_RUN_ID" \
+            -o shared-latest-r2-after.json
+          curl -fsSL --retry 5 --retry-all-errors \
+            "$R2_ROUTED_PUBLIC_BASE_URL/latest/manifest?after=$GITHUB_RUN_ID" \
+            -o shared-latest-routed-after.json
+          cmp artifacts/emergency-probe/shared-latest-r2-before.json shared-latest-r2-after.json
+          cmp artifacts/emergency-probe/shared-latest-routed-before.json shared-latest-routed-after.json
+
+          gh release view "$RELEASE_TAG" --json isDraft,isPrerelease,tagName,assets \
+            --jq 'select(.isDraft == false and .isPrerelease == true and (.assets | length) >= 20)'
+
+      - name: Write publication summary
+        shell: bash
+        run: |
+          tag="codex-app-${{ inputs.expected_codex_version }}"
+          {
+            echo "## Emergency Stable candidate published"
+            echo
+            echo "- GitHub prerelease: https://github.com/${{ github.repository }}/releases/tag/$tag"
+            echo "- R2 direct manifest: $R2_DIRECT_PUBLIC_BASE_URL/releases/$tag/latest/manifest"
+            echo "- Secondary S3 snapshot: verified through the repository S3 credentials"
+            echo "- Shared latest advanced: no"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/scripts/emergency-download-macos.sh
+++ b/scripts/emergency-download-macos.sh
@@ -1,0 +1,104 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+manifest_path="${1:?probe manifest is required}"
+out_dir="${2:-dist/macos}"
+mkdir -p "$out_dir"
+
+for command in curl jq shasum; do
+  if ! command -v "$command" >/dev/null 2>&1; then
+    echo "Missing required command: $command" >&2
+    exit 1
+  fi
+done
+
+names_file="$(mktemp)"
+cleanup() {
+  rm -f "$names_file"
+}
+trap cleanup EXIT
+: > "$names_file"
+
+file_size() {
+  local file="$1"
+  if stat -f '%z' "$file" >/dev/null 2>&1; then
+    stat -f '%z' "$file"
+  else
+    stat -c '%s' "$file"
+  fi
+}
+
+download_object() {
+  local label="$1"
+  local url="$2"
+  local output_name="$3"
+  local expected_size="$4"
+  local expected_source_basename="$5"
+  local actual_size
+
+  if [[ -z "$url" || "$url" == "null" || -z "$output_name" || "$output_name" == "null" ]]; then
+    echo "Missing URL or mirror filename for $label" >&2
+    exit 1
+  fi
+  if [[ "${url##*/}" != "$expected_source_basename" ]]; then
+    echo "$label source basename drifted: URL=${url##*/} manifest=$expected_source_basename" >&2
+    exit 1
+  fi
+
+  echo "Downloading $label from $expected_source_basename as $output_name" >&2
+  curl -fL \
+    --retry 5 \
+    --retry-delay 2 \
+    --retry-max-time 1200 \
+    --retry-all-errors \
+    --connect-timeout 20 \
+    -o "$out_dir/$output_name" \
+    "$url"
+
+  actual_size="$(file_size "$out_dir/$output_name")"
+  if [[ ! "$expected_size" =~ ^[0-9]+$ || "$expected_size" == "0" || "$actual_size" != "$expected_size" ]]; then
+    echo "$label size mismatch: expected=$expected_size actual=$actual_size" >&2
+    exit 1
+  fi
+  printf '%s\n' "$output_name" >> "$names_file"
+}
+
+download_arch() {
+  local arch_key="$1"
+  local dmg_url dmg_source dmg_mirror dmg_size
+  local zip_url zip_source zip_mirror zip_size
+  local delta_count index delta_url delta_name delta_size
+
+  dmg_url="$(jq -r --arg a "$arch_key" '.sources.macos[$a].sourceUrl' "$manifest_path")"
+  dmg_source="$(jq -r --arg a "$arch_key" '.sources.macos[$a].sourceBasename' "$manifest_path")"
+  dmg_mirror="$(jq -r --arg a "$arch_key" '.sources.macos[$a].mirrorBasename' "$manifest_path")"
+  dmg_size="$(jq -r --arg a "$arch_key" '.sources.macos[$a].contentLength' "$manifest_path")"
+  download_object "macOS $arch_key DMG" "$dmg_url" "$dmg_mirror" "$dmg_size" "$dmg_source"
+
+  zip_url="$(jq -r --arg a "$arch_key" '.sources.macos[$a].appcast.sourceUrl' "$manifest_path")"
+  zip_source="$(jq -r --arg a "$arch_key" '.sources.macos[$a].appcast.sourceBasename' "$manifest_path")"
+  zip_mirror="$(jq -r --arg a "$arch_key" '.sources.macos[$a].appcast.mirrorEnclosureBasename' "$manifest_path")"
+  zip_size="$(jq -r --arg a "$arch_key" '.sources.macos[$a].appcast.enclosureLength' "$manifest_path")"
+  download_object "macOS $arch_key Sparkle archive" "$zip_url" "$zip_mirror" "$zip_size" "$zip_source"
+
+  delta_count="$(jq -r --arg a "$arch_key" '.sources.macos[$a].appcast.deltas | length' "$manifest_path")"
+  for ((index = 0; index < delta_count; index++)); do
+    delta_url="$(jq -r --arg a "$arch_key" --argjson i "$index" '.sources.macos[$a].appcast.deltas[$i].url' "$manifest_path")"
+    delta_name="$(jq -r --arg a "$arch_key" --argjson i "$index" '.sources.macos[$a].appcast.deltas[$i].basename' "$manifest_path")"
+    delta_size="$(jq -r --arg a "$arch_key" --argjson i "$index" '.sources.macos[$a].appcast.deltas[$i].length' "$manifest_path")"
+    download_object "macOS $arch_key Sparkle delta[$index]" "$delta_url" "$delta_name" "$delta_size" "$delta_name"
+  done
+}
+
+download_arch arm64
+download_arch x64
+
+LC_ALL=C sort -u "$names_file" | while IFS= read -r name; do
+  [[ -n "$name" ]] || continue
+  (
+    cd "$out_dir"
+    shasum -a 256 "$name"
+  )
+done > "$out_dir/SHA256SUMS-macos.txt"
+
+cat "$out_dir/SHA256SUMS-macos.txt"

--- a/scripts/emergency-finalize-candidate.sh
+++ b/scripts/emergency-finalize-candidate.sh
@@ -1,0 +1,158 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+manifest_path="${1:-release-manifest.json}"
+macos_metadata="${2:?macOS metadata is required}"
+windows_identity="${3:?Windows identity metadata is required}"
+artifacts_dir="${4:?artifacts directory is required}"
+expected_version="${5:?expected Codex version is required}"
+public_base_url="${6:?public base URL is required}"
+release_tag="${7:?release tag is required}"
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+candidate_prefix="releases/$release_tag"
+candidate_base_url="${public_base_url%/}/$candidate_prefix"
+tmp_manifest="$(mktemp)"
+tmp_dir="$(mktemp -d)"
+
+cleanup() {
+  rm -f "$tmp_manifest"
+  rm -rf "$tmp_dir"
+}
+trap cleanup EXIT
+
+jq \
+  --slurpfile mac "$macos_metadata" \
+  --slurpfile win "$windows_identity" \
+  --arg expectedVersion "$expected_version" \
+  --arg releaseTag "$release_tag" \
+  --arg candidatePrefix "$candidate_prefix" \
+  --arg candidateBaseUrl "$candidate_base_url" '
+  if .codexVersion != $expectedVersion or .derived.codexVersion != $expectedVersion then
+    error("canonical Codex version does not match emergency snapshot")
+  elif .derived.includeWindowsX64 != true
+    or .derived.includeWindowsArm64 != true
+    or .derived.includeMacosArm64 != true
+    or .derived.includeMacosX64 != true then
+    error("emergency Stable candidate must include all four architectures")
+  elif $win[0].expectedIdentity != "OpenAI.Codex" then
+    error("Windows identity gate did not verify OpenAI.Codex")
+  elif $mac[0].identityGate.bundleIdentifier != "com.openai.codex"
+    or $mac[0].identityGate.rejectedBundleIdentifier != "com.openai.chat"
+    or $mac[0].identityGate.teamIdentifier != "2DC432GLL2" then
+    error("macOS identity gate metadata is incomplete")
+  else . end
+  | .sources.windows.architectures.x64.packageIdentity = $win[0].architectures.x64.packageIdentity
+  | .sources.windows.architectures.x64.applicationId = $win[0].architectures.x64.applicationId
+  | .sources.windows.architectures.x64.applicationExecutable = $win[0].architectures.x64.applicationExecutable
+  | .sources.windows.architectures.arm64.packageIdentity = $win[0].architectures.arm64.packageIdentity
+  | .sources.windows.architectures.arm64.applicationId = $win[0].architectures.arm64.applicationId
+  | .sources.windows.architectures.arm64.applicationExecutable = $win[0].architectures.arm64.applicationExecutable
+  | .sources.macos.arm64.identity = {
+      bundleIdentifier: $mac[0].macos.arm64.bundleIdentifier,
+      teamIdentifier: $mac[0].macos.arm64.teamIdentifier,
+      sparklePublicKey: $mac[0].macos.arm64.sparklePublicKey,
+      rejectedBundleIdentifier: $mac[0].identityGate.rejectedBundleIdentifier
+    }
+  | .sources.macos.x64.identity = {
+      bundleIdentifier: $mac[0].macos.x64.bundleIdentifier,
+      teamIdentifier: $mac[0].macos.x64.teamIdentifier,
+      sparklePublicKey: $mac[0].macos.x64.sparklePublicKey,
+      rejectedBundleIdentifier: $mac[0].identityGate.rejectedBundleIdentifier
+    }
+  | .derived.prerelease = true
+  | .derived.publishLatest = false
+  | .derived.syncLatest = false
+  | .derived.emergencyCandidate = true
+  | .candidate = {
+      releaseTag: $releaseTag,
+      prefix: $candidatePrefix,
+      baseUrl: $candidateBaseUrl,
+      manifestUrl: ($candidateBaseUrl + "/latest/manifest"),
+      checksumsUrl: ($candidateBaseUrl + "/latest/checksums"),
+      arm64AppcastUrl: ($candidateBaseUrl + "/latest/appcast.xml"),
+      x64AppcastUrl: ($candidateBaseUrl + "/latest/appcast-x64.xml"),
+      sharedLatestAdvanced: false,
+      contract: "issues-37-38-stable-p0"
+    }
+  | .emergency.sharedLatestAdvanced = false
+  ' "$manifest_path" > "$tmp_manifest"
+mv "$tmp_manifest" "$manifest_path"
+
+# Build appcasts from an isolated copy whose full enclosure basename comes from
+# mirrorEnclosureBasename instead of reconstructing it at the egress boundary.
+cp "$script_dir/build-appcast.sh" "$tmp_dir/build-appcast.sh"
+python3 - "$tmp_dir/build-appcast.sh" <<'PY'
+from pathlib import Path
+import sys
+
+path = Path(sys.argv[1])
+source = path.read_text(encoding="utf-8")
+old = 'enclosure_url="$base/latest/$mirror_dir/Codex-darwin-${archive_arch}-${short_version}.zip"'
+new = '''mirror_enclosure_basename="$(jq -r --arg a "$manifest_key" '.sources.macos[$a].appcast.mirrorEnclosureBasename // ""' "$manifest")"
+if [[ -z "$mirror_enclosure_basename" ]]; then
+  echo "Missing macOS $arch mirrorEnclosureBasename in $manifest." >&2
+  exit 1
+fi
+enclosure_url="$base/latest/$mirror_dir/$mirror_enclosure_basename"'''
+if source.count(old) != 1:
+    raise SystemExit("build-appcast shape changed; refusing emergency patch")
+path.write_text(source.replace(old, new), encoding="utf-8")
+PY
+chmod +x "$tmp_dir/build-appcast.sh"
+"$tmp_dir/build-appcast.sh" arm64 "$manifest_path" "$candidate_base_url" candidate-appcast.xml >/dev/null
+"$tmp_dir/build-appcast.sh" x64 "$manifest_path" "$candidate_base_url" candidate-appcast-x64.xml >/dev/null
+
+python3 - release-notes.md "$candidate_base_url" <<'PY'
+from pathlib import Path
+import re
+import sys
+
+path = Path(sys.argv[1])
+base = sys.argv[2]
+notes = path.read_text(encoding="utf-8")
+for start, end in (
+    ("<!-- latest-links-cn:start -->", "<!-- latest-links-cn:end -->"),
+    ("<!-- latest-links-en:start -->", "<!-- latest-links-en:end -->"),
+):
+    notes = re.sub(re.escape(start) + r".*?" + re.escape(end) + r"\n?", "", notes, flags=re.S)
+
+banner = f"""> [!IMPORTANT]
+> 这是按 #37/#38 Stable P0 契约发布的临时候选版本。GitHub Release 与 R2 / secondary S3 的版本化快照已发布，但 shared `latest/*` 尚未推进；正式切换仍以 Manager 兼容验证为前置。
+>
+> Candidate manifest: {base}/latest/manifest
+
+"""
+path.write_text(banner + notes, encoding="utf-8")
+PY
+
+refresh_manifest_checksum() {
+  local file="$1"
+  local tmp
+  tmp="$(mktemp)"
+  awk '$2 != "release-manifest.json" { print }' "$file" > "$tmp"
+  sha256sum "$manifest_path" | awk '{print tolower($1) "  release-manifest.json"}' >> "$tmp"
+  mv "$tmp" "$file"
+}
+
+refresh_manifest_checksum SHA256SUMS.txt
+refresh_manifest_checksum latest-SHA256SUMS.txt
+sha256sum candidate-appcast.xml candidate-appcast-x64.xml |
+  awk '{print tolower($1) "  " $2}' >> SHA256SUMS.txt
+
+jq -e \
+  --arg expectedVersion "$expected_version" \
+  --arg candidateBaseUrl "$candidate_base_url" '
+    .codexVersion == $expectedVersion
+    and .derived.prerelease == true
+    and .derived.publishLatest == false
+    and .derived.syncLatest == false
+    and .candidate.baseUrl == $candidateBaseUrl
+    and .candidate.sharedLatestAdvanced == false
+    and .sources.macos.arm64.identity.bundleIdentifier == "com.openai.codex"
+    and .sources.macos.x64.identity.bundleIdentifier == "com.openai.codex"
+    and .sources.windows.architectures.x64.packageIdentity == "OpenAI.Codex"
+    and .sources.windows.architectures.arm64.packageIdentity == "OpenAI.Codex"
+  ' "$manifest_path" >/dev/null
+
+echo "Finalized immutable candidate $release_tag at $candidate_base_url"
+jq '{codexVersion, derived, candidate, windowsEntrypoints: {x64: .sources.windows.architectures.x64.applicationExecutable, arm64: .sources.windows.architectures.arm64.applicationExecutable}, macosIdentity: {arm64: .sources.macos.arm64.identity, x64: .sources.macos.x64.identity}}' "$manifest_path"

--- a/scripts/emergency-probe-rebrand.sh
+++ b/scripts/emergency-probe-rebrand.sh
@@ -1,0 +1,120 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# One-shot Stable probe used by emergency-stable-release.yml while the permanent
+# #37/#38 implementation is being completed. It runs the production probe from
+# an isolated copy and replaces only the obsolete Codex DMG reconstruction with
+# a derivation anchored to the authoritative Sparkle enclosure basename.
+
+output_path="${1:-probe-manifest.json}"
+expected_codex_version="${EXPECTED_CODEX_VERSION:?EXPECTED_CODEX_VERSION is required}"
+expected_windows_package_version="${EXPECTED_WINDOWS_PACKAGE_VERSION:?EXPECTED_WINDOWS_PACKAGE_VERSION is required}"
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+repo_root="$(cd "$script_dir/.." && pwd)"
+tmp_dir="$(mktemp -d)"
+
+cleanup() {
+  rm -rf "$tmp_dir"
+}
+trap cleanup EXIT
+
+cp -R "$repo_root/scripts" "$tmp_dir/scripts"
+
+python3 - "$tmp_dir/scripts/probe-release.sh" <<'PY'
+from pathlib import Path
+import sys
+
+path = Path(sys.argv[1])
+source = path.read_text(encoding="utf-8")
+old = '''arm_url="https://persistent.oaistatic.com/codex-app-prod/Codex-${arm_appcast_version}-arm64.dmg"
+x64_url="https://persistent.oaistatic.com/codex-app-prod/Codex-${x64_appcast_version}-x64.dmg"'''
+new = '''dmg_url_from_appcast() {
+  local enclosure_url="$1"
+  local short_version="$2"
+  local arch="$3"
+  local basename suffix product_prefix base_url
+
+  basename="${enclosure_url##*/}"
+  suffix="-darwin-${arch}-${short_version}.zip"
+  if [[ -z "$enclosure_url" || "$basename" != *"$suffix" ]]; then
+    echo "Cannot derive macOS $arch DMG source from appcast enclosure: $enclosure_url" >&2
+    return 1
+  fi
+  product_prefix="${basename%$suffix}"
+  base_url="${enclosure_url%/*}"
+  printf '%s/%s-%s-%s.dmg' "$base_url" "$product_prefix" "$short_version" "$arch"
+}
+
+arm_url="$(dmg_url_from_appcast "$(jq -r '.enclosureUrl' <<<"$arm_appcast_json")" "$arm_appcast_version" arm64)"
+x64_url="$(dmg_url_from_appcast "$(jq -r '.enclosureUrl' <<<"$x64_appcast_json")" "$x64_appcast_version" x64)"'''
+
+if source.count(old) != 1:
+    raise SystemExit("production probe shape changed; refusing emergency patch")
+path.write_text(source.replace(old, new), encoding="utf-8")
+PY
+
+mkdir -p "$(dirname "$output_path")"
+GITHUB_OUTPUT= \
+FORCE_RELEASE=true \
+MANIFEST_PATH="$output_path" \
+bash "$tmp_dir/scripts/probe-release.sh"
+
+tmp_manifest="$(mktemp)"
+jq '
+  def basename: split("/") | last;
+  .sources.macos.arm64.sourceUrl = .sources.macos.arm64.url
+  | .sources.macos.arm64.sourceBasename = (.sources.macos.arm64.url | basename)
+  | .sources.macos.arm64.mirrorBasename = "Codex-mac-arm64.dmg"
+  | .sources.macos.arm64.appcast.sourceUrl = .sources.macos.arm64.appcast.enclosureUrl
+  | .sources.macos.arm64.appcast.sourceBasename = (.sources.macos.arm64.appcast.enclosureUrl | basename)
+  | .sources.macos.arm64.appcast.mirrorEnclosureBasename = ("Codex-darwin-arm64-" + .sources.macos.arm64.appcast.shortVersionString + ".zip")
+  | .sources.macos.x64.sourceUrl = .sources.macos.x64.url
+  | .sources.macos.x64.sourceBasename = (.sources.macos.x64.url | basename)
+  | .sources.macos.x64.mirrorBasename = "Codex-mac-x64.dmg"
+  | .sources.macos.x64.appcast.sourceUrl = .sources.macos.x64.appcast.enclosureUrl
+  | .sources.macos.x64.appcast.sourceBasename = (.sources.macos.x64.appcast.enclosureUrl | basename)
+  | .sources.macos.x64.appcast.mirrorEnclosureBasename = ("Codex-darwin-x64-" + .sources.macos.x64.appcast.shortVersionString + ".zip")
+  | .emergency = {
+      contract: "issues-37-38-stable-p0",
+      channel: "stable",
+      sharedLatestAdvanced: false
+    }
+' "$output_path" > "$tmp_manifest"
+mv "$tmp_manifest" "$output_path"
+
+jq -e \
+  --arg codex "$expected_codex_version" \
+  --arg windows "$expected_windows_package_version" '
+    .sources.windows.updateManifest.packageIdentity == "OpenAI.Codex"
+    and .sources.windows.updateManifest.buildVersion == $windows
+    and .sources.windows.architectures.x64.version == $windows
+    and .sources.windows.architectures.arm64.version == $windows
+    and .sources.windows.architectures.x64.downloadable == true
+    and .sources.windows.architectures.arm64.downloadable == true
+    and (.sources.windows.architectures.x64.packageMoniker | startswith("OpenAI.Codex_"))
+    and (.sources.windows.architectures.arm64.packageMoniker | startswith("OpenAI.Codex_"))
+    and .sources.macos.arm64.appcast.shortVersionString == $codex
+    and .sources.macos.x64.appcast.shortVersionString == $codex
+    and .sources.macos.arm64.appcast.sourceBasename != ""
+    and .sources.macos.x64.appcast.sourceBasename != ""
+    and .sources.macos.arm64.appcast.mirrorEnclosureBasename == ("Codex-darwin-arm64-" + $codex + ".zip")
+    and .sources.macos.x64.appcast.mirrorEnclosureBasename == ("Codex-darwin-x64-" + $codex + ".zip")
+  ' "$output_path" >/dev/null
+
+jq '{
+  windowsPackageVersion: .sources.windows.version,
+  windowsX64: .sources.windows.architectures.x64.packageMoniker,
+  windowsArm64: .sources.windows.architectures.arm64.packageMoniker,
+  macosArm64: {
+    version: .sources.macos.arm64.appcast.shortVersionString,
+    source: .sources.macos.arm64.sourceBasename,
+    sparkleSource: .sources.macos.arm64.appcast.sourceBasename,
+    sparkleMirror: .sources.macos.arm64.appcast.mirrorEnclosureBasename
+  },
+  macosX64: {
+    version: .sources.macos.x64.appcast.shortVersionString,
+    source: .sources.macos.x64.sourceBasename,
+    sparkleSource: .sources.macos.x64.appcast.sourceBasename,
+    sparkleMirror: .sources.macos.x64.appcast.mirrorEnclosureBasename
+  }
+}' "$output_path"

--- a/scripts/emergency-publish-release.sh
+++ b/scripts/emergency-publish-release.sh
@@ -1,0 +1,128 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+tag="${1:?release tag is required}"
+title="${2:?release title is required}"
+notes_file="${3:?release notes file is required}"
+manifest_path="${4:?release manifest is required}"
+checksums_path="${5:?release checksums are required}"
+arm_appcast="${6:?candidate arm64 appcast is required}"
+x64_appcast="${7:?candidate x64 appcast is required}"
+artifacts_dir="${8:?artifacts directory is required}"
+
+: "${GH_TOKEN:?GH_TOKEN is required}"
+: "${GH_REPO:?GH_REPO is required}"
+
+for command in gh jq sha256sum stat; do
+  command -v "$command" >/dev/null 2>&1 || { echo "Missing required command: $command" >&2; exit 1; }
+done
+
+mac_dir="$artifacts_dir/codex-macos"
+windows_dir="$artifacts_dir/codex-windows"
+assets=(
+  assets/status.png
+  "$manifest_path"
+  "$checksums_path"
+  "$arm_appcast"
+  "$x64_appcast"
+  "$mac_dir/SHA256SUMS-macos.txt"
+  "$windows_dir/SHA256SUMS-windows.txt"
+  "$mac_dir/$(jq -r '.sources.macos.arm64.mirrorBasename' "$manifest_path")"
+  "$mac_dir/$(jq -r '.sources.macos.x64.mirrorBasename' "$manifest_path")"
+  "$mac_dir/$(jq -r '.sources.macos.arm64.appcast.mirrorEnclosureBasename' "$manifest_path")"
+  "$mac_dir/$(jq -r '.sources.macos.x64.appcast.mirrorEnclosureBasename' "$manifest_path")"
+)
+
+while IFS= read -r basename; do
+  [[ -n "$basename" ]] || continue
+  assets+=("$mac_dir/$basename")
+done < <(jq -r '.sources.macos.arm64.appcast.deltas[]?.basename // empty, .sources.macos.x64.appcast.deltas[]?.basename // empty' "$manifest_path")
+
+while IFS= read -r msix; do
+  [[ -n "$msix" ]] || continue
+  assets+=("$msix")
+done < <(find "$windows_dir" -maxdepth 1 -type f \( -name '*.Msix' -o -name '*.msix' \) | sort)
+
+seen_names_file="$(mktemp)"
+cleanup() {
+  rm -f "$seen_names_file"
+}
+trap cleanup EXIT
+: > "$seen_names_file"
+for asset in "${assets[@]}"; do
+  [[ -f "$asset" ]] || { echo "Missing release asset: $asset" >&2; exit 1; }
+  name="$(basename "$asset")"
+  if grep -Fxq "$name" "$seen_names_file"; then
+    echo "Duplicate release asset basename: $name" >&2
+    exit 1
+  fi
+  printf '%s\n' "$name" >> "$seen_names_file"
+done
+
+is_replaceable_metadata() {
+  case "$1" in
+    release-manifest.json|SHA256SUMS.txt|SHA256SUMS-macos.txt|SHA256SUMS-windows.txt|candidate-appcast.xml|candidate-appcast-x64.xml|status.png)
+      return 0
+      ;;
+    *)
+      return 1
+      ;;
+  esac
+}
+
+file_size() {
+  local file="$1"
+  if stat -c '%s' "$file" >/dev/null 2>&1; then
+    stat -c '%s' "$file"
+  else
+    stat -f '%z' "$file"
+  fi
+}
+
+lowercase() {
+  tr '[:upper:]' '[:lower:]' <<<"$1"
+}
+
+if existing_assets="$(gh release view "$tag" --json assets --jq '.assets' 2>/dev/null)"; then
+  gh release edit "$tag" \
+    --title "$title" \
+    --notes-file "$notes_file" \
+    --prerelease \
+    --latest=false
+
+  for asset in "${assets[@]}"; do
+    name="$(basename "$asset")"
+    local_size="$(file_size "$asset")"
+    local_sha="$(sha256sum "$asset" | awk '{print tolower($1)}')"
+    existing_size="$(jq -r --arg name "$name" '.[] | select(.name == $name) | .size' <<<"$existing_assets" | head -n 1)"
+    existing_digest="$(jq -r --arg name "$name" '.[] | select(.name == $name) | .digest // ""' <<<"$existing_assets" | head -n 1)"
+    existing_sha="${existing_digest#sha256:}"
+
+    if [[ -z "$existing_size" ]]; then
+      gh release upload "$tag" "$asset"
+      continue
+    fi
+    if [[ "$existing_size" == "$local_size" && -n "$existing_sha" && "$(lowercase "$existing_sha")" == "$local_sha" ]]; then
+      echo "Release asset already matches: $name"
+      continue
+    fi
+    if ! is_replaceable_metadata "$name"; then
+      echo "Refusing to overwrite immutable GitHub Release asset $name (release=$existing_size/${existing_sha:-no-sha256}, local=$local_size/$local_sha)" >&2
+      exit 1
+    fi
+
+    gh release delete-asset "$tag" "$name" --yes
+    gh release upload "$tag" "$asset"
+  done
+else
+  gh release create "$tag" \
+    --target "${GITHUB_SHA:-main}" \
+    --title "$title" \
+    --notes-file "$notes_file" \
+    --prerelease \
+    --latest=false \
+    "${assets[@]}"
+fi
+
+gh release view "$tag" --json tagName,name,isDraft,isPrerelease,publishedAt,assets \
+  --jq '{tagName,name,isDraft,isPrerelease,publishedAt,assetCount:(.assets|length),assets:[.assets[]|{name,size,digest}]}'

--- a/scripts/emergency-sync-candidate-s3.sh
+++ b/scripts/emergency-sync-candidate-s3.sh
@@ -1,0 +1,219 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+manifest_path="${1:?release manifest is required}"
+artifacts_dir="${2:?artifacts directory is required}"
+candidate_checksums="${3:?candidate checksums path is required}"
+arm_appcast="${4:?arm64 appcast path is required}"
+x64_appcast="${5:?x64 appcast path is required}"
+candidate_prefix="${6:?candidate prefix is required}"
+
+: "${S3_ENDPOINT:?S3_ENDPOINT is required}"
+: "${S3_BUCKET:?S3_BUCKET is required}"
+: "${AWS_ACCESS_KEY_ID:?AWS_ACCESS_KEY_ID is required}"
+: "${AWS_SECRET_ACCESS_KEY:?AWS_SECRET_ACCESS_KEY is required}"
+
+region="${AWS_DEFAULT_REGION:-auto}"
+upload_attempts="${S3_UPLOAD_ATTEMPTS:-4}"
+backend_label="${S3_BACKEND_LABEL:-S3}"
+connect_timeout="${S3_CONNECT_TIMEOUT_SECONDS:-20}"
+read_timeout="${S3_READ_TIMEOUT_SECONDS:-300}"
+
+if [[ ! "$candidate_prefix" =~ ^releases/codex-app-[0-9A-Za-z._-]+$ ]]; then
+  echo "Refusing unsafe candidate prefix: $candidate_prefix" >&2
+  exit 1
+fi
+if [[ ! "$upload_attempts" =~ ^[1-9][0-9]*$ ]]; then
+  echo "S3_UPLOAD_ATTEMPTS must be a positive integer" >&2
+  exit 1
+fi
+
+for command in aws jq sha256sum stat; do
+  if ! command -v "$command" >/dev/null 2>&1; then
+    echo "Missing required command: $command" >&2
+    exit 1
+  fi
+done
+
+export AWS_RETRY_MODE="${AWS_RETRY_MODE:-adaptive}"
+export AWS_MAX_ATTEMPTS="${AWS_MAX_ATTEMPTS:-10}"
+export AWS_REQUEST_CHECKSUM_CALCULATION="${AWS_REQUEST_CHECKSUM_CALCULATION:-when_required}"
+export AWS_RESPONSE_CHECKSUM_VALIDATION="${AWS_RESPONSE_CHECKSUM_VALIDATION:-when_required}"
+aws configure set default.s3.multipart_threshold 64MB
+aws configure set default.s3.multipart_chunksize 64MB
+aws configure set default.s3.max_concurrent_requests 4
+
+aws_common=(
+  --endpoint-url "$S3_ENDPOINT"
+  --region "$region"
+  --cli-connect-timeout "$connect_timeout"
+  --cli-read-timeout "$read_timeout"
+)
+
+lowercase() {
+  tr '[:upper:]' '[:lower:]' <<<"$1"
+}
+
+head_object() {
+  local key="$1"
+  aws s3api head-object \
+    --bucket "$S3_BUCKET" \
+    --key "$key" \
+    "${aws_common[@]}" \
+    --output json 2>/dev/null
+}
+
+head_matches() {
+  local key="$1"
+  local expected_size="$2"
+  local expected_sha="$3"
+  local head_json actual_size actual_sha
+
+  if ! head_json="$(head_object "$key")"; then
+    return 1
+  fi
+  actual_size="$(jq -r '.ContentLength // 0' <<<"$head_json")"
+  actual_sha="$(jq -r '.Metadata.sha256 // ""' <<<"$head_json")"
+  [[ "$actual_size" == "$expected_size" && "$(lowercase "$actual_sha")" == "$(lowercase "$expected_sha")" ]]
+}
+
+file_size() {
+  local file="$1"
+  if stat -c '%s' "$file" >/dev/null 2>&1; then
+    stat -c '%s' "$file"
+  else
+    stat -f '%z' "$file"
+  fi
+}
+
+put_immutable() {
+  local key="$1"
+  local file="$2"
+  local content_type="$3"
+  local size sha head_json existing_size existing_sha attempt
+
+  [[ -f "$file" ]] || { echo "Missing upload file: $file" >&2; exit 1; }
+  size="$(file_size "$file")"
+  sha="$(sha256sum "$file" | awk '{print tolower($1)}')"
+
+  if head_json="$(head_object "$key")"; then
+    existing_size="$(jq -r '.ContentLength // 0' <<<"$head_json")"
+    existing_sha="$(jq -r '.Metadata.sha256 // ""' <<<"$head_json")"
+    if [[ "$existing_size" == "$size" && "$(lowercase "$existing_sha")" == "$sha" ]]; then
+      echo "[$backend_label] immutable object already matches: s3://$S3_BUCKET/$key"
+      return 0
+    fi
+    echo "[$backend_label] refusing to overwrite immutable object s3://$S3_BUCKET/$key (existing=$existing_size/${existing_sha:-no-sha256}, local=$size/$sha)" >&2
+    exit 1
+  fi
+
+  for ((attempt = 1; attempt <= upload_attempts; attempt++)); do
+    echo "[$backend_label] upload $attempt/$upload_attempts: s3://$S3_BUCKET/$key"
+    if aws s3 cp "$file" "s3://$S3_BUCKET/$key" \
+      "${aws_common[@]}" \
+      --metadata "sha256=$sha" \
+      --content-type "$content_type" \
+      --cache-control "public, max-age=31536000, immutable" \
+      --only-show-errors \
+      --no-progress; then
+      if head_matches "$key" "$size" "$sha"; then
+        return 0
+      fi
+      echo "[$backend_label] post-upload HEAD mismatch for $key" >&2
+    elif head_matches "$key" "$size" "$sha"; then
+      echo "[$backend_label] upload response failed but committed object matches: $key"
+      return 0
+    fi
+
+    if ((attempt < upload_attempts)); then
+      sleep $((attempt * 5))
+    fi
+  done
+
+  echo "[$backend_label] failed to upload verified immutable object: $key" >&2
+  exit 1
+}
+
+put_replaceable_metadata() {
+  local key="$1"
+  local file="$2"
+  local content_type="$3"
+  local size sha attempt
+
+  [[ -f "$file" ]] || { echo "Missing upload file: $file" >&2; exit 1; }
+  size="$(file_size "$file")"
+  sha="$(sha256sum "$file" | awk '{print tolower($1)}')"
+  if head_matches "$key" "$size" "$sha"; then
+    echo "[$backend_label] candidate metadata already matches: s3://$S3_BUCKET/$key"
+    return 0
+  fi
+
+  for ((attempt = 1; attempt <= upload_attempts; attempt++)); do
+    echo "[$backend_label] metadata upload $attempt/$upload_attempts: s3://$S3_BUCKET/$key"
+    if aws s3 cp "$file" "s3://$S3_BUCKET/$key" \
+      "${aws_common[@]}" \
+      --metadata "sha256=$sha" \
+      --content-type "$content_type" \
+      --cache-control "public, max-age=600" \
+      --only-show-errors \
+      --no-progress; then
+      if head_matches "$key" "$size" "$sha"; then
+        return 0
+      fi
+    elif head_matches "$key" "$size" "$sha"; then
+      return 0
+    fi
+    if ((attempt < upload_attempts)); then
+      sleep $((attempt * 5))
+    fi
+  done
+
+  echo "[$backend_label] failed to upload verified candidate metadata: $key" >&2
+  exit 1
+}
+
+mac_dir="$artifacts_dir/codex-macos"
+windows_dir="$artifacts_dir/codex-windows"
+win_x64="$(find "$windows_dir" -maxdepth 1 -type f \( -name '*_x64__*.Msix' -o -name '*_x64__*.msix' \) | sort | head -n 1)"
+win_arm64="$(find "$windows_dir" -maxdepth 1 -type f \( -name '*_arm64__*.Msix' -o -name '*_arm64__*.msix' \) | sort | head -n 1)"
+arm_dmg="$mac_dir/$(jq -r '.sources.macos.arm64.mirrorBasename' "$manifest_path")"
+x64_dmg="$mac_dir/$(jq -r '.sources.macos.x64.mirrorBasename' "$manifest_path")"
+arm_zip_name="$(jq -r '.sources.macos.arm64.appcast.mirrorEnclosureBasename' "$manifest_path")"
+x64_zip_name="$(jq -r '.sources.macos.x64.appcast.mirrorEnclosureBasename' "$manifest_path")"
+
+base="$candidate_prefix/latest"
+
+# Upload all bytes first. The candidate appcasts and manifest are committed last,
+# so readers never observe metadata that points to a missing immutable object.
+put_immutable "$base/mac-arm64" "$arm_dmg" application/x-apple-diskimage
+put_immutable "$base/mac-intel" "$x64_dmg" application/x-apple-diskimage
+put_immutable "$base/win" "$win_x64" application/msix
+put_immutable "$base/win-x64" "$win_x64" application/msix
+put_immutable "$base/win-arm64" "$win_arm64" application/msix
+put_immutable "$base/mac/arm64/$arm_zip_name" "$mac_dir/$arm_zip_name" application/zip
+put_immutable "$base/mac/intel/$x64_zip_name" "$mac_dir/$x64_zip_name" application/zip
+
+while IFS= read -r basename; do
+  [[ -n "$basename" ]] || continue
+  if [[ "$basename" == */* ]]; then
+    echo "Unsafe arm64 delta basename: $basename" >&2
+    exit 1
+  fi
+  put_immutable "$base/mac/arm64/$basename" "$mac_dir/$basename" application/octet-stream
+done < <(jq -r '.sources.macos.arm64.appcast.deltas[]?.basename // empty' "$manifest_path")
+
+while IFS= read -r basename; do
+  [[ -n "$basename" ]] || continue
+  if [[ "$basename" == */* ]]; then
+    echo "Unsafe x64 delta basename: $basename" >&2
+    exit 1
+  fi
+  put_immutable "$base/mac/intel/$basename" "$mac_dir/$basename" application/octet-stream
+done < <(jq -r '.sources.macos.x64.appcast.deltas[]?.basename // empty' "$manifest_path")
+
+put_replaceable_metadata "$base/checksums" "$candidate_checksums" text/plain
+put_replaceable_metadata "$base/appcast.xml" "$arm_appcast" application/xml
+put_replaceable_metadata "$base/appcast-x64.xml" "$x64_appcast" application/xml
+put_replaceable_metadata "$base/manifest" "$manifest_path" application/json
+
+echo "[$backend_label] candidate snapshot complete: s3://$S3_BUCKET/$candidate_prefix/"

--- a/scripts/emergency-verify-macos.sh
+++ b/scripts/emergency-verify-macos.sh
@@ -1,0 +1,226 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+manifest_path="${1:?probe manifest is required}"
+artifacts_dir="${2:-dist/macos}"
+output_path="${3:-$artifacts_dir/macos-metadata.json}"
+expected_bundle_id="com.openai.codex"
+rejected_classic_bundle_id="com.openai.chat"
+expected_team_id="2DC432GLL2"
+expected_sparkle_key="mNfr1v9t63BfgDtlw4C8lRvSY6uMggIXABDOCi3tS6k="
+plistbuddy="/usr/libexec/PlistBuddy"
+tmp_dir="$(mktemp -d)"
+mounts_file="$tmp_dir/mounts"
+: > "$mounts_file"
+
+cleanup() {
+  while IFS= read -r volume; do
+    [[ -n "$volume" ]] || continue
+    hdiutil detach "$volume" -quiet >/dev/null 2>&1 || true
+  done < "$mounts_file"
+  rm -rf "$tmp_dir"
+}
+trap cleanup EXIT
+
+for command in codesign ditto hdiutil jq python3 shasum; do
+  if ! command -v "$command" >/dev/null 2>&1; then
+    echo "Missing required command: $command" >&2
+    exit 1
+  fi
+done
+if [[ ! -x "$plistbuddy" ]]; then
+  echo "Missing required command: $plistbuddy" >&2
+  exit 1
+fi
+
+plist_value() {
+  local plist="$1"
+  local key="$2"
+  "$plistbuddy" -c "Print :$key" "$plist" 2>/dev/null || true
+}
+
+single_top_level_app() {
+  local root="$1"
+  local candidate found="" count=0
+  for candidate in "$root"/*.app; do
+    [[ -d "$candidate" ]] || continue
+    count=$((count + 1))
+    found="$candidate"
+  done
+  if [[ "$count" -ne 1 ]]; then
+    echo "Expected exactly one top-level .app in $root, found $count" >&2
+    return 1
+  fi
+  printf '%s' "$found"
+}
+
+assert_stable_identity() {
+  local label="$1"
+  local app_path="$2"
+  local expected_version="$3"
+  local expected_build="$4"
+  local plist signature_info
+
+  plist="$app_path/Contents/Info.plist"
+  if [[ ! -f "$plist" ]]; then
+    echo "$label has no Contents/Info.plist" >&2
+    exit 1
+  fi
+
+  APP_SHORT_VERSION="$(plist_value "$plist" CFBundleShortVersionString)"
+  APP_BUILD_VERSION="$(plist_value "$plist" CFBundleVersion)"
+  APP_BUNDLE_ID="$(plist_value "$plist" CFBundleIdentifier)"
+  APP_MINIMUM_VERSION="$(plist_value "$plist" LSMinimumSystemVersion)"
+  APP_SPARKLE_KEY="$(plist_value "$plist" SUPublicEDKey)"
+
+  if [[ "$APP_BUNDLE_ID" == "$rejected_classic_bundle_id" ]]; then
+    echo "$label is ChatGPT Classic ($rejected_classic_bundle_id); refusing it explicitly" >&2
+    exit 1
+  fi
+  if [[ "$APP_BUNDLE_ID" != "$expected_bundle_id" ]]; then
+    echo "$label bundle ID mismatch: expected=$expected_bundle_id actual=$APP_BUNDLE_ID" >&2
+    exit 1
+  fi
+  if [[ "$APP_SHORT_VERSION" != "$expected_version" || "$APP_BUILD_VERSION" != "$expected_build" ]]; then
+    echo "$label version mismatch: expected=$expected_version/$expected_build actual=$APP_SHORT_VERSION/$APP_BUILD_VERSION" >&2
+    exit 1
+  fi
+  if [[ "$APP_SPARKLE_KEY" != "$expected_sparkle_key" ]]; then
+    echo "$label Sparkle key mismatch" >&2
+    exit 1
+  fi
+
+  codesign --verify --deep --strict --verbose=2 "$app_path"
+  signature_info="$(codesign -dv --verbose=4 "$app_path" 2>&1)"
+  APP_TEAM_ID="$(awk -F= '/^TeamIdentifier=/ { print $2; exit }' <<<"$signature_info")"
+  if [[ "$APP_TEAM_ID" != "$expected_team_id" ]]; then
+    echo "$label Team ID mismatch: expected=$expected_team_id actual=$APP_TEAM_ID" >&2
+    exit 1
+  fi
+
+  echo "$label passed Stable identity gate: $APP_BUNDLE_ID / $APP_TEAM_ID / $APP_SHORT_VERSION ($APP_BUILD_VERSION)" >&2
+}
+
+mount_dmg() {
+  local dmg="$1"
+  local attach_plist volume
+  attach_plist="$(hdiutil attach -plist -nobrowse -readonly "$dmg")"
+  volume="$(python3 -c '
+import plistlib
+import sys
+data = plistlib.loads(sys.stdin.buffer.read())
+mounts = [
+    item.get("mount-point", "")
+    for item in data.get("system-entities", [])
+    if item.get("mount-point", "").startswith("/Volumes/")
+]
+print(mounts[-1] if mounts else "")
+' <<<"$attach_plist")"
+  if [[ -z "$volume" ]]; then
+    echo "Could not find mounted volume for $dmg" >&2
+    exit 1
+  fi
+  printf '%s\n' "$volume" >> "$mounts_file"
+  printf '%s' "$volume"
+}
+
+inspect_arch() {
+  local arch="$1"
+  local expected_version expected_build dmg_name zip_name dmg_path zip_path
+  local volume dmg_app extract_dir zip_app dmg_sha zip_sha
+  local zip_json dmg_json
+
+  expected_version="$(jq -r --arg a "$arch" '.sources.macos[$a].appcast.shortVersionString' "$manifest_path")"
+  expected_build="$(jq -r --arg a "$arch" '.sources.macos[$a].appcast.version' "$manifest_path")"
+  dmg_name="$(jq -r --arg a "$arch" '.sources.macos[$a].mirrorBasename' "$manifest_path")"
+  zip_name="$(jq -r --arg a "$arch" '.sources.macos[$a].appcast.mirrorEnclosureBasename' "$manifest_path")"
+  dmg_path="$artifacts_dir/$dmg_name"
+  zip_path="$artifacts_dir/$zip_name"
+
+  [[ -f "$dmg_path" ]] || { echo "Missing $dmg_path" >&2; exit 1; }
+  [[ -f "$zip_path" ]] || { echo "Missing $zip_path" >&2; exit 1; }
+
+  volume="$(mount_dmg "$dmg_path")"
+  dmg_app="$(single_top_level_app "$volume")"
+  assert_stable_identity "macOS $arch DMG" "$dmg_app" "$expected_version" "$expected_build"
+  dmg_sha="$(shasum -a 256 "$dmg_path" | awk '{print $1}')"
+  dmg_json="$tmp_dir/$arch-dmg.json"
+  jq -n \
+    --arg architecture "$arch" \
+    --arg fileName "$dmg_name" \
+    --arg sha256 "$dmg_sha" \
+    --arg shortVersion "$APP_SHORT_VERSION" \
+    --arg bundleVersion "$APP_BUILD_VERSION" \
+    --arg bundleId "$APP_BUNDLE_ID" \
+    --arg minimumVersion "$APP_MINIMUM_VERSION" \
+    --arg teamId "$APP_TEAM_ID" \
+    --arg sparkleKey "$APP_SPARKLE_KEY" \
+    '{
+      architecture: $architecture,
+      fileName: $fileName,
+      sha256: $sha256,
+      bundleShortVersion: $shortVersion,
+      bundleVersion: $bundleVersion,
+      bundleIdentifier: $bundleId,
+      minimumSystemVersion: $minimumVersion,
+      teamIdentifier: $teamId,
+      sparklePublicKey: $sparkleKey
+    }' > "$dmg_json"
+  hdiutil detach "$volume" -quiet
+
+  extract_dir="$tmp_dir/$arch-zip"
+  mkdir -p "$extract_dir"
+  ditto -x -k "$zip_path" "$extract_dir"
+  zip_app="$(single_top_level_app "$extract_dir")"
+  assert_stable_identity "macOS $arch Sparkle ZIP" "$zip_app" "$expected_version" "$expected_build"
+  zip_sha="$(shasum -a 256 "$zip_path" | awk '{print $1}')"
+  zip_json="$tmp_dir/$arch-zip.json"
+  jq -n \
+    --arg fileName "$zip_name" \
+    --arg sha256 "$zip_sha" \
+    --arg sourceBasename "$(jq -r --arg a "$arch" '.sources.macos[$a].appcast.sourceBasename' "$manifest_path")" \
+    --arg shortVersion "$APP_SHORT_VERSION" \
+    --arg bundleVersion "$APP_BUILD_VERSION" \
+    --arg bundleId "$APP_BUNDLE_ID" \
+    --arg teamId "$APP_TEAM_ID" \
+    --arg sparkleKey "$APP_SPARKLE_KEY" \
+    '{
+      fileName: $fileName,
+      sourceBasename: $sourceBasename,
+      sha256: $sha256,
+      bundleShortVersion: $shortVersion,
+      bundleVersion: $bundleVersion,
+      bundleIdentifier: $bundleId,
+      teamIdentifier: $teamId,
+      sparklePublicKey: $sparkleKey
+    }' > "$zip_json"
+
+  jq --slurpfile sparkle "$zip_json" '. + {sparkleArchive: $sparkle[0]}' "$dmg_json" > "$tmp_dir/$arch.json"
+  rm -rf "$extract_dir"
+}
+
+inspect_arch arm64
+inspect_arch x64
+mkdir -p "$(dirname "$output_path")"
+jq -n \
+  --slurpfile arm "$tmp_dir/arm64.json" \
+  --slurpfile x64 "$tmp_dir/x64.json" '
+  {
+    schemaVersion: 2,
+    macos: {arm64: $arm[0], x64: $x64[0]},
+    commonShortVersion: $arm[0].bundleShortVersion,
+    commonBundleVersion: $arm[0].bundleVersion,
+    versionsMatch: (
+      $arm[0].bundleShortVersion == $x64[0].bundleShortVersion
+      and $arm[0].bundleVersion == $x64[0].bundleVersion
+    ),
+    identityGate: {
+      bundleIdentifier: "com.openai.codex",
+      rejectedBundleIdentifier: "com.openai.chat",
+      teamIdentifier: "2DC432GLL2",
+      sparklePublicKey: "mNfr1v9t63BfgDtlw4C8lRvSY6uMggIXABDOCi3tS6k="
+    }
+  }' > "$output_path"
+
+jq -e '.versionsMatch == true' "$output_path" >/dev/null
+cat "$output_path"

--- a/scripts/emergency-verify-windows.ps1
+++ b/scripts/emergency-verify-windows.ps1
@@ -1,0 +1,127 @@
+param(
+  [Parameter(Mandatory = $true)]
+  [string] $ManifestPath,
+  [string] $ArtifactsDir = "dist/windows",
+  [string] $OutputPath = "dist/windows/windows-identity.json"
+)
+
+$ErrorActionPreference = "Stop"
+$expectedIdentity = "OpenAI.Codex"
+$manifest = Get-Content -LiteralPath $ManifestPath -Raw | ConvertFrom-Json
+$packages = Get-ChildItem -LiteralPath $ArtifactsDir -File |
+  Where-Object { $_.Name -match '\.(Msix|msix)$' } |
+  Sort-Object Name
+
+if ($packages.Count -ne 2) {
+  throw "Expected exactly two Stable MSIX packages, found $($packages.Count)."
+}
+
+Add-Type -AssemblyName System.IO.Compression.FileSystem
+$architectures = [ordered]@{}
+
+foreach ($package in $packages) {
+  if ($package.Name -match '_x64__') {
+    $architecture = 'x64'
+  } elseif ($package.Name -match '_arm64__') {
+    $architecture = 'arm64'
+  } else {
+    throw "Cannot determine architecture from $($package.Name)."
+  }
+
+  $expected = $manifest.sources.windows.architectures.$architecture
+  if (-not $expected -or $expected.downloadable -ne $true) {
+    throw "Probe manifest does not advertise downloadable Windows $architecture."
+  }
+  if ($package.BaseName -ne $expected.packageMoniker) {
+    throw "Windows $architecture package drift: expected $($expected.packageMoniker), got $($package.BaseName)."
+  }
+  if ($package.Length -ne [int64]$expected.contentLength) {
+    throw "Windows $architecture size mismatch: expected $($expected.contentLength), got $($package.Length)."
+  }
+
+  $archive = [System.IO.Compression.ZipFile]::OpenRead($package.FullName)
+  try {
+    $manifestEntries = @($archive.Entries | Where-Object {
+      $_.FullName.Replace('\', '/').ToLowerInvariant() -eq 'appxmanifest.xml'
+    })
+    if ($manifestEntries.Count -ne 1) {
+      throw "$($package.Name) must contain exactly one root AppxManifest.xml; found $($manifestEntries.Count)."
+    }
+
+    $stream = $manifestEntries[0].Open()
+    try {
+      $document = [System.Xml.Linq.XDocument]::Load($stream)
+    } finally {
+      $stream.Dispose()
+    }
+
+    $ns = $document.Root.Name.Namespace
+    $identity = $document.Root.Element($ns + 'Identity')
+    if ($null -eq $identity) {
+      throw "$($package.Name) has no Package/Identity element."
+    }
+    $identityName = $identity.Attribute('Name').Value
+    $packageVersion = $identity.Attribute('Version').Value
+    $processorArchitecture = $identity.Attribute('ProcessorArchitecture').Value.ToLowerInvariant()
+    if ($identityName -ne $expectedIdentity) {
+      throw "$($package.Name) identity mismatch: expected=$expectedIdentity actual=$identityName."
+    }
+    if ($packageVersion -ne $expected.version) {
+      throw "$($package.Name) package version mismatch: expected=$($expected.version) actual=$packageVersion."
+    }
+    if ($processorArchitecture -ne $architecture) {
+      throw "$($package.Name) processor architecture mismatch: expected=$architecture actual=$processorArchitecture."
+    }
+
+    $applicationsNode = $document.Root.Element($ns + 'Applications')
+    $applications = if ($null -eq $applicationsNode) { @() } else { @($applicationsNode.Elements($ns + 'Application')) }
+    if ($applications.Count -ne 1) {
+      throw "$($package.Name) must contain exactly one Application entry; found $($applications.Count)."
+    }
+    $applicationId = $applications[0].Attribute('Id').Value
+    $executable = $applications[0].Attribute('Executable').Value.Replace('\', '/')
+    if ([string]::IsNullOrWhiteSpace($executable)) {
+      throw "$($package.Name) Application@Executable is empty."
+    }
+
+    $matchingExecutables = @($archive.Entries | Where-Object {
+      $_.FullName.Replace('\', '/').Equals($executable, [StringComparison]::OrdinalIgnoreCase)
+    })
+    if ($matchingExecutables.Count -ne 1) {
+      throw "$($package.Name) manifest executable '$executable' does not resolve to exactly one package entry."
+    }
+
+    $sha256 = (Get-FileHash -Algorithm SHA256 -LiteralPath $package.FullName).Hash.ToLowerInvariant()
+    $architectures[$architecture] = [ordered]@{
+      architecture = $architecture
+      fileName = $package.Name
+      sha256 = $sha256
+      packageIdentity = $identityName
+      packageVersion = $packageVersion
+      packageFamilyName = [string]$expected.catalog.packageFamilyName
+      applicationId = $applicationId
+      applicationExecutable = $executable
+    }
+    Write-Host "$($package.Name) passed Stable identity gate: $identityName / $applicationId / $executable"
+  } finally {
+    $archive.Dispose()
+  }
+}
+
+if (-not $architectures.Contains('x64') -or -not $architectures.Contains('arm64')) {
+  throw "Verified MSIX set is missing x64 or arm64."
+}
+
+$payload = [ordered]@{
+  schemaVersion = 1
+  channel = 'stable'
+  expectedIdentity = $expectedIdentity
+  architectures = $architectures
+}
+
+$parent = Split-Path -Parent $OutputPath
+if ($parent) {
+  New-Item -ItemType Directory -Force -Path $parent | Out-Null
+}
+$payload | ConvertTo-Json -Depth 10 | Set-Content -Encoding utf8 -LiteralPath $OutputPath
+Get-Content -LiteralPath $OutputPath


### PR DESCRIPTION
Temporary one-shot publication path while #37/#38 are being implemented.

- freezes Stable 26.707.31428 / Windows package 26.707.3748.0
- enforces macOS bundle ID, Team ID, Sparkle key, and Windows package identity/entrypoint
- publishes a GitHub prerelease plus versioned R2 and secondary-S3 candidate snapshots
- never writes shared `latest/*`
- refuses to overwrite mismatched immutable binaries

Local verification: live source probe; actionlint; Bash/PowerShell parse checks; synthetic MSIX identity fixture; candidate appcast/checksum fixture; idempotent S3 fixture.