### PR TITLE
ci: add emergency Windows Beta candidate release

### DIFF
--- a/.github/workflows/emergency-windows-beta-release.yml
+++ b/.github/workflows/emergency-windows-beta-release.yml
@@ -1,0 +1,287 @@
+name: Emergency Windows Beta candidate release
+
+on:
+  workflow_dispatch:
+    inputs:
+      expected_windows_package_version:
+        description: Exact Microsoft Store Windows Beta package version to stage
+        required: true
+        default: "26.707.3351.0"
+        type: string
+
+permissions:
+  contents: read
+
+env:
+  BETA_PRODUCT_ID: 9N8CJ4W95TBZ
+  BETA_PACKAGE_IDENTITY: OpenAI.CodexBeta
+  R2_BUCKET_NAME: codex-app-mirror
+  R2_ROUTED_PUBLIC_BASE_URL: https://codexapp.agentsmirror.com
+  R2_DIRECT_PUBLIC_BASE_URL: https://codexapp-r2.agentsmirror.com
+
+# Share the production publication lock so Stable latest cannot move while the
+# independent Beta candidate snapshot is being committed.
+concurrency:
+  group: codex-app-mirror
+  cancel-in-progress: false
+
+jobs:
+  probe:
+    name: Freeze Windows Beta source snapshot
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-dotnet@v5
+        with:
+          dotnet-version: 10.0.x
+
+      - name: Probe exact Microsoft Store Beta packages
+        env:
+          EXPECTED_WINDOWS_PACKAGE_VERSION: ${{ inputs.expected_windows_package_version }}
+        run: bash scripts/emergency-probe-windows-beta.sh probe-manifest.json
+
+      - name: Snapshot Stable and shared latest before emergency work
+        env:
+          GH_TOKEN: ${{ github.token }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          curl -fsSL --retry 5 --retry-all-errors \
+            "$R2_DIRECT_PUBLIC_BASE_URL/latest/manifest?before=$GITHUB_RUN_ID" \
+            -o shared-latest-r2-before.json
+          curl -fsSL --retry 5 --retry-all-errors \
+            "$R2_ROUTED_PUBLIC_BASE_URL/latest/manifest?before=$GITHUB_RUN_ID" \
+            -o shared-latest-routed-before.json
+          gh api "repos/$GITHUB_REPOSITORY/releases/latest" --jq .tag_name \
+            > github-latest-before.txt
+          sha256sum shared-latest-r2-before.json shared-latest-routed-before.json
+          cat github-latest-before.txt
+
+      - uses: actions/upload-artifact@v7
+        with:
+          name: emergency-beta-probe
+          path: |
+            probe-manifest.json
+            shared-latest-r2-before.json
+            shared-latest-routed-before.json
+            github-latest-before.txt
+          if-no-files-found: error
+          retention-days: 3
+
+  windows:
+    name: Download and verify Windows Beta
+    needs: probe
+    runs-on: windows-latest
+    timeout-minutes: 120
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-dotnet@v5
+        with:
+          dotnet-version: 10.0.x
+
+      - uses: actions/download-artifact@v8
+        with:
+          name: emergency-beta-probe
+          path: .
+
+      - name: Download exact probed Beta MSIX packages
+        shell: pwsh
+        run: |
+          ./scripts/download-windows.ps1 `
+            -OutDir dist/windows `
+            -ManifestPath probe-manifest.json `
+            -ProductId "$env:BETA_PRODUCT_ID" `
+            -PackageIdentity "$env:BETA_PACKAGE_IDENTITY" `
+            -RequireArm64
+
+      - name: Enforce Beta identity and ChatGPT entrypoint
+        shell: pwsh
+        run: |
+          ./scripts/emergency-verify-windows.ps1 `
+            -ManifestPath probe-manifest.json `
+            -ArtifactsDir dist/windows `
+            -OutputPath dist/windows/windows-identity.json `
+            -ExpectedIdentity "$env:BETA_PACKAGE_IDENTITY" `
+            -Channel beta `
+            -ExpectedExecutable app/ChatGPT.exe
+
+      - uses: actions/upload-artifact@v7
+        with:
+          name: codex-windows
+          path: dist/windows/*
+          if-no-files-found: error
+          compression-level: 0
+          retention-days: 3
+
+  release:
+    name: Publish immutable Beta candidate to GitHub, R2, and secondary S3
+    needs:
+      - probe
+      - windows
+    runs-on: ubuntu-latest
+    timeout-minutes: 240
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/download-artifact@v8
+        with:
+          path: artifacts
+
+      - name: Freeze Windows Beta candidate contract
+        env:
+          RELEASE_TAG: codex-app-beta-${{ inputs.expected_windows_package_version }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          cp artifacts/emergency-beta-probe/probe-manifest.json release-manifest.json
+          bash scripts/emergency-finalize-windows-beta.sh \
+            release-manifest.json \
+            artifacts/codex-windows/windows-identity.json \
+            artifacts \
+            "${{ inputs.expected_windows_package_version }}" \
+            "$R2_DIRECT_PUBLIC_BASE_URL" \
+            "$RELEASE_TAG"
+
+      - name: Publish GitHub prerelease without moving GitHub latest
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+          RELEASE_TAG: codex-app-beta-${{ inputs.expected_windows_package_version }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          bash scripts/emergency-publish-release.sh \
+            "$RELEASE_TAG" \
+            "Codex App Mirror Windows Beta ${{ inputs.expected_windows_package_version }} (emergency candidate)" \
+            release-notes.md \
+            release-manifest.json \
+            SHA256SUMS.txt \
+            - \
+            - \
+            artifacts
+
+      - name: Ensure AWS CLI
+        shell: bash
+        run: |
+          set -euo pipefail
+          if ! command -v aws >/dev/null 2>&1; then
+            python3 -m pip install --user awscli
+            echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+          fi
+          aws --version
+
+      - name: Upload versioned Beta candidate snapshot to Cloudflare R2
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+          AWS_DEFAULT_REGION: auto
+          S3_ENDPOINT: https://${{ secrets.CLOUDFLARE_ACCOUNT_ID }}.r2.cloudflarestorage.com
+          S3_BUCKET: ${{ env.R2_BUCKET_NAME }}
+          S3_BACKEND_LABEL: Cloudflare-R2
+          S3_UPLOAD_ATTEMPTS: 4
+        shell: bash
+        run: |
+          set -euo pipefail
+          bash scripts/emergency-sync-candidate-s3.sh \
+            release-manifest.json \
+            artifacts \
+            SHA256SUMS.txt \
+            - \
+            - \
+            "releases/codex-app-beta-${{ inputs.expected_windows_package_version }}"
+
+      - name: Upload the same Beta candidate snapshot to secondary S3
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.SECONDARY_S3_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.SECONDARY_S3_SECRET_ACCESS_KEY }}
+          AWS_DEFAULT_REGION: ${{ secrets.SECONDARY_S3_REGION }}
+          S3_ENDPOINT: ${{ secrets.SECONDARY_S3_ENDPOINT }}
+          S3_BUCKET: ${{ secrets.SECONDARY_S3_BUCKET }}
+          S3_BACKEND_LABEL: Secondary-S3
+          S3_UPLOAD_ATTEMPTS: 4
+          S3_CONNECT_TIMEOUT_SECONDS: 15
+          S3_READ_TIMEOUT_SECONDS: 300
+          S3_SHA256_VERIFICATION_MODE: sidecar
+          S3_BOOTSTRAP_SIDECARS: "true"
+        shell: bash
+        run: |
+          set -euo pipefail
+          bash scripts/emergency-sync-candidate-s3.sh \
+            release-manifest.json \
+            artifacts \
+            SHA256SUMS.txt \
+            - \
+            - \
+            "releases/codex-app-beta-${{ inputs.expected_windows_package_version }}"
+
+      - name: Verify public Beta candidate and prove Stable latest was untouched
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+          RELEASE_TAG: codex-app-beta-${{ inputs.expected_windows_package_version }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          prefix="releases/$RELEASE_TAG/latest"
+
+          fetch_and_compare() {
+            local url="$1"
+            local expected="$2"
+            local output
+            output="$(mktemp)"
+            curl -fsSL --retry 5 --retry-delay 2 --retry-all-errors \
+              "$url?verify=$GITHUB_RUN_ID-$GITHUB_RUN_ATTEMPT" -o "$output"
+            cmp "$expected" "$output"
+            rm -f "$output"
+          }
+
+          range_size() {
+            local url="$1"
+            local headers size
+            headers="$(mktemp)"
+            curl -fsSL -L --retry 5 --retry-delay 2 --retry-all-errors \
+              --range 0-0 --max-filesize 2 \
+              -D "$headers" -o /dev/null \
+              "$url?verify=$GITHUB_RUN_ID-$GITHUB_RUN_ATTEMPT"
+            size="$(tr -d '\r' < "$headers" | awk 'tolower($1) == "content-range:" { value=$0 } END { sub(/^.*\//, "", value); print value }')"
+            rm -f "$headers"
+            [[ "$size" =~ ^[0-9]+$ ]] || { echo "No valid Content-Range size for $url" >&2; return 1; }
+            printf '%s' "$size"
+          }
+
+          fetch_and_compare "$R2_DIRECT_PUBLIC_BASE_URL/$prefix/manifest" release-manifest.json
+          fetch_and_compare "$R2_DIRECT_PUBLIC_BASE_URL/$prefix/checksums" SHA256SUMS.txt
+          test "$(range_size "$R2_DIRECT_PUBLIC_BASE_URL/$prefix/win-x64")" = "$(jq -r '.sources.windows.architectures.x64.contentLength' release-manifest.json)"
+          test "$(range_size "$R2_DIRECT_PUBLIC_BASE_URL/$prefix/win-arm64")" = "$(jq -r '.sources.windows.architectures.arm64.contentLength' release-manifest.json)"
+
+          curl -fsSL --retry 5 --retry-all-errors \
+            "$R2_DIRECT_PUBLIC_BASE_URL/latest/manifest?after=$GITHUB_RUN_ID" \
+            -o shared-latest-r2-after.json
+          curl -fsSL --retry 5 --retry-all-errors \
+            "$R2_ROUTED_PUBLIC_BASE_URL/latest/manifest?after=$GITHUB_RUN_ID" \
+            -o shared-latest-routed-after.json
+          cmp artifacts/emergency-beta-probe/shared-latest-r2-before.json shared-latest-r2-after.json
+          cmp artifacts/emergency-beta-probe/shared-latest-routed-before.json shared-latest-routed-after.json
+
+          gh api "repos/$GITHUB_REPOSITORY/releases/latest" --jq .tag_name > github-latest-after.txt
+          cmp artifacts/emergency-beta-probe/github-latest-before.txt github-latest-after.txt
+          gh release view "$RELEASE_TAG" --json isDraft,isPrerelease,tagName,assets \
+            --jq 'select(.isDraft == false and .isPrerelease == true and (.assets | length) >= 7)'
+
+      - name: Write publication summary
+        shell: bash
+        run: |
+          tag="codex-app-beta-${{ inputs.expected_windows_package_version }}"
+          {
+            echo "## Emergency Windows Beta candidate published"
+            echo
+            echo "- GitHub prerelease: https://github.com/${{ github.repository }}/releases/tag/$tag"
+            echo "- R2 direct manifest: $R2_DIRECT_PUBLIC_BASE_URL/releases/$tag/latest/manifest"
+            echo "- Secondary S3 snapshot: verified through the repository S3 credentials"
+            echo "- Stable/shared latest advanced: no"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/scripts/download-windows.ps1
+++ b/scripts/download-windows.ps1
@@ -1,6 +1,9 @@
 param(
   [string] $OutDir = "dist",
   [string] $ManifestPath = "",
+  [string] $ProductId = "9PLM9XGG6VKS",
+  [string] $PackageIdentity = "OpenAI.Codex",
+  [switch] $RequireArm64,
   [int] $StoreLinkMaxAttempts = 12,
   [int] $StoreLinkRetryDelaySeconds = 30
 )
@@ -35,11 +38,14 @@ if ($ManifestPath) {
         if (-not $entry.packageMoniker) {
           throw "Probe manifest has downloadable Windows $($property.Name) entry without packageMoniker."
         }
+        if (-not $entry.packageMoniker.StartsWith("$PackageIdentity`_", [StringComparison]::OrdinalIgnoreCase)) {
+          throw "Probe manifest Windows $($property.Name) package does not match identity $PackageIdentity`: $($entry.packageMoniker)."
+        }
         $windowsPackages += [pscustomobject]@{
           Architecture = $property.Name
           ExpectedPackageMoniker = $entry.packageMoniker
           ExpectedContentLength = [int64] ($entry.contentLength ?? 0)
-          Required = ($property.Name -eq "x64")
+          Required = ($property.Name -eq "x64" -or $RequireArm64.IsPresent)
         }
       }
     }
@@ -78,12 +84,13 @@ function Resolve-StorePackageLink {
   for ($attempt = 1; $attempt -le $StoreLinkMaxAttempts; $attempt++) {
     Write-Host "Resolving Microsoft Store $Architecture package link (attempt $attempt/$StoreLinkMaxAttempts)"
 
-    $resolverOutput = & dotnet run --project scripts/store-link -- 9PLM9XGG6VKS $Architecture
+    $resolverOutput = & dotnet run --project scripts/store-link -- $ProductId $Architecture $PackageIdentity
     if ($LASTEXITCODE -ne 0) {
       $lastError = "Microsoft Store resolver failed with exit code $LASTEXITCODE."
     } else {
+      $expectedPrefix = "$PackageIdentity`_"
       $linkLine = $resolverOutput |
-        Where-Object { $_ -match "^OpenAI\.Codex_" } |
+        Where-Object { $_.StartsWith($expectedPrefix, [StringComparison]::OrdinalIgnoreCase) } |
         Select-Object -First 1
 
       if (-not $linkLine) {

--- a/scripts/emergency-finalize-windows-beta.sh
+++ b/scripts/emergency-finalize-windows-beta.sh
@@ -1,0 +1,131 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+manifest_path="${1:-probe-manifest.json}"
+windows_identity="${2:?Windows identity metadata is required}"
+artifacts_dir="${3:?artifacts directory is required}"
+expected_version="${4:?expected Windows package version is required}"
+public_base_url="${5:?public base URL is required}"
+release_tag="${6:?release tag is required}"
+candidate_prefix="releases/$release_tag"
+candidate_base_url="${public_base_url%/}/$candidate_prefix"
+windows_dir="$artifacts_dir/codex-windows"
+tmp_manifest="$(mktemp)"
+
+if [[ "$release_tag" != "codex-app-beta-$expected_version" ]]; then
+  echo "Windows Beta release tag/version mismatch: $release_tag / $expected_version" >&2
+  exit 1
+fi
+
+cleanup() {
+  rm -f "$tmp_manifest"
+}
+trap cleanup EXIT
+
+jq \
+  --slurpfile win "$windows_identity" \
+  --arg expectedVersion "$expected_version" \
+  --arg releaseTag "$release_tag" \
+  --arg candidatePrefix "$candidate_prefix" \
+  --arg candidateBaseUrl "$candidate_base_url" '
+  if .emergency.contract != "issue-36-windows-beta"
+    or .emergency.channel != "beta" then
+    error("manifest is not the issue #36 Windows Beta emergency contract")
+  elif .sources.windows.productId != "9N8CJ4W95TBZ"
+    or .sources.windows.packageIdentity != "OpenAI.CodexBeta" then
+    error("Windows Beta Store identity contract mismatch")
+  elif .sources.windows.version != $expectedVersion then
+    error("Windows Beta package version does not match the frozen input")
+  elif $win[0].channel != "beta"
+    or $win[0].expectedIdentity != "OpenAI.CodexBeta"
+    or $win[0].expectedExecutable != "app/ChatGPT.exe" then
+    error("Windows Beta identity gate metadata is incomplete")
+  elif $win[0].architectures.x64.packageVersion != $expectedVersion
+    or $win[0].architectures.arm64.packageVersion != $expectedVersion then
+    error("verified MSIX package version drift")
+  else . end
+  | .sources.windows.architectures.x64 += {
+      fileName: $win[0].architectures.x64.fileName,
+      sha256: $win[0].architectures.x64.sha256,
+      packageIdentity: $win[0].architectures.x64.packageIdentity,
+      packageFamilyName: $win[0].architectures.x64.packageFamilyName,
+      applicationId: $win[0].architectures.x64.applicationId,
+      applicationExecutable: $win[0].architectures.x64.applicationExecutable
+    }
+  | .sources.windows.architectures.arm64 += {
+      fileName: $win[0].architectures.arm64.fileName,
+      sha256: $win[0].architectures.arm64.sha256,
+      packageIdentity: $win[0].architectures.arm64.packageIdentity,
+      packageFamilyName: $win[0].architectures.arm64.packageFamilyName,
+      applicationId: $win[0].architectures.arm64.applicationId,
+      applicationExecutable: $win[0].architectures.arm64.applicationExecutable
+    }
+  | .derived.prerelease = true
+  | .derived.publishLatest = false
+  | .derived.syncLatest = false
+  | .derived.emergencyCandidate = true
+  | .candidate = {
+      releaseTag: $releaseTag,
+      prefix: $candidatePrefix,
+      baseUrl: $candidateBaseUrl,
+      manifestUrl: ($candidateBaseUrl + "/latest/manifest"),
+      checksumsUrl: ($candidateBaseUrl + "/latest/checksums"),
+      windowsIdentityUrl: ($candidateBaseUrl + "/latest/windows-identity.json"),
+      windowsUrl: ($candidateBaseUrl + "/latest/win"),
+      windowsX64Url: ($candidateBaseUrl + "/latest/win-x64"),
+      windowsArm64Url: ($candidateBaseUrl + "/latest/win-arm64"),
+      sharedLatestAdvanced: false,
+      contract: "issue-36-windows-beta"
+    }
+  | .emergency.sharedLatestAdvanced = false
+  ' "$manifest_path" > "$tmp_manifest"
+mv "$tmp_manifest" "$manifest_path"
+
+windows_sums="$windows_dir/SHA256SUMS-windows.txt"
+[[ -f "$windows_sums" ]] || { echo "Missing Windows checksums: $windows_sums" >&2; exit 1; }
+while IFS=$'\t' read -r digest file_name; do
+  grep -Fqx "$digest  $file_name" "$windows_sums" || {
+    echo "Windows checksum metadata mismatch for $file_name" >&2
+    exit 1
+  }
+done < <(jq -r '.architectures.x64, .architectures.arm64 | [.sha256, .fileName] | @tsv' "$windows_identity")
+cp "$windows_sums" SHA256SUMS.txt
+sha256sum "$windows_identity" | awk '{print tolower($1) "  windows-identity.json"}' >> SHA256SUMS.txt
+sha256sum "$manifest_path" | awk '{print tolower($1) "  release-manifest.json"}' >> SHA256SUMS.txt
+
+cat > release-notes.md <<EOF
+> [!IMPORTANT]
+> 这是按 #36 发布的临时 Windows Beta 候选版本。仅镜像 Microsoft Store 的官方 MSIX 原始字节；GitHub Release、R2 和 secondary S3 使用独立 Beta 版本化路径，Stable 与 shared \`latest/*\` 均未推进。
+
+- Microsoft Store ProductId: \`9N8CJ4W95TBZ\`
+- Package identity: \`OpenAI.CodexBeta\`
+- Package version: \`$expected_version\`
+- Entrypoint: \`app/ChatGPT.exe\`
+- Candidate manifest: $candidate_base_url/latest/manifest
+- Windows x64: $candidate_base_url/latest/win-x64
+- Windows ARM64: $candidate_base_url/latest/win-arm64
+
+This emergency prerelease mirrors the official Windows Beta MSIX packages for issue #36. It does not replace the Stable channel or advance shared \`latest/*\`.
+EOF
+
+jq -e \
+  --arg expectedVersion "$expected_version" \
+  --arg releaseTag "$release_tag" \
+  --arg candidateBaseUrl "$candidate_base_url" '
+    .sources.windows.version == $expectedVersion
+    and .sources.windows.productId == "9N8CJ4W95TBZ"
+    and .sources.windows.packageIdentity == "OpenAI.CodexBeta"
+    and .sources.windows.architectures.x64.packageIdentity == "OpenAI.CodexBeta"
+    and .sources.windows.architectures.arm64.packageIdentity == "OpenAI.CodexBeta"
+    and .sources.windows.architectures.x64.applicationExecutable == "app/ChatGPT.exe"
+    and .sources.windows.architectures.arm64.applicationExecutable == "app/ChatGPT.exe"
+    and .derived.prerelease == true
+    and .derived.publishLatest == false
+    and .derived.syncLatest == false
+    and .candidate.releaseTag == $releaseTag
+    and .candidate.baseUrl == $candidateBaseUrl
+    and .candidate.sharedLatestAdvanced == false
+  ' "$manifest_path" >/dev/null
+
+echo "Finalized immutable Windows Beta candidate $release_tag at $candidate_base_url"
+jq '{version: .sources.windows.version, emergency, derived, candidate, architectures: (.sources.windows.architectures | map_values({fileName, contentLength, sha256, packageIdentity, applicationId, applicationExecutable}))}' "$manifest_path"

--- a/scripts/emergency-probe-windows-beta.sh
+++ b/scripts/emergency-probe-windows-beta.sh
@@ -1,0 +1,225 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+output_path="${1:-probe-manifest.json}"
+product_id="${BETA_PRODUCT_ID:-9N8CJ4W95TBZ}"
+package_identity="${BETA_PACKAGE_IDENTITY:-OpenAI.CodexBeta}"
+expected_version="${EXPECTED_WINDOWS_PACKAGE_VERSION:?EXPECTED_WINDOWS_PACKAGE_VERSION is required}"
+display_catalog_url="https://displaycatalog.mp.microsoft.com/v7.0/products/${product_id}?market=US&languages=en-US,en,neutral"
+resolve_attempts="${STORE_LINK_STABILITY_MAX_ATTEMPTS:-12}"
+resolve_delay="${STORE_LINK_STABILITY_RETRY_DELAY_SECONDS:-30}"
+
+require() {
+  command -v "$1" >/dev/null 2>&1 || {
+    echo "Missing required command: $1" >&2
+    exit 1
+  }
+}
+
+for command in curl dotnet jq; do
+  require "$command"
+done
+
+if [[ ! "$resolve_attempts" =~ ^[1-9][0-9]*$ || ! "$resolve_delay" =~ ^[0-9]+$ ]]; then
+  echo "Store resolver retry settings must be non-negative integers with at least one attempt." >&2
+  exit 2
+fi
+
+curl_args=(
+  --retry 5
+  --retry-delay 2
+  --retry-max-time 300
+  --connect-timeout 20
+  --max-time 180
+  --retry-all-errors
+)
+
+package_version() {
+  local moniker="$1"
+  local remainder="${moniker#${package_identity}_}"
+  printf '%s' "${remainder%%_*}"
+}
+
+header_value() {
+  local headers="$1"
+  local wanted="$2"
+  tr -d '\r' <<<"$headers" |
+    awk -v wanted="$(tr '[:upper:]' '[:lower:]' <<<"$wanted")" '
+      {
+        line = $0
+        lower = tolower(line)
+        if (index(lower, wanted ":") == 1) {
+          sub("^[^:]+:[[:space:]]*", "", line)
+          value = line
+        }
+      }
+      END { print value }
+    '
+}
+
+resolve_exact_package() {
+  local arch="$1"
+  local expected_moniker="$2"
+  local attempt output line moniker
+
+  for ((attempt = 1; attempt <= resolve_attempts; attempt++)); do
+    echo "Resolving Microsoft Store Beta $arch package (attempt $attempt/$resolve_attempts)" >&2
+    if output="$(dotnet run --project scripts/store-link -- "$product_id" "$arch" "$package_identity")"; then
+      line="$(awk -v prefix="${package_identity}_" 'index($0, prefix) == 1 { print; exit }' <<<"$output")"
+      moniker="${line%%$'\t'*}"
+      if [[ -n "$line" && "$line" == *$'\t'* && "$moniker" == "$expected_moniker" ]]; then
+        printf '%s\n' "$line"
+        return 0
+      fi
+      echo "Store resolver returned ${moniker:-no matching package}; DisplayCatalog expects $expected_moniker." >&2
+    fi
+
+    if ((attempt < resolve_attempts && resolve_delay > 0)); then
+      sleep "$resolve_delay"
+    fi
+  done
+
+  echo "Microsoft Store Beta $arch did not converge on $expected_moniker." >&2
+  return 1
+}
+
+catalog_json="$(curl -fsSL "${curl_args[@]}" "$display_catalog_url")"
+
+catalog_package() {
+  local arch="$1"
+  jq -c --arg arch "$arch" --arg identity "$package_identity" '
+    [
+      .Product.DisplaySkuAvailabilities[].Sku.Properties.Packages[]?
+      | select((.PackageFamilyName // "") | startswith($identity + "_"))
+      | select(((.Architectures // []) | map(ascii_downcase) | index($arch)) != null)
+    ]
+    | unique_by(.PackageFullName)
+    | sort_by(.PackageFullName)
+    | last // {}
+  ' <<<"$catalog_json"
+}
+
+x64_catalog="$(catalog_package x64)"
+arm64_catalog="$(catalog_package arm64)"
+x64_catalog_moniker="$(jq -r '.PackageFullName // empty' <<<"$x64_catalog")"
+arm64_catalog_moniker="$(jq -r '.PackageFullName // empty' <<<"$arm64_catalog")"
+
+if [[ -z "$x64_catalog_moniker" || -z "$arm64_catalog_moniker" ]]; then
+  echo "DisplayCatalog is missing a Windows Beta x64 or ARM64 package." >&2
+  exit 1
+fi
+
+x64_version="$(package_version "$x64_catalog_moniker")"
+arm64_version="$(package_version "$arm64_catalog_moniker")"
+if [[ "$x64_version" != "$expected_version" || "$arm64_version" != "$expected_version" ]]; then
+  echo "Windows Beta version drift: expected=$expected_version x64=$x64_version arm64=$arm64_version" >&2
+  exit 1
+fi
+
+x64_line="$(resolve_exact_package x64 "$x64_catalog_moniker")"
+arm64_line="$(resolve_exact_package arm64 "$arm64_catalog_moniker")"
+x64_url="${x64_line#*$'\t'}"
+arm64_url="${arm64_line#*$'\t'}"
+
+x64_headers="$(curl -fsSI -L "${curl_args[@]}" "$x64_url")"
+arm64_headers="$(curl -fsSI -L "${curl_args[@]}" "$arm64_url")"
+x64_size="$(header_value "$x64_headers" content-length)"
+arm64_size="$(header_value "$arm64_headers" content-length)"
+x64_catalog_size="$(jq -r '.MaxDownloadSizeInBytes // 0' <<<"$x64_catalog")"
+arm64_catalog_size="$(jq -r '.MaxDownloadSizeInBytes // 0' <<<"$arm64_catalog")"
+
+if [[ ! "$x64_size" =~ ^[0-9]+$ || ! "$arm64_size" =~ ^[0-9]+$ ]]; then
+  echo "Microsoft CDN did not return valid Windows Beta Content-Length headers." >&2
+  exit 1
+fi
+if [[ "$x64_size" != "$x64_catalog_size" || "$arm64_size" != "$arm64_catalog_size" ]]; then
+  echo "Windows Beta size drift: CDN=$x64_size/$arm64_size catalog=$x64_catalog_size/$arm64_catalog_size" >&2
+  exit 1
+fi
+
+mkdir -p "$(dirname "$output_path")"
+jq -n \
+  --arg generatedAt "$(date -u +'%Y-%m-%dT%H:%M:%SZ')" \
+  --arg productId "$product_id" \
+  --arg packageIdentity "$package_identity" \
+  --arg version "$expected_version" \
+  --arg x64UrlHost "$(sed -E 's#^(https?://[^/]+).*#\1#' <<<"$x64_url")" \
+  --arg arm64UrlHost "$(sed -E 's#^(https?://[^/]+).*#\1#' <<<"$arm64_url")" \
+  --arg x64LastModified "$(header_value "$x64_headers" last-modified)" \
+  --arg arm64LastModified "$(header_value "$arm64_headers" last-modified)" \
+  --arg x64Etag "$(header_value "$x64_headers" etag)" \
+  --arg arm64Etag "$(header_value "$arm64_headers" etag)" \
+  --argjson x64Catalog "$x64_catalog" \
+  --argjson arm64Catalog "$arm64_catalog" '
+  {
+    schemaVersion: 1,
+    generatedAt: $generatedAt,
+    version: $version,
+    emergency: {
+      contract: "issue-36-windows-beta",
+      channel: "beta",
+      sharedLatestAdvanced: false
+    },
+    derived: {
+      prerelease: true,
+      publishLatest: false,
+      syncLatest: false,
+      includeWindowsX64: true,
+      includeWindowsArm64: true,
+      includeMacosArm64: false,
+      includeMacosX64: false,
+      missingArchitectures: []
+    },
+    sources: {
+      windows: {
+        productId: $productId,
+        packageIdentity: $packageIdentity,
+        packageFamilyName: ($x64Catalog.PackageFamilyName // ""),
+        version: $version,
+        architectures: {
+          x64: {
+            architecture: "x64",
+            status: "downloadable",
+            downloadable: true,
+            version: $version,
+            packageMoniker: ($x64Catalog.PackageFullName // ""),
+            urlHost: $x64UrlHost,
+            contentLength: ($x64Catalog.MaxDownloadSizeInBytes // 0),
+            lastModified: $x64LastModified,
+            etag: $x64Etag,
+            catalog: $x64Catalog
+          },
+          arm64: {
+            architecture: "arm64",
+            status: "downloadable",
+            downloadable: true,
+            version: $version,
+            packageMoniker: ($arm64Catalog.PackageFullName // ""),
+            urlHost: $arm64UrlHost,
+            contentLength: ($arm64Catalog.MaxDownloadSizeInBytes // 0),
+            lastModified: $arm64LastModified,
+            etag: $arm64Etag,
+            catalog: $arm64Catalog
+          }
+        }
+      }
+    }
+  }
+  ' > "$output_path"
+
+jq -e \
+  --arg productId "$product_id" \
+  --arg identity "$package_identity" \
+  --arg version "$expected_version" '
+    .emergency.channel == "beta"
+    and .emergency.sharedLatestAdvanced == false
+    and .sources.windows.productId == $productId
+    and .sources.windows.packageIdentity == $identity
+    and .sources.windows.version == $version
+    and .sources.windows.architectures.x64.downloadable == true
+    and .sources.windows.architectures.arm64.downloadable == true
+    and (.sources.windows.architectures.x64.packageMoniker | startswith($identity + "_"))
+    and (.sources.windows.architectures.arm64.packageMoniker | startswith($identity + "_"))
+  ' "$output_path" >/dev/null
+
+jq '{version, channel: .emergency.channel, productId: .sources.windows.productId, packageIdentity: .sources.windows.packageIdentity, architectures: (.sources.windows.architectures | map_values({packageMoniker, contentLength, urlHost}))}' "$output_path"

--- a/scripts/emergency-publish-release.sh
+++ b/scripts/emergency-publish-release.sh
@@ -19,24 +19,39 @@ done
 
 mac_dir="$artifacts_dir/codex-macos"
 windows_dir="$artifacts_dir/codex-windows"
+has_macos="$(jq -r '(.sources.macos.arm64? != null) and (.sources.macos.x64? != null)' "$manifest_path")"
+channel="$(jq -r '.emergency.channel // "stable"' "$manifest_path")"
 assets=(
   assets/status.png
   "$manifest_path"
   "$checksums_path"
-  "$arm_appcast"
-  "$x64_appcast"
-  "$mac_dir/SHA256SUMS-macos.txt"
   "$windows_dir/SHA256SUMS-windows.txt"
-  "$mac_dir/$(jq -r '.sources.macos.arm64.mirrorBasename' "$manifest_path")"
-  "$mac_dir/$(jq -r '.sources.macos.x64.mirrorBasename' "$manifest_path")"
-  "$mac_dir/$(jq -r '.sources.macos.arm64.appcast.mirrorEnclosureBasename' "$manifest_path")"
-  "$mac_dir/$(jq -r '.sources.macos.x64.appcast.mirrorEnclosureBasename' "$manifest_path")"
 )
 
-while IFS= read -r basename; do
-  [[ -n "$basename" ]] || continue
-  assets+=("$mac_dir/$basename")
-done < <(jq -r '.sources.macos.arm64.appcast.deltas[]?.basename // empty, .sources.macos.x64.appcast.deltas[]?.basename // empty' "$manifest_path")
+if [[ "$channel" == "beta" && -f "$windows_dir/windows-identity.json" ]]; then
+  assets+=("$windows_dir/windows-identity.json")
+fi
+
+if [[ "$has_macos" == "true" ]]; then
+  [[ "$arm_appcast" != "-" && "$x64_appcast" != "-" ]] || {
+    echo "macOS candidate requires both appcast paths" >&2
+    exit 1
+  }
+  assets+=(
+    "$arm_appcast"
+    "$x64_appcast"
+    "$mac_dir/SHA256SUMS-macos.txt"
+    "$mac_dir/$(jq -r '.sources.macos.arm64.mirrorBasename' "$manifest_path")"
+    "$mac_dir/$(jq -r '.sources.macos.x64.mirrorBasename' "$manifest_path")"
+    "$mac_dir/$(jq -r '.sources.macos.arm64.appcast.mirrorEnclosureBasename' "$manifest_path")"
+    "$mac_dir/$(jq -r '.sources.macos.x64.appcast.mirrorEnclosureBasename' "$manifest_path")"
+  )
+
+  while IFS= read -r basename; do
+    [[ -n "$basename" ]] || continue
+    assets+=("$mac_dir/$basename")
+  done < <(jq -r '.sources.macos.arm64.appcast.deltas[]?.basename // empty, .sources.macos.x64.appcast.deltas[]?.basename // empty' "$manifest_path")
+fi
 
 while IFS= read -r msix; do
   [[ -n "$msix" ]] || continue

--- a/scripts/emergency-sync-candidate-s3.sh
+++ b/scripts/emergency-sync-candidate-s3.sh
@@ -261,46 +261,61 @@ put_replaceable_metadata() {
 
 mac_dir="$artifacts_dir/codex-macos"
 windows_dir="$artifacts_dir/codex-windows"
+has_macos="$(jq -r '(.sources.macos.arm64? != null) and (.sources.macos.x64? != null)' "$manifest_path")"
+channel="$(jq -r '.emergency.channel // "stable"' "$manifest_path")"
 win_x64="$(find "$windows_dir" -maxdepth 1 -type f \( -name '*_x64__*.Msix' -o -name '*_x64__*.msix' \) | sort | head -n 1)"
 win_arm64="$(find "$windows_dir" -maxdepth 1 -type f \( -name '*_arm64__*.Msix' -o -name '*_arm64__*.msix' \) | sort | head -n 1)"
-arm_dmg="$mac_dir/$(jq -r '.sources.macos.arm64.mirrorBasename' "$manifest_path")"
-x64_dmg="$mac_dir/$(jq -r '.sources.macos.x64.mirrorBasename' "$manifest_path")"
-arm_zip_name="$(jq -r '.sources.macos.arm64.appcast.mirrorEnclosureBasename' "$manifest_path")"
-x64_zip_name="$(jq -r '.sources.macos.x64.appcast.mirrorEnclosureBasename' "$manifest_path")"
 
 base="$candidate_prefix/latest"
 
 # Upload all bytes first. The candidate appcasts and manifest are committed last,
 # so readers never observe metadata that points to a missing immutable object.
-put_immutable "$base/mac-arm64" "$arm_dmg" application/x-apple-diskimage
-put_immutable "$base/mac-intel" "$x64_dmg" application/x-apple-diskimage
 put_immutable "$base/win" "$win_x64" application/msix
 put_immutable "$base/win-x64" "$win_x64" application/msix
 put_immutable "$base/win-arm64" "$win_arm64" application/msix
-put_immutable "$base/mac/arm64/$arm_zip_name" "$mac_dir/$arm_zip_name" application/zip
-put_immutable "$base/mac/intel/$x64_zip_name" "$mac_dir/$x64_zip_name" application/zip
 
-while IFS= read -r basename; do
-  [[ -n "$basename" ]] || continue
-  if [[ "$basename" == */* ]]; then
-    echo "Unsafe arm64 delta basename: $basename" >&2
+if [[ "$has_macos" == "true" ]]; then
+  [[ "$arm_appcast" != "-" && "$x64_appcast" != "-" ]] || {
+    echo "macOS candidate requires both appcast paths" >&2
     exit 1
-  fi
-  put_immutable "$base/mac/arm64/$basename" "$mac_dir/$basename" application/octet-stream
-done < <(jq -r '.sources.macos.arm64.appcast.deltas[]?.basename // empty' "$manifest_path")
+  }
+  arm_dmg="$mac_dir/$(jq -r '.sources.macos.arm64.mirrorBasename' "$manifest_path")"
+  x64_dmg="$mac_dir/$(jq -r '.sources.macos.x64.mirrorBasename' "$manifest_path")"
+  arm_zip_name="$(jq -r '.sources.macos.arm64.appcast.mirrorEnclosureBasename' "$manifest_path")"
+  x64_zip_name="$(jq -r '.sources.macos.x64.appcast.mirrorEnclosureBasename' "$manifest_path")"
 
-while IFS= read -r basename; do
-  [[ -n "$basename" ]] || continue
-  if [[ "$basename" == */* ]]; then
-    echo "Unsafe x64 delta basename: $basename" >&2
-    exit 1
-  fi
-  put_immutable "$base/mac/intel/$basename" "$mac_dir/$basename" application/octet-stream
-done < <(jq -r '.sources.macos.x64.appcast.deltas[]?.basename // empty' "$manifest_path")
+  put_immutable "$base/mac-arm64" "$arm_dmg" application/x-apple-diskimage
+  put_immutable "$base/mac-intel" "$x64_dmg" application/x-apple-diskimage
+  put_immutable "$base/mac/arm64/$arm_zip_name" "$mac_dir/$arm_zip_name" application/zip
+  put_immutable "$base/mac/intel/$x64_zip_name" "$mac_dir/$x64_zip_name" application/zip
+
+  while IFS= read -r basename; do
+    [[ -n "$basename" ]] || continue
+    if [[ "$basename" == */* ]]; then
+      echo "Unsafe arm64 delta basename: $basename" >&2
+      exit 1
+    fi
+    put_immutable "$base/mac/arm64/$basename" "$mac_dir/$basename" application/octet-stream
+  done < <(jq -r '.sources.macos.arm64.appcast.deltas[]?.basename // empty' "$manifest_path")
+
+  while IFS= read -r basename; do
+    [[ -n "$basename" ]] || continue
+    if [[ "$basename" == */* ]]; then
+      echo "Unsafe x64 delta basename: $basename" >&2
+      exit 1
+    fi
+    put_immutable "$base/mac/intel/$basename" "$mac_dir/$basename" application/octet-stream
+  done < <(jq -r '.sources.macos.x64.appcast.deltas[]?.basename // empty' "$manifest_path")
+fi
 
 put_replaceable_metadata "$base/checksums" "$candidate_checksums" text/plain
-put_replaceable_metadata "$base/appcast.xml" "$arm_appcast" application/xml
-put_replaceable_metadata "$base/appcast-x64.xml" "$x64_appcast" application/xml
+if [[ "$channel" == "beta" && -f "$windows_dir/windows-identity.json" ]]; then
+  put_replaceable_metadata "$base/windows-identity.json" "$windows_dir/windows-identity.json" application/json
+fi
+if [[ "$has_macos" == "true" ]]; then
+  put_replaceable_metadata "$base/appcast.xml" "$arm_appcast" application/xml
+  put_replaceable_metadata "$base/appcast-x64.xml" "$x64_appcast" application/xml
+fi
 put_replaceable_metadata "$base/manifest" "$manifest_path" application/json
 
 echo "[$backend_label] candidate snapshot complete: s3://$S3_BUCKET/$candidate_prefix/"

--- a/scripts/emergency-verify-windows.ps1
+++ b/scripts/emergency-verify-windows.ps1
@@ -2,18 +2,21 @@ param(
   [Parameter(Mandatory = $true)]
   [string] $ManifestPath,
   [string] $ArtifactsDir = "dist/windows",
-  [string] $OutputPath = "dist/windows/windows-identity.json"
+  [string] $OutputPath = "dist/windows/windows-identity.json",
+  [string] $ExpectedIdentity = "OpenAI.Codex",
+  [ValidateSet("stable", "beta")]
+  [string] $Channel = "stable",
+  [string] $ExpectedExecutable = "app/ChatGPT.exe"
 )
 
 $ErrorActionPreference = "Stop"
-$expectedIdentity = "OpenAI.Codex"
 $manifest = Get-Content -LiteralPath $ManifestPath -Raw | ConvertFrom-Json
 $packages = Get-ChildItem -LiteralPath $ArtifactsDir -File |
   Where-Object { $_.Name -match '\.(Msix|msix)$' } |
   Sort-Object Name
 
 if ($packages.Count -ne 2) {
-  throw "Expected exactly two Stable MSIX packages, found $($packages.Count)."
+  throw "Expected exactly two $Channel MSIX packages, found $($packages.Count)."
 }
 
 Add-Type -AssemblyName System.IO.Compression.FileSystem
@@ -63,8 +66,8 @@ foreach ($package in $packages) {
     $identityName = $identity.Attribute('Name').Value
     $packageVersion = $identity.Attribute('Version').Value
     $processorArchitecture = $identity.Attribute('ProcessorArchitecture').Value.ToLowerInvariant()
-    if ($identityName -ne $expectedIdentity) {
-      throw "$($package.Name) identity mismatch: expected=$expectedIdentity actual=$identityName."
+    if ($identityName -ne $ExpectedIdentity) {
+      throw "$($package.Name) identity mismatch: expected=$ExpectedIdentity actual=$identityName."
     }
     if ($packageVersion -ne $expected.version) {
       throw "$($package.Name) package version mismatch: expected=$($expected.version) actual=$packageVersion."
@@ -82,6 +85,9 @@ foreach ($package in $packages) {
     $executable = $applications[0].Attribute('Executable').Value.Replace('\', '/')
     if ([string]::IsNullOrWhiteSpace($executable)) {
       throw "$($package.Name) Application@Executable is empty."
+    }
+    if (-not $executable.Equals($ExpectedExecutable, [StringComparison]::OrdinalIgnoreCase)) {
+      throw "$($package.Name) entrypoint mismatch: expected=$ExpectedExecutable actual=$executable."
     }
 
     $matchingExecutables = @($archive.Entries | Where-Object {
@@ -102,7 +108,7 @@ foreach ($package in $packages) {
       applicationId = $applicationId
       applicationExecutable = $executable
     }
-    Write-Host "$($package.Name) passed Stable identity gate: $identityName / $applicationId / $executable"
+    Write-Host "$($package.Name) passed $Channel identity gate: $identityName / $applicationId / $executable"
   } finally {
     $archive.Dispose()
   }
@@ -114,8 +120,9 @@ if (-not $architectures.Contains('x64') -or -not $architectures.Contains('arm64'
 
 $payload = [ordered]@{
   schemaVersion = 1
-  channel = 'stable'
-  expectedIdentity = $expectedIdentity
+  channel = $Channel
+  expectedIdentity = $ExpectedIdentity
+  expectedExecutable = $ExpectedExecutable
   architectures = $architectures
 }
 

--- a/scripts/store-link/Program.cs
+++ b/scripts/store-link/Program.cs
@@ -9,7 +9,6 @@ using System.Xml.Linq;
 
 internal static class Program
 {
-    private const string ProductPrefix = "OpenAI.Codex_";
     private const string DisplayCatalogBaseUrl = "https://displaycatalog.mp.microsoft.com/v7.0/products";
     private const string Fe3Host = "fe3.delivery.mp.microsoft.com";
     private const string Fe3Endpoint = "https://fe3.delivery.mp.microsoft.com/ClientWebService/client.asmx";
@@ -85,12 +84,19 @@ internal static class Program
     {
         if (args.Length < 1)
         {
-            Console.Error.WriteLine("Usage: StoreLink <product-id> [architecture]");
+            Console.Error.WriteLine("Usage: StoreLink <product-id> [architecture] [package-identity]");
             return 2;
         }
 
         var productId = args[0];
         var architecture = NormalizeArchitecture(args.Length > 1 ? args[1] : "x64");
+        var packageIdentity = args.Length > 2 ? args[2] : "OpenAI.Codex";
+        if (string.IsNullOrWhiteSpace(packageIdentity))
+        {
+            Console.Error.WriteLine("package-identity must not be empty.");
+            return 2;
+        }
+        var productPrefix = packageIdentity + "_";
 
         using var handler = new HttpClientHandler
         {
@@ -111,7 +117,7 @@ internal static class Program
             var syncXml = await SyncUpdatesAsync(httpClient, cookie, wuCategoryId, deviceAttributes);
             var candidates = ParsePackageCandidates(syncXml);
             var package = candidates
-                .Where(p => p.PackageMoniker.StartsWith(ProductPrefix, StringComparison.OrdinalIgnoreCase))
+                .Where(p => p.PackageMoniker.StartsWith(productPrefix, StringComparison.OrdinalIgnoreCase))
                 .Where(p => p.PackageMoniker.Contains($"_{architecture}__", StringComparison.OrdinalIgnoreCase))
                 .OrderByDescending(p => ExtractVersion(p.PackageMoniker))
                 .FirstOrDefault();

--- a/scripts/test-download-windows-retry.sh
+++ b/scripts/test-download-windows-retry.sh
@@ -33,7 +33,7 @@ case "${1:-}" in
     printf 'fake dotnet info\n'
     ;;
   run)
-    if [[ "$*" == *" arm64" ]]; then
+    if [[ " $* " == *" arm64 "* ]]; then
       printf '%s\thttp://127.0.0.1:%s/%s.Msix\n' \
         "${TEST_CHANGED_ARM64_PACKAGE:?TEST_CHANGED_ARM64_PACKAGE must be set}" \
         "${TEST_HTTP_PORT:?TEST_HTTP_PORT must be set}" \


### PR DESCRIPTION
## What changed

- add a one-shot Windows Beta candidate workflow for issue #36
- resolve ProductId `9N8CJ4W95TBZ` for both x64 and ARM64 while pinning package identity `OpenAI.CodexBeta`
- verify the downloaded MSIX identity, package version, architecture, and `app/ChatGPT.exe` entrypoint
- publish an isolated prerelease plus immutable R2 and secondary-S3 snapshots under `releases/codex-app-beta-<version>/`
- prove GitHub Stable latest and both shared mirror `latest/manifest` endpoints are unchanged

## Why

The Stable P0 stopgap intentionally excludes Windows Beta. This adds a separate emergency path without coupling Beta packages to the Stable release or shared latest channel.

## Live source snapshot

- package version: `26.707.3351.0`
- x64: `OpenAI.CodexBeta_26.707.3351.0_x64__2p2nqsd0c76g0` / `728598083` bytes
- ARM64: `OpenAI.CodexBeta_26.707.3351.0_arm64__2p2nqsd0c76g0` / `723923759` bytes

## Validation

- real Microsoft Store DisplayCatalog + FE3 probe for both architectures
- `actionlint`
- shell and PowerShell parser checks
- `dotnet build scripts/store-link/StoreLink.csproj`
- Windows download retry fixture
- release/probe/appcast/prune/portable fixtures
- secondary-S3 retry fixture with agents-mirror-kit v0.2.0

Refs #36