### PR TITLE
fix(ci): verify encoded Windows Beta archive path

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,6 +78,10 @@ jobs:
         shell: bash
         run: scripts/test-download-windows-retry.sh
 
+      - name: Test emergency Windows identity fixture
+        shell: bash
+        run: scripts/test-emergency-verify-windows.sh
+
       - name: Test secondary S3 retry fixture
         shell: bash
         run: scripts/test-sync-secondary-s3.sh

--- a/scripts/emergency-finalize-windows-beta.sh
+++ b/scripts/emergency-finalize-windows-beta.sh
@@ -43,6 +43,9 @@ jq \
   elif $win[0].architectures.x64.packageVersion != $expectedVersion
     or $win[0].architectures.arm64.packageVersion != $expectedVersion then
     error("verified MSIX package version drift")
+  elif $win[0].architectures.x64.applicationArchivePath != "app/ChatGPT%20%28Beta%29.exe"
+    or $win[0].architectures.arm64.applicationArchivePath != "app/ChatGPT%20%28Beta%29.exe" then
+    error("verified MSIX archive entrypoint drift")
   else . end
   | .sources.windows.architectures.x64 += {
       fileName: $win[0].architectures.x64.fileName,
@@ -50,7 +53,8 @@ jq \
       packageIdentity: $win[0].architectures.x64.packageIdentity,
       packageFamilyName: $win[0].architectures.x64.packageFamilyName,
       applicationId: $win[0].architectures.x64.applicationId,
-      applicationExecutable: $win[0].architectures.x64.applicationExecutable
+      applicationExecutable: $win[0].architectures.x64.applicationExecutable,
+      applicationArchivePath: $win[0].architectures.x64.applicationArchivePath
     }
   | .sources.windows.architectures.arm64 += {
       fileName: $win[0].architectures.arm64.fileName,
@@ -58,7 +62,8 @@ jq \
       packageIdentity: $win[0].architectures.arm64.packageIdentity,
       packageFamilyName: $win[0].architectures.arm64.packageFamilyName,
       applicationId: $win[0].architectures.arm64.applicationId,
-      applicationExecutable: $win[0].architectures.arm64.applicationExecutable
+      applicationExecutable: $win[0].architectures.arm64.applicationExecutable,
+      applicationArchivePath: $win[0].architectures.arm64.applicationArchivePath
     }
   | .derived.prerelease = true
   | .derived.publishLatest = false
@@ -119,6 +124,8 @@ jq -e \
     and .sources.windows.architectures.arm64.packageIdentity == "OpenAI.CodexBeta"
     and .sources.windows.architectures.x64.applicationExecutable == "app/ChatGPT (Beta).exe"
     and .sources.windows.architectures.arm64.applicationExecutable == "app/ChatGPT (Beta).exe"
+    and .sources.windows.architectures.x64.applicationArchivePath == "app/ChatGPT%20%28Beta%29.exe"
+    and .sources.windows.architectures.arm64.applicationArchivePath == "app/ChatGPT%20%28Beta%29.exe"
     and .derived.prerelease == true
     and .derived.publishLatest == false
     and .derived.syncLatest == false
@@ -128,4 +135,4 @@ jq -e \
   ' "$manifest_path" >/dev/null
 
 echo "Finalized immutable Windows Beta candidate $release_tag at $candidate_base_url"
-jq '{version: .sources.windows.version, emergency, derived, candidate, architectures: (.sources.windows.architectures | map_values({fileName, contentLength, sha256, packageIdentity, applicationId, applicationExecutable}))}' "$manifest_path"
+jq '{version: .sources.windows.version, emergency, derived, candidate, architectures: (.sources.windows.architectures | map_values({fileName, contentLength, sha256, packageIdentity, applicationId, applicationExecutable, applicationArchivePath}))}' "$manifest_path"

--- a/scripts/emergency-verify-windows.ps1
+++ b/scripts/emergency-verify-windows.ps1
@@ -90,12 +90,18 @@ foreach ($package in $packages) {
       throw "$($package.Name) entrypoint mismatch: expected=$ExpectedExecutable actual=$executable."
     }
 
+    $encodedExecutable = (($executable -split '/') | ForEach-Object {
+      [Uri]::EscapeDataString($_)
+    }) -join '/'
     $matchingExecutables = @($archive.Entries | Where-Object {
-      $_.FullName.Replace('\', '/').Equals($executable, [StringComparison]::OrdinalIgnoreCase)
+      $archivePath = $_.FullName.Replace('\', '/')
+      $archivePath.Equals($executable, [StringComparison]::OrdinalIgnoreCase) -or
+        $archivePath.Equals($encodedExecutable, [StringComparison]::OrdinalIgnoreCase)
     })
     if ($matchingExecutables.Count -ne 1) {
       throw "$($package.Name) manifest executable '$executable' does not resolve to exactly one package entry."
     }
+    $applicationArchivePath = $matchingExecutables[0].FullName.Replace('\', '/')
 
     $sha256 = (Get-FileHash -Algorithm SHA256 -LiteralPath $package.FullName).Hash.ToLowerInvariant()
     $architectures[$architecture] = [ordered]@{
@@ -107,8 +113,9 @@ foreach ($package in $packages) {
       packageFamilyName = [string]$expected.catalog.packageFamilyName
       applicationId = $applicationId
       applicationExecutable = $executable
+      applicationArchivePath = $applicationArchivePath
     }
-    Write-Host "$($package.Name) passed $Channel identity gate: $identityName / $applicationId / $executable"
+    Write-Host "$($package.Name) passed $Channel identity gate: $identityName / $applicationId / $executable -> $applicationArchivePath"
   } finally {
     $archive.Dispose()
   }

--- a/scripts/test-emergency-verify-windows.sh
+++ b/scripts/test-emergency-verify-windows.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+tmp_dir="$(mktemp -d)"
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cleanup() {
+  rm -rf "$tmp_dir"
+}
+trap cleanup EXIT
+
+python3 - "$tmp_dir" <<'PY'
+import json
+from pathlib import Path
+import sys
+import zipfile
+
+root = Path(sys.argv[1])
+artifacts = root / "windows"
+artifacts.mkdir(parents=True)
+version = "26.707.3351.0"
+identity = "OpenAI.CodexBeta"
+family = "OpenAI.CodexBeta_2p2nqsd0c76g0"
+architectures = {}
+
+for arch in ("x64", "arm64"):
+    moniker = f"{identity}_{version}_{arch}__2p2nqsd0c76g0"
+    package_path = artifacts / f"{moniker}.Msix"
+    manifest_xml = f'''<?xml version="1.0" encoding="utf-8"?>
+<Package xmlns="http://schemas.microsoft.com/appx/manifest/foundation/windows10">
+  <Identity Name="{identity}" Version="{version}" ProcessorArchitecture="{arch}" />
+  <Applications>
+    <Application Id="App" Executable="app\\ChatGPT (Beta).exe" />
+  </Applications>
+</Package>
+'''
+    with zipfile.ZipFile(package_path, "w", compression=zipfile.ZIP_DEFLATED) as package:
+        package.writestr("AppxManifest.xml", manifest_xml)
+        package.writestr("app/ChatGPT%20%28Beta%29.exe", b"fixture")
+
+    architectures[arch] = {
+        "architecture": arch,
+        "downloadable": True,
+        "version": version,
+        "packageMoniker": moniker,
+        "contentLength": package_path.stat().st_size,
+        "catalog": {"packageFamilyName": family},
+    }
+
+probe = {"sources": {"windows": {"architectures": architectures}}}
+(root / "probe-manifest.json").write_text(json.dumps(probe), encoding="utf-8")
+PY
+
+pwsh -NoLogo -NoProfile -File "$repo_root/scripts/emergency-verify-windows.ps1" \
+  -ManifestPath "$tmp_dir/probe-manifest.json" \
+  -ArtifactsDir "$tmp_dir/windows" \
+  -OutputPath "$tmp_dir/windows-identity.json" \
+  -ExpectedIdentity OpenAI.CodexBeta \
+  -Channel beta \
+  -ExpectedExecutable 'app/ChatGPT (Beta).exe'
+
+jq -e '
+  .channel == "beta"
+  and .expectedIdentity == "OpenAI.CodexBeta"
+  and .expectedExecutable == "app/ChatGPT (Beta).exe"
+  and ([.architectures[]
+    | .applicationExecutable == "app/ChatGPT (Beta).exe"
+      and .applicationArchivePath == "app/ChatGPT%20%28Beta%29.exe"] | all)
+' "$tmp_dir/windows-identity.json" >/dev/null
+
+echo "emergency Windows identity fixture PASS"


### PR DESCRIPTION
## Root cause

The second real Beta run matched the AppxManifest entrypoint `app/ChatGPT (Beta).exe`, but the MSIX ZIP stores that file as `app/ChatGPT%20%28Beta%29.exe`. The verifier previously required the manifest spelling to equal the raw ZIP entry spelling.

Failed run: https://github.com/Wangnov/codex-app-mirror/actions/runs/29069591184

## Fix

- derive the canonical per-path-segment URI encoding of the manifest entrypoint
- require exactly one ZIP entry matching either the literal manifest path or that canonical encoded path
- record both `applicationExecutable` and `applicationArchivePath` in identity/release metadata
- keep the Beta finalizer pinned to the exact encoded archive path observed in both official packages
- add a dual-architecture synthetic MSIX regression fixture to CI

## Validation

- read-only HTTP Range inspection of the official ARM64 MSIX central directory
- new x64/ARM64 encoded-entrypoint fixture
- actionlint, shell parser, PowerShell parser
- Beta finalizer fixture