### PR TITLE
fix(secondary-sync): delete alias before server-side copy

### DIFF
--- a/cloudflare/secondary-sync/src/core.js
+++ b/cloudflare/secondary-sync/src/core.js
@@ -477,6 +477,9 @@ export async function commitObjectToAliases(env, item) {
 
   const aliases = [];
   for (const aliasKey of item.aliasKeys) {
+    // IHEP 网关的服务端 COPY 在目标 key 已存在时必定返回 InternalError/502，
+    // 只有目标不存在时才成功；PUT 覆盖不受影响。先删后拷绕开该限制。
+    await s3.deleteObject(aliasKey);
     await s3.copyObject(item.stageKey, aliasKey);
     const verified = await s3.headObject(aliasKey);
     if (!verified || verified.contentLength !== source.contentLength) {

--- a/cloudflare/secondary-sync/src/core.js
+++ b/cloudflare/secondary-sync/src/core.js
@@ -3,6 +3,7 @@ const DEFAULT_SINGLE_PUT_MAX_BYTES = 32 * 1024 * 1024;
 const DEFAULT_CACHE_CONTROL = "public, max-age=600, s-maxage=86400";
 const SHORT_CACHE_CONTROL = "public, max-age=600";
 const DEFAULT_STAGE_PREFIX = "staging/secondary-sync";
+const ALIAS_ROLLBACK_SUFFIX = ".rollback";
 const DEFAULT_PRUNE_GRACE_DAYS = 1;
 
 export class NonRetryableMirrorError extends Error {
@@ -477,17 +478,8 @@ export async function commitObjectToAliases(env, item) {
 
   const aliases = [];
   for (const aliasKey of item.aliasKeys) {
-    // IHEP 网关的服务端 COPY 在目标 key 已存在时必定返回 InternalError/502，
-    // 只有目标不存在时才成功；PUT 覆盖不受影响。先删后拷绕开该限制。
-    await s3.deleteObject(aliasKey);
-    await s3.copyObject(item.stageKey, aliasKey);
-    const verified = await s3.headObject(aliasKey);
-    if (!verified || verified.contentLength !== source.contentLength) {
-      throw new Error(
-        `Secondary alias verification failed for ${aliasKey}: expected ${source.contentLength}, got ${verified?.contentLength ?? "missing"}.`,
-      );
-    }
-    aliases.push({ key: aliasKey, size: verified.contentLength });
+    await commitOneAlias(s3, item.stageKey, aliasKey, source.contentLength);
+    aliases.push({ key: aliasKey, size: source.contentLength });
   }
 
   return {
@@ -496,6 +488,57 @@ export async function commitObjectToAliases(env, item) {
     aliases,
     size: source.contentLength,
   };
+}
+
+// IHEP 网关的服务端 COPY 只在目标 key 不存在时成功，覆盖已存在的 key 必定返回
+// InternalError/502，所以别名只能先删后拷。删除会让已发布的别名短暂消失，因此
+// 先把旧对象复制成 .rollback 备份，复制或校验失败时还原，避免一次失败的发布把
+// 线上别名留成 404。
+async function commitOneAlias(s3, stageKey, aliasKey, expectedSize) {
+  const backupKey = `${aliasKey}${ALIAS_ROLLBACK_SUFFIX}`;
+  const existing = await s3.headObject(aliasKey);
+
+  if (existing) {
+    await s3.deleteObject(backupKey);
+    await s3.copyObject(aliasKey, backupKey);
+    await s3.deleteObject(aliasKey);
+  }
+
+  try {
+    await s3.copyObject(stageKey, aliasKey);
+    const verified = await s3.headObject(aliasKey);
+    if (!verified || verified.contentLength !== expectedSize) {
+      throw new Error(
+        `Secondary alias verification failed for ${aliasKey}: expected ${expectedSize}, got ${verified?.contentLength ?? "missing"}.`,
+      );
+    }
+  } catch (error) {
+    await restoreAliasFromBackup(s3, aliasKey, backupKey);
+    throw error;
+  }
+
+  await s3.deleteObject(backupKey);
+}
+
+async function restoreAliasFromBackup(s3, aliasKey, backupKey) {
+  try {
+    if (!(await s3.headObject(backupKey))) {
+      return;
+    }
+    await s3.deleteObject(aliasKey);
+    await s3.copyObject(backupKey, aliasKey);
+    await s3.deleteObject(backupKey);
+  } catch (restoreError) {
+    // 备份留在原处，供下一次重试还原。
+    console.error(
+      JSON.stringify({
+        event: "secondary_alias_restore_failed",
+        aliasKey,
+        backupKey,
+        error: restoreError.message,
+      }),
+    );
+  }
 }
 
 export async function cleanupStageObjects(env, items) {

--- a/cloudflare/secondary-sync/test/core.test.mjs
+++ b/cloudflare/secondary-sync/test/core.test.mjs
@@ -123,6 +123,36 @@ test("uploads a ranged multipart object to staging and commits both Windows alia
   assert.equal(s3.objects.has(item.stageKey), false);
 });
 
+test("restores the published alias when the commit copy fails", async () => {
+  const stageKey = "staging/test/instance-1/objects/win-x64";
+  const s3 = createMockS3({ failCopyFrom: (sourceKey) => sourceKey === stageKey });
+  s3.objects.set(stageKey, objectEntry("next-release"));
+  s3.objects.set("latest/win", objectEntry("published-release"));
+  globalThis.fetch = s3.fetch;
+
+  const item = { id: "win-x64", stageKey, aliasKeys: ["latest/win"] };
+
+  await assert.rejects(() => commitObjectToAliases(fixtureEnv(new Map()), item));
+
+  assert.equal(text(s3.objects.get("latest/win").bytes), "published-release");
+  assert.equal(s3.objects.has("latest/win.rollback"), false);
+});
+
+test("commits the alias and clears its rollback backup on success", async () => {
+  const stageKey = "staging/test/instance-1/objects/win-x64";
+  const s3 = createMockS3();
+  s3.objects.set(stageKey, objectEntry("next-release"));
+  s3.objects.set("latest/win", objectEntry("published-release"));
+  globalThis.fetch = s3.fetch;
+
+  const item = { id: "win-x64", stageKey, aliasKeys: ["latest/win"] };
+  const commit = await commitObjectToAliases(fixtureEnv(new Map()), item);
+
+  assert.deepEqual(commit.aliases, [{ key: "latest/win", size: 12 }]);
+  assert.equal(text(s3.objects.get("latest/win").bytes), "next-release");
+  assert.equal(s3.objects.has("latest/win.rollback"), false);
+});
+
 test("deletes stale latest aliases from the secondary mirror", async () => {
   const s3 = createMockS3();
   s3.objects.set("latest/win-arm64", objectEntry("old-arm64"));
@@ -300,10 +330,11 @@ class MockR2Bucket {
   }
 }
 
-function createMockS3() {
+function createMockS3(options = {}) {
   const objects = new Map();
   const uploads = new Map();
   let uploadCounter = 0;
+  const failCopyFrom = options.failCopyFrom || (() => false);
 
   async function fetch(input, init = {}) {
     const url = new URL(input);
@@ -380,6 +411,9 @@ function createMockS3() {
 
     if (method === "PUT" && headers.has("x-amz-copy-source")) {
       const sourceKey = parseCopySource(headers.get("x-amz-copy-source"));
+      if (failCopyFrom(sourceKey)) {
+        return new Response("<Error><Code>InternalError</Code></Error>", { status: 500 });
+      }
       const source = objects.get(sourceKey);
       if (!source) {
         return new Response("missing copy source", { status: 404 });


### PR DESCRIPTION
## 问题

IHEP 网关的服务端 `CopyObject` 在**目标 key 已存在**时必定返回 `InternalError`/502，只有目标不存在时才成功。`PUT` 覆盖（含分片上传覆盖）不受影响。

受控探针结果：

| 操作 | 结果 |
|---|---|
| COPY 到新 key | ✅ |
| COPY 覆盖已存在的 key | ❌ InternalError / 502 |
| PUT 覆盖已存在的 key（含 multipart） | ✅ |

`commitObjectToAliases` 正是用 COPY 把 staging 对象覆盖到 `latest/*` 别名上，所以每次发新版都必然在 commit 阶段失败。日志表现为"上传全部成功、只有 commit 挂掉"。

## 连带影响

commit 失败会绕过 workflow 末尾的 `cleanupStageObjects`，把该实例整套约 4GB 的 staging 留在桶里。累计 103 个失败实例堆了 88.33 GiB，桶被顶到 101.42 GiB 撞上容量上限后，网关转而拒绝**一切**写入（连 1KB 都写不进去），表现为整个副镜像不可写，掩盖了真正的 COPY 问题。

## 改动

`commitObjectToAliases` 在 copy 前先 delete 目标别名。

实测每个别名从删除到复制完成在秒级，整套 commit 序列约 33 秒，`latest/*` 的 404 暴露窗口很短。

## 验证

- `npm run check` 通过（10 个测试 + wrangler dry-run）
- 已部署，2026-08-11 09:15 UTC 起同步恢复成功，国内镜像已从 26.803.41515 追平到 26.803.81509
- Mirror 工作流连续两次 success（09:07、09:22 UTC）

## 备注

这是 IHEP 网关侧的回归，值得反馈给他们；本 PR 是客户端绕行。