### PR TITLE
fix(ci): verify Windows Beta entrypoint

### DIFF
--- a/.github/workflows/emergency-windows-beta-release.yml
+++ b/.github/workflows/emergency-windows-beta-release.yml
@@ -106,7 +106,7 @@ jobs:
             -OutputPath dist/windows/windows-identity.json `
             -ExpectedIdentity "$env:BETA_PACKAGE_IDENTITY" `
             -Channel beta `
-            -ExpectedExecutable app/ChatGPT.exe
+            -ExpectedExecutable 'app/ChatGPT (Beta).exe'
 
       - uses: actions/upload-artifact@v7
         with:

--- a/scripts/emergency-finalize-windows-beta.sh
+++ b/scripts/emergency-finalize-windows-beta.sh
@@ -38,7 +38,7 @@ jq \
     error("Windows Beta package version does not match the frozen input")
   elif $win[0].channel != "beta"
     or $win[0].expectedIdentity != "OpenAI.CodexBeta"
-    or $win[0].expectedExecutable != "app/ChatGPT.exe" then
+    or $win[0].expectedExecutable != "app/ChatGPT (Beta).exe" then
     error("Windows Beta identity gate metadata is incomplete")
   elif $win[0].architectures.x64.packageVersion != $expectedVersion
     or $win[0].architectures.arm64.packageVersion != $expectedVersion then
@@ -100,7 +100,7 @@ cat > release-notes.md <<EOF
 - Microsoft Store ProductId: \`9N8CJ4W95TBZ\`
 - Package identity: \`OpenAI.CodexBeta\`
 - Package version: \`$expected_version\`
-- Entrypoint: \`app/ChatGPT.exe\`
+- Entrypoint: \`app/ChatGPT (Beta).exe\`
 - Candidate manifest: $candidate_base_url/latest/manifest
 - Windows x64: $candidate_base_url/latest/win-x64
 - Windows ARM64: $candidate_base_url/latest/win-arm64
@@ -117,8 +117,8 @@ jq -e \
     and .sources.windows.packageIdentity == "OpenAI.CodexBeta"
     and .sources.windows.architectures.x64.packageIdentity == "OpenAI.CodexBeta"
     and .sources.windows.architectures.arm64.packageIdentity == "OpenAI.CodexBeta"
-    and .sources.windows.architectures.x64.applicationExecutable == "app/ChatGPT.exe"
-    and .sources.windows.architectures.arm64.applicationExecutable == "app/ChatGPT.exe"
+    and .sources.windows.architectures.x64.applicationExecutable == "app/ChatGPT (Beta).exe"
+    and .sources.windows.architectures.arm64.applicationExecutable == "app/ChatGPT (Beta).exe"
     and .derived.prerelease == true
     and .derived.publishLatest == false
     and .derived.syncLatest == false

--- a/scripts/emergency-probe-windows-beta.sh
+++ b/scripts/emergency-probe-windows-beta.sh
@@ -158,6 +158,7 @@ jq -n \
     emergency: {
       contract: "issue-36-windows-beta",
       channel: "beta",
+      expectedExecutable: "app/ChatGPT (Beta).exe",
       sharedLatestAdvanced: false
     },
     derived: {


### PR DESCRIPTION
## Root cause

The first real Beta run downloaded both exact MSIX packages successfully, then failed closed during package inspection because the Beta AppxManifest uses `app/ChatGPT (Beta).exe`. The stopgap had inherited Stable's `app/ChatGPT.exe` expectation.

Failed run: https://github.com/Wangnov/codex-app-mirror/actions/runs/29069414290

## Fix

- pin the Beta workflow to the observed `app/ChatGPT (Beta).exe` entrypoint
- record that expectation in the frozen Beta probe manifest
- keep Stable's default `app/ChatGPT.exe` gate unchanged
- keep package identity `OpenAI.CodexBeta` and all other fail-closed checks unchanged

## Validation

- actionlint
- shell and PowerShell parser checks
- fresh live Store probe for x64 and ARM64
- Beta finalizer fixture with the observed entrypoint