### PR TITLE
fix(ci): avoid redundant backend input transfers

### DIFF
--- a/.github/workflows/mirror.yml
+++ b/.github/workflows/mirror.yml
@@ -94,6 +94,7 @@ jobs:
           name: codex-macos-x64-backend-input
           path: dist/macos-x64-backend-input/*
           if-no-files-found: error
+          retention-days: 1
 
       - name: Upload macOS artifacts
         uses: actions/upload-artifact@v7
@@ -192,6 +193,7 @@ jobs:
           name: codex-windows-arm64-backend-input
           path: dist/windows-arm64-backend-input/*
           if-no-files-found: error
+          retention-days: 1
 
       - name: Upload Windows artifact
         uses: actions/upload-artifact@v7
@@ -296,9 +298,31 @@ jobs:
           ref: v0.2.0
           path: .mirror-kit
 
-      - uses: actions/download-artifact@v8
+      - name: Download macOS release artifacts
+        uses: actions/download-artifact@v8
         with:
-          path: artifacts
+          name: codex-macos
+          path: artifacts/codex-macos
+
+      - name: Download Windows release artifacts
+        uses: actions/download-artifact@v8
+        with:
+          name: codex-windows
+          path: artifacts/codex-windows
+
+      - name: Download Windows ARM64 backend metadata
+        continue-on-error: true
+        uses: actions/download-artifact@v8
+        with:
+          name: codex-windows-arm64-backend
+          path: artifacts/codex-windows-arm64-backend
+
+      - name: Download macOS Intel backend metadata
+        continue-on-error: true
+        uses: actions/download-artifact@v8
+        with:
+          name: codex-macos-x64-backend
+          path: artifacts/codex-macos-x64-backend
 
       - name: Prepare release metadata
         id: meta


### PR DESCRIPTION
## Summary

- download only installer and optional backend metadata artifacts in the publish job
- retain cross-architecture backend input artifacts for one day

## Why

PR #29 replaced multi-gigabyte native-job downloads with two small backend input artifacts. The publish job still downloaded every workflow artifact, so it fetched those inputs again even though it never consumes them. The inputs also inherited the default 90-day retention period despite only being needed within the same run.

## Behavior

- macOS and Windows installer artifacts remain required
- optional backend metadata downloads remain fail-open
- backend input artifacts are consumed only by their native reader jobs

## Validation

- `actionlint`
- `bash -n scripts/*.sh`
- `scripts/test-prepare-release-metadata.sh`
- `git diff --check`
