### PR TITLE
fix(ci): normalize Windows Beta checksums

### DIFF
--- a/scripts/emergency-finalize-windows-beta.sh
+++ b/scripts/emergency-finalize-windows-beta.sh
@@ -88,13 +88,13 @@ mv "$tmp_manifest" "$manifest_path"
 
 windows_sums="$windows_dir/SHA256SUMS-windows.txt"
 [[ -f "$windows_sums" ]] || { echo "Missing Windows checksums: $windows_sums" >&2; exit 1; }
+tr -d '\r' < "$windows_sums" > SHA256SUMS.txt
 while IFS=$'\t' read -r digest file_name; do
-  grep -Fqx "$digest  $file_name" "$windows_sums" || {
+  grep -Fqx "$digest  $file_name" SHA256SUMS.txt || {
     echo "Windows checksum metadata mismatch for $file_name" >&2
     exit 1
   }
 done < <(jq -r '.architectures.x64, .architectures.arm64 | [.sha256, .fileName] | @tsv' "$windows_identity")
-cp "$windows_sums" SHA256SUMS.txt
 sha256sum "$windows_identity" | awk '{print tolower($1) "  windows-identity.json"}' >> SHA256SUMS.txt
 sha256sum "$manifest_path" | awk '{print tolower($1) "  release-manifest.json"}' >> SHA256SUMS.txt
 

--- a/scripts/test-emergency-verify-windows.sh
+++ b/scripts/test-emergency-verify-windows.sh
@@ -15,7 +15,7 @@ import sys
 import zipfile
 
 root = Path(sys.argv[1])
-artifacts = root / "windows"
+artifacts = root / "artifacts" / "codex-windows"
 artifacts.mkdir(parents=True)
 version = "26.707.3351.0"
 identity = "OpenAI.CodexBeta"
@@ -46,14 +46,41 @@ for arch in ("x64", "arm64"):
         "catalog": {"packageFamilyName": family},
     }
 
-probe = {"sources": {"windows": {"architectures": architectures}}}
+probe = {
+    "version": version,
+    "emergency": {
+        "contract": "issue-36-windows-beta",
+        "channel": "beta",
+        "expectedExecutable": "app/ChatGPT (Beta).exe",
+        "sharedLatestAdvanced": False,
+    },
+    "derived": {
+        "prerelease": True,
+        "publishLatest": False,
+        "syncLatest": False,
+        "includeWindowsX64": True,
+        "includeWindowsArm64": True,
+        "includeMacosArm64": False,
+        "includeMacosX64": False,
+        "missingArchitectures": [],
+    },
+    "sources": {
+        "windows": {
+            "productId": "9N8CJ4W95TBZ",
+            "packageIdentity": identity,
+            "packageFamilyName": family,
+            "version": version,
+            "architectures": architectures,
+        }
+    },
+}
 (root / "probe-manifest.json").write_text(json.dumps(probe), encoding="utf-8")
 PY
 
 pwsh -NoLogo -NoProfile -File "$repo_root/scripts/emergency-verify-windows.ps1" \
   -ManifestPath "$tmp_dir/probe-manifest.json" \
-  -ArtifactsDir "$tmp_dir/windows" \
-  -OutputPath "$tmp_dir/windows-identity.json" \
+  -ArtifactsDir "$tmp_dir/artifacts/codex-windows" \
+  -OutputPath "$tmp_dir/artifacts/codex-windows/windows-identity.json" \
   -ExpectedIdentity OpenAI.CodexBeta \
   -Channel beta \
   -ExpectedExecutable 'app/ChatGPT (Beta).exe'
@@ -65,6 +92,40 @@ jq -e '
   and ([.architectures[]
     | .applicationExecutable == "app/ChatGPT (Beta).exe"
       and .applicationArchivePath == "app/ChatGPT%20%28Beta%29.exe"] | all)
-' "$tmp_dir/windows-identity.json" >/dev/null
+' "$tmp_dir/artifacts/codex-windows/windows-identity.json" >/dev/null
+
+python3 - "$tmp_dir/artifacts/codex-windows" <<'PY'
+import hashlib
+from pathlib import Path
+import sys
+
+root = Path(sys.argv[1])
+lines = []
+for package in sorted(root.glob("*.Msix")):
+    lines.append(f"{hashlib.sha256(package.read_bytes()).hexdigest()}  {package.name}")
+(root / "SHA256SUMS-windows.txt").write_bytes(("\r\n".join(lines) + "\r\n").encode("ascii"))
+PY
+
+cp "$tmp_dir/probe-manifest.json" "$tmp_dir/release-manifest.json"
+(
+  cd "$tmp_dir"
+  bash "$repo_root/scripts/emergency-finalize-windows-beta.sh" \
+    release-manifest.json \
+    artifacts/codex-windows/windows-identity.json \
+    artifacts \
+    26.707.3351.0 \
+    https://codexapp-r2.agentsmirror.com \
+    codex-app-beta-26.707.3351.0 >/dev/null
+
+  if LC_ALL=C grep -q $'\r' SHA256SUMS.txt; then
+    echo "Canonical Beta checksums must use LF line endings." >&2
+    exit 1
+  fi
+  jq -e '
+    .sources.windows.architectures.x64.applicationArchivePath == "app/ChatGPT%20%28Beta%29.exe"
+    and .sources.windows.architectures.arm64.applicationArchivePath == "app/ChatGPT%20%28Beta%29.exe"
+    and .candidate.sharedLatestAdvanced == false
+  ' release-manifest.json >/dev/null
+)
 
 echo "emergency Windows identity fixture PASS"


### PR DESCRIPTION
## Root cause

The third real Beta run completed both MSIX downloads and all identity gates, then failed before publication because PowerShell wrote `SHA256SUMS-windows.txt` with CRLF line endings. The Linux finalizer's exact line match included the trailing carriage return.

Failed run: https://github.com/Wangnov/codex-app-mirror/actions/runs/29069851680

## Fix

- normalize the Windows checksum artifact to LF before exact digest/file-name validation
- use that normalized file as the canonical candidate/release checksum list
- extend the emergency Windows fixture to create real CRLF checksums and run the complete Beta finalizer

No GitHub Release or S3/R2 objects were written by the failed run.